### PR TITLE
Fix CMake error on CMake 3.15

### DIFF
--- a/cmake/libocispec.cmake
+++ b/cmake/libocispec.cmake
@@ -45,7 +45,7 @@ execute_process(
 )
 
 # Get a list of all the JSON customs schema files and copy them into libocispec
-file(GLOB CUSTOM_SCHEMA_FILES "${SCHEMAS_DIR}/*.json" CONFIGURE_DEPENDS)
+file(GLOB CUSTOM_SCHEMA_FILES CONFIGURE_DEPENDS "${SCHEMAS_DIR}/*.json")
 file(COPY ${CUSTOM_SCHEMA_FILES} DESTINATION ${LIBOCISPEC_DIR}/runtime-spec/schema/)
 
 # Get the add_plugin_tables.py script and copy it into libocispec


### PR DESCRIPTION
CMake 3.15 fails to build Dobby with error:

```
| configure: creating ./config.status
| config.status: creating Makefile
| config.status: creating config.h
| config.status: executing libtool commands
| config.status: executing depfiles commands
| Found wrong amount of files 0, should be 2
| Traceback (most recent call last):
|   File "add_plugin_tables.py", line 149, in <module>
|     process_files()
|   File "add_plugin_tables.py", line 58, in process_files
|     files = find_files()
|   File "add_plugin_tables.py", line 136, in find_files
|     raise IndexError
| IndexError
| -- Configuring incomplete, errors occurred!
```

Fix syntax error preventing schema files from being copied to `libocispec/runtime-schema` with CMake 3.15