### PR TITLE
RDK-29415 Container kill fix

### DIFF
--- a/daemon/lib/source/DobbyRunC.cpp
+++ b/daemon/lib/source/DobbyRunC.cpp
@@ -340,10 +340,33 @@ bool DobbyRunC::kill(const ContainerId& id, int signal, bool all) const
         return false;
     }
 
-    AI_LOG_FN_EXIT();
 
     // get the return code, 0 for success, 1 for failure
-    return (WEXITSTATUS(status) == EXIT_SUCCESS);
+    bool returnValue = (WEXITSTATUS(status) == EXIT_SUCCESS);
+
+    // Fix problem where SIGTERM was masked and containers never exited
+    if(signal == SIGTERM)
+    {
+        int retryCounter = 10;
+
+        while (state(id) != ContainerStatus::Unknown && retryCounter > 0)
+        {
+            retryCounter--;
+            usleep(500);
+        }
+
+        // Container wasn't killed
+        if(retryCounter <= 0)
+        {
+            AI_LOG_DEBUG("SIGTERM kill wasn't kill container (probably masked), " +
+                        "retrying kill with SIGKILL");
+            // retry kill with SIGKILL now, its result will be proper result now
+            returnValue = DobbyRunC::kill(id, SIGKILL, all);
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+    return returnValue;
 }
 
 // -----------------------------------------------------------------------------

--- a/daemon/lib/source/DobbyRunC.cpp
+++ b/daemon/lib/source/DobbyRunC.cpp
@@ -349,10 +349,18 @@ bool DobbyRunC::kill(const ContainerId& id, int signal, bool all) const
     {
         int retryCounter = 10;
 
-        while (state(id) != ContainerStatus::Unknown && retryCounter > 0)
+        // get current container status
+        ContainerStatus contStatus = state(id);
+
+        // Unknown (container deleted), or Stopped (continer stopped)
+        // are both valid options after successfull kill
+        while (contStatus != ContainerStatus::Unknown &&
+               contStatus != ContainerStatus::Stopped &&
+               retryCounter > 0)
         {
             retryCounter--;
             usleep(500);
+            contStatus = state(id);
         }
 
         // Container wasn't killed

--- a/daemon/lib/source/DobbyRunC.cpp
+++ b/daemon/lib/source/DobbyRunC.cpp
@@ -358,7 +358,7 @@ bool DobbyRunC::kill(const ContainerId& id, int signal, bool all) const
         // Container wasn't killed
         if(retryCounter <= 0)
         {
-            AI_LOG_DEBUG("SIGTERM kill wasn't kill container (probably masked), " +
+            AI_LOG_DEBUG("SIGTERM kill wasn't kill container (probably masked), "
                         "retrying kill with SIGKILL");
             // retry kill with SIGKILL now, its result will be proper result now
             returnValue = DobbyRunC::kill(id, SIGKILL, all);


### PR DESCRIPTION
This work fixes problem found in creation of "RDK-29415 Add Dobby as backend for ProcessContainers", where containers killed by SIGTERM wasn't killed properly.