### PR TITLE
Update Vagrantfile to use GCC and G++ 6.4 by default

### DIFF
--- a/develop/vagrant/Vagrantfile
+++ b/develop/vagrant/Vagrantfile
@@ -86,8 +86,8 @@ Vagrant.configure("2") do |config|
 
         figlet GCC
         # Use GCC/G++ 6.4 as the default instead of 5.4 to match build environment
-        add-apt-repository ppa:jonathonf/gcc
-        apt update && apt install gcc-6 g++-6
+        add-apt-repository -y ppa:jonathonf/gcc
+        apt update && apt install -y gcc-6 g++-6
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 10
         update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 10
 

--- a/develop/vagrant/Vagrantfile
+++ b/develop/vagrant/Vagrantfile
@@ -73,7 +73,7 @@ Vagrant.configure("2") do |config|
 
     ##################################################
     #
-    # Install dependencies inc. CMake
+    # Install dependencies inc. CMake 3.8.2
     #
     config.vm.provision "shell", inline: <<-SHELL
         figlet DEPENDENCIES  # ASCII banner
@@ -83,6 +83,13 @@ Vagrant.configure("2") do |config|
         apt install -y build-essential libctemplate-dev libjsoncpp-dev libjsoncpp1 libjsoncpp-doc libdbus-1-dev libdbus-cpp-dev dbus libdbus-c++-dev libnl-3-dev libnl-route-3-dev libsystemd-dev libcap-dev runc bison flex zlib1g-dev autoconf python-pip python3.7  pkgconf libtool seccomp libseccomp-dev libyajl2 libyajl-dev go-md2man python3-pip gdb libcurl4-openssl-dev libssl-dev libgpgme11-dev
         alias python=python3.7
         pip3 install jsonref
+
+        figlet GCC
+        # Use GCC/G++ 6.4 as the default instead of 5.4 to match build environment
+        add-apt-repository ppa:jonathonf/gcc
+        apt update && apt install gcc-6 g++-6
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 10
+        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 10
 
         figlet CMAKE
         # If CMake is already installed, skip


### PR DESCRIPTION
Latest sprint branch uses GCC 6.4 - upgrade the Vagrant VM.

Set 6.4 as default instead of 5.4 included with Xenial.