### PR TITLE
[RDK-29360] Add --westeros-socket option

### DIFF
--- a/AppInfrastructure/Public/Dobby/IDobbyProxy.h
+++ b/AppInfrastructure/Public/Dobby/IDobbyProxy.h
@@ -124,18 +124,21 @@ public:
     virtual int32_t startContainerFromSpec(const std::string& id,
                                            const std::string& jsonSpec,
                                            const std::list<int>& files,
-                                           const std::string& command = "") const = 0;
+                                           const std::string& command = "",
+                                           const std::string& displaySocket = "") const = 0;
 
     virtual int32_t startContainerFromSpec(const std::string& id,
                                            const Json::Value& spec,
                                            const std::list<int>& files,
-                                           const std::string& command = "") const = 0;
+                                           const std::string& command = "",
+                                           const std::string& displaySocket = "") const = 0;
 
 
     virtual int32_t startContainerFromBundle(const std::string& id,
                                              const std::string& bundlePath,
                                              const std::list<int>& files,
-                                             const std::string& command = "") const = 0;
+                                             const std::string& command = "",
+                                             const std::string& displaySocket = "") const = 0;
 
     virtual bool stopContainer(int32_t descriptor,
                                bool withPrejudice) const = 0;

--- a/client/lib/include/DobbyProxy.h
+++ b/client/lib/include/DobbyProxy.h
@@ -75,18 +75,21 @@ public:
     int32_t startContainerFromSpec(const std::string& id,
                                    const std::string& jsonSpec,
                                    const std::list<int>& files,
-                                    const std::string& command = "") const override;
+                                   const std::string& command = "",
+                                   const std::string& displaySocket = "") const override;
 
     int32_t startContainerFromSpec(const std::string& id,
                                    const Json::Value& spec,
                                    const std::list<int>& files,
-                                   const std::string& command = "") const override;
+                                   const std::string& command = "",
+                                   const std::string& displaySocket = "") const override;
 
 
     int32_t startContainerFromBundle(const std::string& id,
                                      const std::string& bundlePath,
                                      const std::list<int>& files,
-                                     const std::string& command = "") const override;
+                                     const std::string& command = "",
+                                     const std::string& displaySocket = "") const override;
 
     bool stopContainer(int32_t cd, bool withPrejudice) const override;
 

--- a/client/lib/source/DobbyProxy.cpp
+++ b/client/lib/source/DobbyProxy.cpp
@@ -534,6 +534,10 @@ bool DobbyProxy::setLogLevel(int level) const
  *                              container spec.
  *  @param[in]  files           An array of file descriptors to pass into the
  *                              container construction, can be empty.
+ *  @param[in]  command         Custom command to run inside the container,
+ *                              overriding the args in the config file
+ *  @param[in]  displaySocket   Path to the westeros display socket to mount into
+ *                              the container
  *
  *  @return on success a container descriptor which is a number greater than
  *  0, on failure a negative error code.
@@ -541,7 +545,8 @@ bool DobbyProxy::setLogLevel(int level) const
 int32_t DobbyProxy::startContainerFromSpec(const std::string& id,
                                            const std::string& jsonSpec,
                                            const std::list<int>& files /*= std::list<int>()*/,
-                                           const std::string& command /*= ""*/) const
+                                           const std::string& command /*= ""*/,
+                                           const std::string& displaySocket /*= ""*/) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -553,7 +558,7 @@ int32_t DobbyProxy::startContainerFromSpec(const std::string& id,
     }
 
     // send off the request
-    const AI_IPC::VariantList params = { id, jsonSpec, fds, command };
+    const AI_IPC::VariantList params = { id, jsonSpec, fds, command, displaySocket };
     AI_IPC::VariantList returns;
 
     int32_t result = -1;
@@ -586,6 +591,10 @@ int32_t DobbyProxy::startContainerFromSpec(const std::string& id,
  *                              a string before being sent to the daemon.
  *  @param[in]  files           An array of file descriptors to pass into the
  *                              container construction, can be empty.
+ *  @param[in]  command         Custom command to run inside the container,
+ *                              overriding the args in the config file
+ *  @param[in]  displaySocket   Path to the westeros display socket to mount into
+ *                              the container
  *
  *  @return on success a container descriptor which is a number greater than
  *  0, on failure a negative error code.
@@ -593,14 +602,15 @@ int32_t DobbyProxy::startContainerFromSpec(const std::string& id,
 int32_t DobbyProxy::startContainerFromSpec(const std::string& id,
                                            const Json::Value& spec,
                                            const std::list<int>& files /*= std::list<int>()*/,
-                                           const std::string& command /*= ""*/) const
+                                           const std::string& command /*= ""*/,
+                                           const std::string& displaySocket /*= ""*/) const
 {
     // convert the json spec to a string
     Json::FastWriter writer;
     const std::string specString = writer.write(spec);
 
     // and then just call start container with the string
-    return startContainerFromSpec(id, specString, files, command);
+    return startContainerFromSpec(id, specString, files, command, displaySocket);
 }
 
 // -----------------------------------------------------------------------------
@@ -615,6 +625,10 @@ int32_t DobbyProxy::startContainerFromSpec(const std::string& id,
  *  @param[in]  bundlePath      Path to the container bundle.
  *  @param[in]  files           An array of file descriptors to pass into the
  *                              container construction, can be empty.
+ *  @param[in]  command         Custom command to run inside the container,
+ *                              overriding the args in the config file
+ *  @param[in]  displaySocket   Path to the westeros display socket to mount into
+ *                              the container
  *
  *  @return on success a container descriptor which is a number greater than
  *  0, on failure a negative error code.
@@ -622,7 +636,8 @@ int32_t DobbyProxy::startContainerFromSpec(const std::string& id,
 int32_t DobbyProxy::startContainerFromBundle(const std::string& id,
                                              const std::string& bundlePath,
                                              const std::list<int>& files,
-                                             const std::string& command /*= ""*/) const
+                                             const std::string& command /*= ""*/,
+                                             const std::string& displaySocket /*= ""*/) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -634,7 +649,7 @@ int32_t DobbyProxy::startContainerFromBundle(const std::string& id,
     }
 
     // send off the request
-    const AI_IPC::VariantList params = { id, bundlePath, fds, command };
+    const AI_IPC::VariantList params = { id, bundlePath, fds, command, displaySocket };
     AI_IPC::VariantList returns;
 
     int32_t result = -1;

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -901,13 +901,14 @@ void Dobby::startFromSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
 {
     AI_LOG_FN_ENTRY();
 
-    // Expecting 3/4 args:
+    // Expecting 3/5 args:
     // (string id, string jsonSpec, vector<unixfd> files)
-    // (string id, string jsonSpec, vector<unixfd> files, string command)
+    // (string id, string jsonSpec, vector<unixfd> files, string command, string displaySocket)
     std::string id;
     std::string jsonSpec;
     std::vector<AI_IPC::UnixFd> files;
     std::string command;
+    std::string displaySocket;
 
     // The command argument might not be sent at all (e.g. from AI) so we should
     // be able to withstand receiving 3 or 4 arguments
@@ -919,13 +920,14 @@ void Dobby::startFromSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
                                                     std::vector<AI_IPC::UnixFd>>(
             replySender->getMethodCallArguments(), &id, &jsonSpec, &files);
     }
-    else if (replySender->getMethodCallArguments().size() == 4)
+    else if (replySender->getMethodCallArguments().size() == 5)
     {
         parseArgsSuccess = AI_IPC::parseVariantList<std::string,
                                                     std::string,
                                                     std::vector<AI_IPC::UnixFd>,
+                                                    std::string,
                                                     std::string>(
-            replySender->getMethodCallArguments(), &id, &jsonSpec, &files, &command);
+            replySender->getMethodCallArguments(), &id, &jsonSpec, &files, &command, &displaySocket);
     }
 
     if (!parseArgsSuccess)
@@ -950,6 +952,7 @@ void Dobby::startFromSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
                  spec = std::move(jsonSpec),
                  files = std::move(files),
                  command = std::move(command),
+                 displaySocket = std::move(displaySocket),
                  replySender]()
                 {
                     // Convert the vector of AI_IPC::UnixFd to a list of plain
@@ -959,7 +962,7 @@ void Dobby::startFromSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
                         fileList.push_back(file.fd());
 
                     // try and start the container
-                    int32_t descriptor = manager->startContainerFromSpec(id, spec, fileList, command);
+                    int32_t descriptor = manager->startContainerFromSpec(id, spec, fileList, command, displaySocket);
 
                     // Fire off the reply
                     AI_IPC::VariantList results = { descriptor };
@@ -1000,15 +1003,17 @@ void Dobby::startFromBundle(std::shared_ptr<AI_IPC::IAsyncReplySender> replySend
 {
     AI_LOG_FN_ENTRY();
 
-    // Expecting 3/4 args args:
+    // Expecting 3/5 args:
     // (string id, string bundlePath, vector<unixfd> files)
-    // (string id, string bundlePath, vector<unixfd> files, string command)
+    // (string id, string bundlePath, vector<unixfd> files, string command, string displaySocket)
     std::string id;
     std::string bundlePath;
     std::vector<AI_IPC::UnixFd> files;
     std::string command;
+    std::string displaySocket;
 
     bool parseArgsSuccess = false;
+
     if (replySender->getMethodCallArguments().size() == 3)
     {
         parseArgsSuccess = AI_IPC::parseVariantList<std::string,
@@ -1016,13 +1021,14 @@ void Dobby::startFromBundle(std::shared_ptr<AI_IPC::IAsyncReplySender> replySend
                                                     std::vector<AI_IPC::UnixFd>>(
             replySender->getMethodCallArguments(), &id, &bundlePath, &files);
     }
-    else if (replySender->getMethodCallArguments().size() == 4)
+    else if (replySender->getMethodCallArguments().size() == 5)
     {
         parseArgsSuccess = AI_IPC::parseVariantList<std::string,
                                                     std::string,
                                                     std::vector<AI_IPC::UnixFd>,
+                                                    std::string,
                                                     std::string>(
-            replySender->getMethodCallArguments(), &id, &bundlePath, &files, &command);
+            replySender->getMethodCallArguments(), &id, &bundlePath, &files, &command, &displaySocket);
     }
 
     if (!parseArgsSuccess)
@@ -1047,6 +1053,7 @@ void Dobby::startFromBundle(std::shared_ptr<AI_IPC::IAsyncReplySender> replySend
                  path = std::move(bundlePath),
                  files = std::move(files),
                  command = std::move(command),
+                 displaySocket = std::move(displaySocket),
                  replySender]()
                 {
                     // Convert the vector of AI_IPC::UnixFd to a list of plain
@@ -1056,7 +1063,7 @@ void Dobby::startFromBundle(std::shared_ptr<AI_IPC::IAsyncReplySender> replySend
                         fileList.push_back(file.fd());
 
                     // try and start the container
-                    int32_t descriptor = manager->startContainerFromBundle(id, path, fileList, command);
+                    int32_t descriptor = manager->startContainerFromBundle(id, path, fileList, command, displaySocket);
 
                     // Fire off the reply
                     AI_IPC::VariantList results = { descriptor };

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -498,8 +498,8 @@ std::string DobbyManager::createCustomConfig(const std::unique_ptr<DobbyContaine
             }
 
             // Display is always mounted as /tmp/westeros into the container
-            newMount->destination = "/tmp/westeros";
-            newMount->type = "bind";
+            newMount->destination = strdup("/tmp/westeros");
+            newMount->type = strdup("bind");
             newMount->source = strdup(displaySocket.c_str());
 
             // allocate memory for new mount and place it in the config struct

--- a/daemon/lib/source/DobbyManager.h
+++ b/daemon/lib/source/DobbyManager.h
@@ -101,11 +101,15 @@ public:
     int32_t startContainerFromSpec(const ContainerId& id,
                                    const std::string& jsonSpec,
                                    const std::list<int>& files,
-                                    const std::string& command = "");
+                                   const std::string& command,
+                                   const std::string& displaySocket);
+
     int32_t startContainerFromBundle(const ContainerId& id,
                                      const std::string& bundlePath,
                                      const std::list<int>& files,
-                                    const std::string& command = "");
+                                     const std::string& command,
+                                     const std::string& displaySocket);
+
     bool stopContainer(int32_t cd, bool withPrejudice);
 
     bool pauseContainer(int32_t cd);
@@ -144,13 +148,15 @@ private:
                         const std::unique_ptr<DobbyContainer> &container,
                         const std::list<int> &files);
 
-    std::string createCustomArgsConfig(const std::unique_ptr<DobbyContainer> &container,
-                                       const std::string &command);
+    std::string createCustomConfig(const std::unique_ptr<DobbyContainer> &container,
+                                   const std::string &command,
+                                   const std::string &displaySocket);
 
     bool createAndStartContainer(const ContainerId& id,
                                  const std::unique_ptr<DobbyContainer>& container,
                                  const std::list<int>& files,
-                                 const std::string& command = "");
+                                 const std::string& command = "",
+                                 const std::string& displaySocket = "");
 
     bool restartContainer(const ContainerId& id,
                           const std::unique_ptr<DobbyContainer>& container);


### PR DESCRIPTION
Add the ability to pass a westeros socket path as an option when starting a container. The socket is then bind-mounted into the container with the following config:

```
        {
            "source": "/tmp/westeros-0",
            "destination": "/tmp/westeros",
            "options": [
                "bind",
                "rw",
                "nosuid",
                "nodev",
                "noexec"
            ],
            "type": "bind"
        }
```

Usage:
```
DobbyTool start --westeros-socket /tmp/westeros sleep ./sleepy
```

