### PR TITLE
Waitpid fix

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -2162,19 +2162,22 @@ void DobbyManager::onChildExit()
         int rc = waitpid(containerPid, &status, WNOHANG);
         if (rc < 0)
         {
-            AI_LOG_SYS_ERROR(errno, "waitpid failed for pid %d", containerPid);
-
             // Sometimes waitpid fails even though container is already dead
             // we can check if it is running by sending "dummy" kill (it will
             // not perform kill, just check if it CAN)
             int tmp = kill(containerPid, 0);
-            AI_LOG_SYS_ERROR(errno, "kill status %d", tmp);
-            // Cannot kill process, probably already dead
+
             if (tmp == -1)
             {
+                // Cannot kill process, probably already dead
                 // Threat it as it would return proper waitpid
                 status = 0;
                 rc = container->containerPid;
+            }
+            else
+            {
+                // Process still exists
+                AI_LOG_ERROR("waitpid failed for pid %d", containerPid);
             }
         }
 

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -2165,12 +2165,10 @@ void DobbyManager::onChildExit()
             // Sometimes waitpid fails even though container is already dead
             // we can check if it is running by sending "dummy" kill (it will
             // not perform kill, just check if it CAN)
-            int tmp = kill(containerPid, 0);
-
-            if (tmp == -1)
+            if (kill(containerPid, 0) == -1)
             {
                 // Cannot kill process, probably already dead
-                // Threat it as it would return proper waitpid
+                // treat it as if it would return proper waitpid
                 status = 0;
                 rc = container->containerPid;
             }

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -2163,8 +2163,22 @@ void DobbyManager::onChildExit()
         if (rc < 0)
         {
             AI_LOG_SYS_ERROR(errno, "waitpid failed for pid %d", containerPid);
+
+            // Sometimes waitpid fails even though container is already dead
+            // we can check if it is running by sending "dummy" kill (it will
+            // not perform kill, just check if it CAN)
+            int tmp = kill(containerPid, 0);
+            AI_LOG_SYS_ERROR(errno, "kill status %d", tmp);
+            // Cannot kill process, probably already dead
+            if (tmp == -1)
+            {
+                // Threat it as it would return proper waitpid
+                status = 0;
+                rc = container->containerPid;
+            }
         }
-        else if (rc == container->containerPid)
+
+        if (rc == container->containerPid)
         {
             const ContainerId &id = it->first;
 


### PR DESCRIPTION
Fixed problem where:
`0000022938.529870 ERR: < M:DobbyManager.cpp F:onChildExit L:1942 > waitpid failed for pid 96201 (10 - No child processes)` error was present