### PR TITLE
Reduce logging severity in RDK plugins

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -641,7 +641,7 @@ int32_t DobbyManager::startContainerFromSpec(const ContainerId &id,
 
     // Load the RDK plugins from disk (if necessary)
     std::map<std::string, Json::Value> rdkPlugins = config->rdkPlugins();
-    AI_LOG_INFO("There are %zd rdk plugins to run", rdkPlugins.size());
+    AI_LOG_DEBUG("There are %zd rdk plugins to run", rdkPlugins.size());
 
     std::unique_ptr<DobbyContainer> container;
     if (rdkPlugins.size() > 0)
@@ -654,7 +654,7 @@ int32_t DobbyManager::startContainerFromSpec(const ContainerId &id,
             std::make_shared<DobbyRdkPluginManager>(containerConfig, rootfsPath, PLUGIN_PATH, rdkPluginUtils);
 
         std::vector<std::string> loadedPlugins = rdkPluginManager->listLoadedPlugins();
-        AI_LOG_INFO("Loaded %zd RDK plugins\n", loadedPlugins.size());
+        AI_LOG_DEBUG("Loaded %zd RDK plugins\n", loadedPlugins.size());
 
         // Create the container wrapper
         std::unique_ptr<DobbyContainer> dobbyContainer(new DobbyContainer(bundle, config, rootfs, rdkPluginManager));
@@ -812,7 +812,7 @@ int32_t DobbyManager::startContainerFromBundle(const ContainerId &id,
 
     // Load the RDK plugins from disk (if necessary)
     std::map<std::string, Json::Value> rdkPlugins = config->rdkPlugins();
-    AI_LOG_INFO("There are %zd rdk plugins to run", rdkPlugins.size());
+    AI_LOG_DEBUG("There are %zd rdk plugins to run", rdkPlugins.size());
 
     std::unique_ptr<DobbyContainer> container;
     if (rdkPlugins.size() > 0)
@@ -825,7 +825,7 @@ int32_t DobbyManager::startContainerFromBundle(const ContainerId &id,
             std::make_shared<DobbyRdkPluginManager>(containerConfig, rootfsPath, PLUGIN_PATH, rdkPluginUtils);
 
         std::vector<std::string> loadedPlugins = rdkPluginManager->listLoadedPlugins();
-        AI_LOG_INFO("Loaded %zd RDK plugins\n", loadedPlugins.size());
+        AI_LOG_DEBUG("Loaded %zd RDK plugins\n", loadedPlugins.size());
 
         // Create the container wrapper
         std::unique_ptr<DobbyContainer> dobbyContainer(new DobbyContainer(bundle, config, rootfs, rdkPluginManager));

--- a/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
@@ -182,7 +182,7 @@ void DobbyRdkPluginManager::loadPlugins()
         if (!isPlugin && !isLogger)
         {
             dlclose(libHandle);
-            AI_LOG_WARN("%s does not contain create/destroy functions, skipping...\n", entry->d_name);
+            AI_LOG_DEBUG("%s does not contain create/destroy functions, skipping...\n", entry->d_name);
             continue;
         }
 
@@ -253,7 +253,7 @@ void DobbyRdkPluginManager::loadPlugins()
                  std::shared_ptr<IDobbyRdkPlugin>>>::iterator it = mPlugins.find(pluginName);
         if (it != mPlugins.end())
         {
-            AI_LOG_INFO("already had a plugin called '%s', replacing with new "
+            AI_LOG_WARN("already had a plugin called '%s', replacing with new "
                         "one from '%s'",
                         pluginName.c_str(), libPath);
 
@@ -268,7 +268,7 @@ void DobbyRdkPluginManager::loadPlugins()
             mLoggers[pluginName] = std::make_pair(libHandle, logger);
         }
 
-        AI_LOG_INFO("Successfully loaded plugin '%s' from '%s'\n", pluginName.c_str(), libPath);
+        AI_LOG_INFO("Loaded plugin '%s' from '%s'\n", pluginName.c_str(), libPath);
     }
 
     closedir(dir);
@@ -493,14 +493,9 @@ bool DobbyRdkPluginManager::executeHook(const std::string &pluginName,
     case IDobbyRdkPlugin::HintFlags::PostStopFlag:
         return plugin->postStop();
     default:
-        AI_LOG_ERROR("Could not work out which hook method to call\n");
-        AI_LOG_FN_EXIT();
+        AI_LOG_ERROR_EXIT("Could not work out which hook method to call");
         return false;
     }
-
-    AI_LOG_INFO("Plugin %s does not implement required hook\n", pluginName.c_str());
-    AI_LOG_FN_EXIT();
-    return false;
 }
 
 // -----------------------------------------------------------------------------
@@ -548,7 +543,7 @@ bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoi
         hookName = "postStop";
         break;
     default:
-        AI_LOG_ERROR("Unknown Hook Point");
+        AI_LOG_ERROR_EXIT("Unknown Hook Point");
         return false;
     }
 
@@ -557,8 +552,7 @@ bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoi
     // Get all the plugins listed in the container config
     if (mContainerConfig == nullptr || mContainerConfig->rdk_plugins == nullptr)
     {
-        AI_LOG_ERROR("Container spec is null");
-        AI_LOG_FN_EXIT();
+        AI_LOG_ERROR_EXIT("Container spec is null");
         return false;
     }
 
@@ -579,8 +573,7 @@ bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoi
             // If the plugin is required, but isn't loaded, then fail early and don't
             // run any more plugins
             // TODO:: Implement a more graceful fallback to default plugin implementation
-            AI_LOG_ERROR("Required plugin %s isn't loaded", pluginName.c_str());
-            AI_LOG_FN_EXIT();
+            AI_LOG_ERROR_EXIT("Required plugin %s isn't loaded", pluginName.c_str());
             return false;
         }
         else if (!isLoaded(pluginName))
@@ -597,7 +590,7 @@ bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoi
         }
 
         // Everything looks good, run the plugin
-        AI_LOG_INFO("Running plugin %s %s hook", pluginName.c_str(), hookName.c_str());
+        AI_LOG_INFO("Running %s plugin", pluginName.c_str());
         success = executeHook(pluginName,
                               hookPoint);
 

--- a/rdkPlugins/IPC/source/IpcPlugin.cpp
+++ b/rdkPlugins/IPC/source/IpcPlugin.cpp
@@ -58,7 +58,8 @@ IpcPlugin::IpcPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
       mDbusSessionEnvVar("DBUS_SESSION_BUS_ADDRESS=unix:path=/" + mDbusSessionSocketPath),
       mDbusDebugEnvVar("DBUS_DEBUG_BUS_ADDRESS=unix:path=/" + mDbusDebugSocketPath)
 {
-    AI_LOG_INFO("IPC Plugin loaded");
+    AI_LOG_FN_ENTRY();
+    AI_LOG_FN_EXIT();
 }
 
 /**

--- a/rdkPlugins/Logging/source/LoggingPlugin.cpp
+++ b/rdkPlugins/Logging/source/LoggingPlugin.cpp
@@ -46,7 +46,8 @@ LoggingPlugin::LoggingPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
       mContainerConfig(containerConfig),
       mUtils(utils)
 {
-    AI_LOG_INFO("Logging Plugin loaded");
+    AI_LOG_FN_ENTRY();
+    AI_LOG_FN_EXIT();
 }
 
 /**
@@ -405,7 +406,7 @@ void LoggingPlugin::FileSink(const ContainerInfo &containerInfo, bool exitEof, b
         }
     }
 
-    AI_LOG_INFO("starting logger for container '%s' to write to '%s' (limit %zd bytes)",
+    AI_LOG_DEBUG("starting logger for container '%s' to write to '%s' (limit %zd bytes)",
                 mContainerConfig->hostname, pathName.c_str(), limit);
 
     // TODO:: Replace with splice/sendfile to avoid copying data in and out of

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -47,7 +47,8 @@ Storage::Storage(std::shared_ptr<rt_dobby_schema> &containerSpec,
       mRootfsPath(rootfsPath),
       mUtils(utils)
 {
-    AI_LOG_INFO("Storage Plugin loaded");
+    AI_LOG_FN_ENTRY();
+    AI_LOG_FN_EXIT();
 }
 
 /**

--- a/rdkPlugins/TestPlugin/source/TestRdkPlugin.cpp
+++ b/rdkPlugins/TestPlugin/source/TestRdkPlugin.cpp
@@ -41,7 +41,8 @@ TestRdkPlugin::TestRdkPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
       mRootfsPath(rootfsPath),
       mUtils(utils)
 {
-    AI_LOG_INFO("Test RDK Plugin loaded");
+    AI_LOG_FN_ENTRY();
+    AI_LOG_FN_EXIT();
 }
 
 /**


### PR DESCRIPTION
DobbyPluginLauncher and the RDK plugins used a lot of `AI_LOG_INFO`. Reduce many of these to `AI_LOG_DEBUG` to make the log files easier to read. 