### PR TITLE
fix compilation error with missing mode paramter in openat() call

### DIFF
--- a/daemon/lib/source/syshooks/GpuMemoryHook.cpp
+++ b/daemon/lib/source/syshooks/GpuMemoryHook.cpp
@@ -116,7 +116,7 @@ bool GpuMemoryHook::writeCgroupFile(const ContainerId& id,
                                     size_t value)
 {
     const std::string filePath(id.str() + "/" + fileName);
-    int fd = openat(mCgroupDirfd, filePath.c_str(), O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC);
+    int fd = openat(mCgroupDirfd, filePath.c_str(), O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0700);
     if (fd < 0)
     {
         AI_LOG_SYS_ERROR(errno, "failed to open '%s'", filePath.c_str());


### PR DESCRIPTION
We see the following compilation error when compiling Dobby with _arm-rdk-linux-gnueabi-gcc (GCC) 6.4.0_
```
| In file included from /mnt/home/goruklu/workspace/arrisXi6-2006/build-arrisxi6/tmp/sysroots/arrisxi6/usr/include/fcntl.h:314:0,
|                  from /mnt/home/goruklu/workspace/arrisXi6-2006/build-arrisxi6/tmp/work/cortexa15t2hf-neon-rdk-linux-gnueabi/dobby/1.0-r0/git/daemon/lib/source/syshooks/GpuMemoryHook.cpp:31:
| In function 'int openat(int, const char*, int, ...)',
|     inlined from 'bool GpuMemoryHook::writeCgroupFile(const ContainerId&, const string&, size_t)' at /mnt/home/goruklu/workspace/arrisXi6-2006/build-arrisxi6/tmp/work/cortexa15t2hf-neon-rdk-linux-gnueabi/dobby/1.0-r0/git/daemon/lib/source/syshooks/GpuMemoryHook.cpp:119:87:
| /mnt/home/goruklu/workspace/arrisXi6-2006/build-arrisxi6/tmp/sysroots/arrisxi6/usr/include/bits/fcntl2.h:126:28: error: call to '__openat_missing_mode' declared with attribute error: openat with O_CREAT or O_TMPFILE in third argument needs 4 arguments
|     __openat_missing_mode ();
```



Signed-off-by: Gurdal Oruklu <gurdal_oruklu@comcast.com>