### PR TITLE
BLDK-734 : License Header changes for RDK-M

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,12 @@
+This component contains software that is Copyright (c) 2020 RDK Management.
+The component is licensed to you under the Apache License, Version 2.0 (the "License").
+You may not use the component except in compliance with the License.
+
+The component may include material which is licensed under other licenses / copyrights as
+listed below. Your use of this material within the component is also subject to the terms and
+conditions of these licenses. The LICENSE file contains the text of all the licenses which apply
+within this component.
+
 Copyright 2013-2020 Sky UK
 Licensed under the Apache License, Version 2.0
 


### PR DESCRIPTION
Notice file updated for Apache License, Version 2.0 (the "License") from RDK-M