### PR TITLE
Add syshooks and dobby specs to LEGACY_COMPONENTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,11 @@ endif()
 # Add defines for DBUS path
 add_definitions( -DDBUS_SYSTEM_ADDRESS="unix:path=/var/run/dbus/system_bus_socket" )
 
-option(LEGACY_COMPONENTS "Enable Dobby legacy components" ON)
+option( LEGACY_COMPONENTS "Enable Dobby legacy components" ON )
+# Add #define if enabled
+if ( LEGACY_COMPONENTS )
+    add_definitions( -DLEGACY_COMPONENTS )
+endif()
 
 # Enable C++14 support. The following tells cmake to always add the -std=c++14
 # flag (nb - if CMAKE_CXX_EXTENSIONS is ON then we'll get -std=gnu++14 instead)
@@ -103,8 +107,10 @@ set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake" )
 find_package( libnl REQUIRED )
 find_package( dbus REQUIRED )
 find_package( jsoncpp REQUIRED )
-find_package( ctemplate REQUIRED )
 find_package( Boost REQUIRED )
+if ( LEGACY_COMPONENTS )
+    find_package( ctemplate REQUIRED )
+endif()
 
 # Required for libocispec only
 find_package( yajl REQUIRED )
@@ -125,7 +131,9 @@ add_subdirectory(settings)
 
 # Add Bundle Generator code
 add_subdirectory(bundle/lib)
-add_subdirectory(bundle/tool)
+if ( LEGACY_COMPONENTS )
+    add_subdirectory(bundle/tool)
+endif()
 
 # Add the dobby daemon code
 add_subdirectory( daemon/init )

--- a/bundle/lib/CMakeLists.txt
+++ b/bundle/lib/CMakeLists.txt
@@ -17,14 +17,21 @@
 
 project(DobbyBundleGenLib)
 
+if (LEGACY_COMPONENTS)
+    list(APPEND ADDITIONAL_SOURCES
+        "source/DobbySpecConfig.cpp"
+        "source/DobbyTemplate.cpp"
+    )
+    list(APPEND ADDITIONAL_INCLUDES ${CTEMPLATE_INCLUDE_DIRS})
+endif()
+
 add_library(${PROJECT_NAME}
     STATIC
     source/DobbyBundle.cpp
     source/DobbyConfig.cpp
-    source/DobbyTemplate.cpp
     source/DobbyRootfs.cpp
-    source/DobbySpecConfig.cpp
     source/DobbyBundleConfig.cpp
+    ${ADDITIONAL_SOURCES}
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -36,8 +43,8 @@ target_include_directories(${PROJECT_NAME}
     $<TARGET_PROPERTY:AppInfraLogging,INTERFACE_INCLUDE_DIRECTORIES>
     $<TARGET_PROPERTY:AppInfraCommon,INTERFACE_INCLUDE_DIRECTORIES>
 
-    ${CTEMPLATE_INCLUDE_DIRS}
     ${JSONCPP_INCLUDE_DIRS}
+    ${ADDITIONAL_INCLUDES}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/bundle/lib/include/DobbyBundle.h
+++ b/bundle/lib/include/DobbyBundle.h
@@ -45,12 +45,14 @@ class IDobbyEnv;
 class DobbyBundle
 {
 public:
+#if defined(LEGACY_COMPONENTS)
     DobbyBundle(const std::shared_ptr<const IDobbyUtils>& utils,
                 const std::shared_ptr<const IDobbyEnv>& env,
                 const ContainerId& id);
     DobbyBundle(const std::shared_ptr<const IDobbyUtils>& utils,
                 const std::string& path,
                 bool persist = true);
+#endif // defined(LEGACY_COMPONENTS)
     DobbyBundle(const std::shared_ptr<const IDobbyUtils>& utils,
                 const std::shared_ptr<const IDobbyEnv>& env,
                 const std::string& bundlePath);

--- a/bundle/lib/include/DobbyBundleConfig.h
+++ b/bundle/lib/include/DobbyBundleConfig.h
@@ -82,9 +82,12 @@ public:
     std::shared_ptr<rt_dobby_schema> config() const override;
 
 public:
-    const std::map<std::string, Json::Value>& legacyPlugins() const override;
     const std::map<std::string, Json::Value>& rdkPlugins() const override;
     const std::list<std::string> sysHooks() const override;
+
+#if defined(LEGACY_COMPONENTS)
+    const std::map<std::string, Json::Value>& legacyPlugins() const override;
+#endif // defined(LEGACY_COMPONENTS)
 
 // ----------------------------------------------------------------------------
 /**
@@ -97,9 +100,13 @@ private:
     bool processLogging(const Json::Value& value);
     bool processIpc(const Json::Value& value);
     bool processGpu(const Json::Value& value);
-    bool processLegacyPlugins(const Json::Value& value);
     bool processRdkServices(const Json::Value& value);
     bool processDrm(const Json::Value& value);
+
+#if defined(LEGACY_COMPONENTS)
+    bool processLegacyPlugins(const Json::Value& value);
+#endif // defined(LEGACY_COMPONENTS)
+
 
 // ----------------------------------------------------------------------------
 /**
@@ -139,10 +146,13 @@ private:
     ssize_t mConsoleLimit;
 
 private:
-    std::map<std::string, Json::Value> mLegacyPlugins;
     std::map<std::string, Json::Value> mRdkPlugins;
     std::list<std::string> mEnabledSysHooks;
     void setSysHooksAndRdkPlugins(void);
+
+#if defined(LEGACY_COMPONENTS)
+    std::map<std::string, Json::Value> mLegacyPlugins;
+#endif // defined(LEGACY_COMPONENTS)
 
 private:
     std::string mRootfsPath;

--- a/bundle/lib/include/DobbyRootfs.h
+++ b/bundle/lib/include/DobbyRootfs.h
@@ -26,7 +26,10 @@
 #include "IDobbyUtils.h"
 #include "ContainerId.h"
 
+#if defined(LEGACY_COMPONENTS)
 #include "DobbySpecConfig.h"
+#endif // LEGACY_COMPONENTS
+
 #include "DobbyBundleConfig.h"
 
 #include <sys/types.h>
@@ -53,9 +56,11 @@ class DobbyBundle;
 class DobbyRootfs
 {
 public:
+#if defined(LEGACY_COMPONENTS)
     DobbyRootfs(const std::shared_ptr<IDobbyUtils>& utils,
                 const std::shared_ptr<const DobbyBundle>& bundle,
                 const std::shared_ptr<const DobbySpecConfig>& config);
+#endif // defined(LEGACY_COMPONENTS)
     DobbyRootfs(const std::shared_ptr<IDobbyUtils>& utils,
                 const std::shared_ptr<const DobbyBundle>& bundle,
                 const std::shared_ptr<const DobbyBundleConfig>& config);
@@ -72,6 +77,7 @@ public:
 private:
     void cleanUp(bool dontRemoveFiles);
 
+#if defined(LEGACY_COMPONENTS)
     bool createMountPoint(int dirfd, const std::string &path, bool isDirectory) const;
     bool createStandardMountPoints(int dirfd) const;
 
@@ -82,6 +88,7 @@ private:
                               const std::string& filePath,
                               const std::string& fileContents,
                               mode_t mode = 0644) const;
+#endif // defined(LEGACY_COMPONENTS)
 
     void unmountAllAt(const std::string& pathPrefix);
 

--- a/bundle/lib/source/DobbyBundle.cpp
+++ b/bundle/lib/source/DobbyBundle.cpp
@@ -34,6 +34,7 @@
 #include <sstream>
 #include <random>
 
+#if defined(LEGACY_COMPONENTS)
 // -----------------------------------------------------------------------------
 /**
  *  @brief Constructor only intended for debugging.
@@ -202,6 +203,7 @@ DobbyBundle::DobbyBundle(const std::shared_ptr<const IDobbyUtils>& utils,
 
     AI_LOG_FN_EXIT();
 }
+#endif // defined(LEGACY_COMPONENTS)
 
 // -----------------------------------------------------------------------------
 /**

--- a/bundle/lib/source/DobbyBundleConfig.cpp
+++ b/bundle/lib/source/DobbyBundleConfig.cpp
@@ -164,10 +164,12 @@ const std::string& DobbyBundleConfig::consolePath() const
     return mConsolePath;
 }
 
+#if defined(LEGACY_COMPONENTS)
 const std::map<std::string, Json::Value>& DobbyBundleConfig::legacyPlugins() const
 {
     return mLegacyPlugins;
 }
+#endif // defined(LEGACY_COMPONENTS)
 
 const std::map<std::string, Json::Value>& DobbyBundleConfig::rdkPlugins() const
 {
@@ -226,10 +228,16 @@ bool DobbyBundleConfig::parseOCIConfig(const std::string& bundlePath)
     // Parse legacy plugins if present & not null
     if (mConfig.isMember("legacyPlugins") && mConfig["legacyPlugins"].isObject())
     {
+#if defined(LEGACY_COMPONENTS)
         if (!processLegacyPlugins(mConfig["legacyPlugins"]))
         {
             return false;
         }
+#else
+        AI_LOG_ERROR_EXIT("legacyPlugins is unsupported, build with "
+                          "LEGACY_COMPONENTS=ON to use legacy plugins");
+        return false;
+#endif // defined(LEGACY_COMPONENTS)
     }
 
     // Parse rdk plugins if present & not null
@@ -587,6 +595,7 @@ bool DobbyBundleConfig::processGpu(const Json::Value& value)
 }
 
 
+#if defined(LEGACY_COMPONENTS)
 // -----------------------------------------------------------------------------
 /**
  *  @brief Processes the legacy plugins field.
@@ -633,6 +642,7 @@ bool DobbyBundleConfig::processLegacyPlugins(const Json::Value& value)
 
     return true;
 }
+#endif // defined(LEGACY_COMPONENTS)
 
 // -----------------------------------------------------------------------------
 /**

--- a/bundle/lib/source/DobbyRootfs.cpp
+++ b/bundle/lib/source/DobbyRootfs.cpp
@@ -37,6 +37,7 @@
 #include <sys/mount.h>
 
 
+#if defined(LEGACY_COMPONENTS)
 // -----------------------------------------------------------------------------
 /**
  *  @brief Constructor that creates the rootfs for a container.
@@ -94,6 +95,7 @@ DobbyRootfs::DobbyRootfs(const std::shared_ptr<IDobbyUtils>& utils,
 
     AI_LOG_FN_EXIT();
 }
+#endif // defined(LEGACY_COMPONENTS)
 
 // -----------------------------------------------------------------------------
 /**
@@ -310,6 +312,7 @@ void DobbyRootfs::unmountAllAt(const std::string& pathPrefix)
     AI_LOG_FN_EXIT();
 }
 
+#if defined(LEGACY_COMPONENTS)
 // -----------------------------------------------------------------------------
 /**
  *  @brief Utility method that simply creates a file at the given path and
@@ -672,3 +675,4 @@ bool DobbyRootfs::constructRootfs(int dirfd,
     AI_LOG_FN_EXIT();
     return true;
 }
+#endif // defined(LEGACY_COMPONENTS)

--- a/client/tool/source/Main.cpp
+++ b/client/tool/source/Main.cpp
@@ -60,6 +60,12 @@
 
 #define ARRAY_LENGTH(x)   (sizeof(x) / sizeof((x)[0]))
 
+#if defined(LEGACY_COMPONENTS)
+    #define ACCEPTED_START_PATHS "specfile/bundlepath"
+#else
+    #define ACCEPTED_START_PATHS "bundlepath"
+#endif // defined(LEGACY_COMPONENTS)
+
 //
 static std::string gDBusService("com.sky.dobby.test");
 
@@ -196,7 +202,7 @@ static void startCommand(const std::shared_ptr<IDobbyProxy> &dobbyProxy,
 {
     if (args.size() < 2 || args[0].empty() || args[1].empty())
     {
-        readLine->printLnError("must provide at least two args; <id> <specfile/bundlepath>");
+        readLine->printLnError("must provide at least two args; <id> <" ACCEPTED_START_PATHS ">");
         return;
     }
 
@@ -239,7 +245,7 @@ static void startCommand(const std::shared_ptr<IDobbyProxy> &dobbyProxy,
     // If we parsed any options, check we've still got enough remaining args
     if (args.size() - i < 2)
     {
-        readLine->printLnError("must provide at least two args; <id> <specfile/bundlepath>");
+        readLine->printLnError("must provide at least two args; <id> <" ACCEPTED_START_PATHS ">");
         return;
     }
 
@@ -258,7 +264,7 @@ static void startCommand(const std::shared_ptr<IDobbyProxy> &dobbyProxy,
     const std::string path = buf;
     if (path.empty())
     {
-        readLine->printLnError("invalid path to spec file or bundle '%s'", id.c_str());
+        readLine->printLnError("invalid path '%s'", id.c_str());
         return;
     }
     i++;
@@ -286,11 +292,10 @@ static void startCommand(const std::shared_ptr<IDobbyProxy> &dobbyProxy,
         return;
     }
 
-    // If path is to a file, expect it to be a dobby spec, otherwise expect
-    // it to be the path to a bundle.
+    // check if path points to a directory
     if (S_ISDIR(statbuf.st_mode))
     {
-        // check that the path contains a config file
+        // path points to a directory check that the path contains a config file
         struct dirent *dir;
         DIR *d = opendir(path.c_str());
         if (d == nullptr)
@@ -321,7 +326,9 @@ static void startCommand(const std::shared_ptr<IDobbyProxy> &dobbyProxy,
     }
     else
     {
-        // check that the file in path has a '.json' filename extension
+#if defined(LEGACY_COMPONENTS)
+        // path does not point to a directory, check that the file in path has
+        // a '.json' filename extension
         if (path.find(".json") == std::string::npos)
         {
             readLine->printLnError("please provide the path to a bundle or a "
@@ -346,6 +353,10 @@ static void startCommand(const std::shared_ptr<IDobbyProxy> &dobbyProxy,
         std::string jsonSpec(buffer, length);
         delete[] buffer;
         cd = dobbyProxy->startContainerFromSpec(id, jsonSpec, files, command, displaySocketPath);
+#else
+        readLine->printLnError("please provide the path to a bundle directory");
+        return;
+#endif // defined(LEGACY_COMPONENTS)
     }
 
     if (cd < 0)
@@ -623,7 +634,7 @@ static void infoCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
     }
 }
 
-#if (AI_BUILD_TYPE == AI_DEBUG)
+#if (AI_BUILD_TYPE == AI_DEBUG) && defined(LEGACY_COMPONENTS)
 // -----------------------------------------------------------------------------
 /**
  * @brief
@@ -666,9 +677,7 @@ static void dumpCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
         }
     }
 }
-#endif // (AI_BUILD_TYPE == AI_DEBUG)
 
-#if (AI_BUILD_TYPE == AI_DEBUG)
 // -----------------------------------------------------------------------------
 /**
  * @brief
@@ -720,7 +729,7 @@ static void bundleCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
         readLine->printLnError("failed to create bundle with container id '%s'", id.c_str());
     }
 }
-#endif // (AI_BUILD_TYPE == AI_DEBUG)
+#endif // (AI_BUILD_TYPE == AI_DEBUG) && defined(LEGACY_COMPONENTS)
 
 // -----------------------------------------------------------------------------
 /**
@@ -800,10 +809,10 @@ static void initCommands(const std::shared_ptr<IReadLine>& readLine,
 
     readLine->addCommand("start",
                          std::bind(startCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),
-                         "start [options...] <id> <specfile/bundlepath> [command]",
-                         "Starts a container using the given spec file or bundle path. Can optionally "
-                         "specify the command to run inside the contianer. Any arguments after command "
-                         "are treated as arguments to the command.\n",
+                         "start [options...] <id> <" ACCEPTED_START_PATHS "> [command]",
+                         "Starts a container using the given path. Can optionally specify the command "
+                         "to run inside the container. Any arguments after command are treated as "
+                         "arguments to the command.\n",
                          "  --hamiltron          Create a container with a hamiltron connection.\n"
                          "  --westeros-socket    Mount the specified westeros socket into the container\n");
 
@@ -843,7 +852,7 @@ static void initCommands(const std::shared_ptr<IReadLine>& readLine,
                          "Gets the json stats for the given container\n",
                          "\n");
 
-#if (AI_BUILD_TYPE == AI_DEBUG)
+#if (AI_BUILD_TYPE == AI_DEBUG) && defined(LEGACY_COMPONENTS)
     readLine->addCommand("dumpspec",
                          std::bind(dumpCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),
                          "dumpspec <id> [options...]",
@@ -856,7 +865,7 @@ static void initCommands(const std::shared_ptr<IReadLine>& readLine,
                          "Creates a bundle containing rootfs and config.json for runc\n"
                          "but doesn't actually run it.  Useful for debugging runc issues\n",
                          "\n");
-#endif // (AI_BUILD_TYPE == AI_DEBUG)
+#endif // (AI_BUILD_TYPE == AI_DEBUG) && defined(LEGACY_COMPONENTS)
 
     readLine->addCommand("set-dbus",
                          std::bind(setDbusCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),

--- a/daemon/lib/CMakeLists.txt
+++ b/daemon/lib/CMakeLists.txt
@@ -15,13 +15,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if (LEGACY_COMPONENTS)
+        list(APPEND ADDITIONAL_SOURCES
+                "source/DobbyPluginManager.cpp"
+                "source/syshooks/BaseHook.cpp"
+                "source/syshooks/GpuMemoryHook.cpp"
+                "source/syshooks/RtSchedulingHook.cpp"
+        )
+        list(APPEND ADDITIONAL_INCLUDES ${CTEMPLATE_INCLUDE_DIRS})
+endif()
+
 add_library( DobbyDaemonLib
 
         STATIC
         source/Dobby.cpp
         source/DobbyContainer.cpp
         source/DobbyManager.cpp
-        source/DobbyPluginManager.cpp
         source/DobbyEnv.cpp
         source/DobbyRunC.cpp
         source/DobbyStream.cpp
@@ -31,10 +40,7 @@ add_library( DobbyDaemonLib
         source/DobbyWorkQueue.cpp
         source/DobbyLogger.cpp
         source/DobbyState.cpp
-
-        source/syshooks/BaseHook.cpp
-        source/syshooks/GpuMemoryHook.cpp
-        source/syshooks/RtSchedulingHook.cpp
+        ${ADDITIONAL_SOURCES}
 )
 
 target_include_directories( DobbyDaemonLib
@@ -46,7 +52,7 @@ target_include_directories( DobbyDaemonLib
         PRIVATE
         ${JSONCPP_INCLUDE_DIRS}
         ${DBUS_INCLUDE_DIRS}
-        ${CTEMPLATE_INCLUDE_DIRS}
+        ${ADDITIONAL_INCLUDES}
 
         $<TARGET_PROPERTY:AppInfraLogging,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:AppInfraCommon,INTERFACE_INCLUDE_DIRECTORIES>

--- a/daemon/lib/include/Dobby.h
+++ b/daemon/lib/include/Dobby.h
@@ -96,8 +96,10 @@ private:
     DOBBY_DBUS_METHOD(getInfo);
 
 #if (AI_BUILD_TYPE == AI_DEBUG)
+#if defined(LEGACY_COMPONENTS)
     DOBBY_DBUS_METHOD(createBundle);
     DOBBY_DBUS_METHOD(getSpec);
+#endif // defined(LEGACY_COMPONENTS)
     DOBBY_DBUS_METHOD(getOCIConfig);
 #endif
 

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -28,9 +28,12 @@
 #include "DobbyEnv.h"
 #include "DobbyUtils.h"
 #include "DobbyIPCUtils.h"
-#include "DobbyTemplate.h"
 #include "DobbyWorkQueue.h"
 #include "DobbyState.h"
+
+#if defined(LEGACY_COMPONENTS)
+#  include "DobbyTemplate.h"
+#endif // defined(LEGACY_COMPONENTS)
 
 #include <Logging.h>
 
@@ -82,8 +85,10 @@ Dobby::Dobby(const std::string& dbusAddress,
 {
     AI_LOG_FN_ENTRY();
 
+#if defined(LEGACY_COMPONENTS)
     // initialise the template code with the settings
     DobbyTemplate::setSettings(settings);
+#endif // defined(LEGACY_COMPONENTS)
 
     // create the two callback function objects for notifying when a container
     // has start and stopped
@@ -588,9 +593,6 @@ void Dobby::initIpcMethods()
         {   DOBBY_ADMIN_INTERFACE,       DOBBY_ADMIN_METHOD_SET_LOG_METHOD,         &Dobby::setLogMethod           },
         {   DOBBY_ADMIN_INTERFACE,       DOBBY_ADMIN_METHOD_SET_LOG_LEVEL,          &Dobby::setLogLevel            },
         {   DOBBY_ADMIN_INTERFACE,       DOBBY_ADMIN_METHOD_SET_AI_DBUS_ADDR,       &Dobby::setAIDbusAddress       },
-
-        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_START,                   &Dobby::startFromSpec          },
-        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_START_FROM_SPEC,         &Dobby::startFromSpec          },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_START_FROM_BUNDLE,       &Dobby::startFromBundle        },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_STOP,                    &Dobby::stop                   },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_PAUSE,                   &Dobby::pause                  },
@@ -600,9 +602,16 @@ void Dobby::initIpcMethods()
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_GETINFO,                 &Dobby::getInfo                },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_LIST,                    &Dobby::list                   },
 
+#if defined(LEGACY_COMPONENTS)
+        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_START,                   &Dobby::startFromSpec          },
+        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_START_FROM_SPEC,         &Dobby::startFromSpec          },
+#endif // defined(LEGACY_COMPONENTS)
+
 #if (AI_BUILD_TYPE == AI_DEBUG)
+#if defined(LEGACY_COMPONENTS)
         {   DOBBY_DEBUG_INTERFACE,       DOBBY_DEBUG_METHOD_CREATE_BUNDLE,          &Dobby::createBundle           },
         {   DOBBY_DEBUG_INTERFACE,       DOBBY_DEBUG_METHOD_GET_SPEC,               &Dobby::getSpec                },
+#endif // defined(LEGACY_COMPONENTS)
         {   DOBBY_DEBUG_INTERFACE,       DOBBY_DEBUG_METHOD_GET_OCI_CONFIG,         &Dobby::getOCIConfig           },
 #endif // (AI_BUILD_TYPE == AI_DEBUG)
 
@@ -889,6 +898,7 @@ void Dobby::setAIDbusAddress(std::shared_ptr<AI_IPC::IAsyncReplySender> replySen
     AI_LOG_FN_EXIT();
 }
 
+#if defined(LEGACY_COMPONENTS)
 // -----------------------------------------------------------------------------
 /**
  *  @brief Starts a new container from the supplied json spec document.
@@ -990,6 +1000,7 @@ void Dobby::startFromSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
 
     AI_LOG_FN_EXIT();
 }
+#endif // defined(LEGACY_COMPONENTS)
 
 // -----------------------------------------------------------------------------
 /**
@@ -1510,7 +1521,7 @@ void Dobby::list(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
     AI_LOG_FN_EXIT();
 }
 
-#if (AI_BUILD_TYPE == AI_DEBUG)
+#if (AI_BUILD_TYPE == AI_DEBUG) && defined(LEGACY_COMPONENTS)
 // -----------------------------------------------------------------------------
 /**
  *  @brief Debugging utility that can be used to create a bundle based on
@@ -1569,9 +1580,7 @@ void Dobby::createBundle(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
         AI_LOG_ERROR("failed to send reply");
     }
 }
-#endif // (AI_BUILD_TYPE == AI_DEBUG)
 
-#if (AI_BUILD_TYPE == AI_DEBUG)
 // -----------------------------------------------------------------------------
 /**
  *  @brief Debugging utility to retrieve the original spec file for a running
@@ -1623,7 +1632,7 @@ void Dobby::getSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
 
     AI_LOG_FN_EXIT();
 }
-#endif // (AI_BUILD_TYPE == AI_DEBUG)
+#endif // (AI_BUILD_TYPE == AI_DEBUG) && defined(LEGACY_COMPONENTS)
 
 #if (AI_BUILD_TYPE == AI_DEBUG)
 // -----------------------------------------------------------------------------

--- a/daemon/lib/source/DobbyManager.h
+++ b/daemon/lib/source/DobbyManager.h
@@ -93,16 +93,21 @@ public:
 private:
     void setupSystem();
     void setupWorkspace(const std::shared_ptr<IDobbyEnv>& env);
+
+#if defined(LEGACY_COMPONENTS)
     void setupSystemHooks();
+#endif // defined(LEGACY_COMPONENTS)
 
     void cleanupContainers();
 
 public:
+#if defined(LEGACY_COMPONENTS)
     int32_t startContainerFromSpec(const ContainerId& id,
                                    const std::string& jsonSpec,
                                    const std::list<int>& files,
                                    const std::string& command,
                                    const std::string& displaySocket);
+#endif // defined(LEGACY_COMPONENTS)
 
     int32_t startContainerFromBundle(const ContainerId& id,
                                      const std::string& bundlePath,
@@ -131,11 +136,12 @@ public:
     std::vector<std::string> getExtIfaces();
 
 public:
-    std::string specOfContainer(int32_t cd) const;
-
     std::string jsonConfigOfContainer(int32_t cd) const;
 
+#if defined(LEGACY_COMPONENTS)
+    std::string specOfContainer(int32_t cd) const;
     bool createBundle(const ContainerId& id, const std::string& jsonSpec);
+#endif // defined(LEGACY_COMPONENTS)
 
 private:
     void onChildExit();
@@ -173,6 +179,9 @@ private:
 private:
     bool onPostInstallationHook(const std::unique_ptr<DobbyContainer> &container);
     bool onPreCreationHook(const std::unique_ptr<DobbyContainer> &container);
+    bool onPostHaltHook(const std::unique_ptr<DobbyContainer> &container);
+
+#if defined(LEGACY_COMPONENTS)
     bool onPostConstructionHook(const ContainerId& id,
                                 const std::shared_ptr<DobbyStartState>& startState,
                                 const std::unique_ptr<DobbyContainer>& container);
@@ -182,10 +191,8 @@ private:
                          const std::unique_ptr<DobbyContainer>& container);
     bool onPostStopHook(const ContainerId& id,
                         const std::unique_ptr<DobbyContainer>& container);
-    bool onPostHaltHook(const std::unique_ptr<DobbyContainer> &container);
     bool onPreDestructionHook(const ContainerId& id,
                               const std::unique_ptr<DobbyContainer>& container);
-
 
 private:
     enum class HookType {
@@ -196,6 +203,7 @@ private:
     bool executeSysHooks(const std::unique_ptr<DobbyContainer>& container,
                          const HookType& hookType,
                          const SysHookFn& sysHookFn);
+#endif // defined(LEGACY_COMPONENTS)
 
 private:
     void startRuncMonitorThread();
@@ -211,8 +219,10 @@ private:
 
 private:
     std::unique_ptr<DobbyRunC> mRunc;
-    std::unique_ptr<DobbyPluginManager> mPlugins;
     std::shared_ptr<DobbyState> mState;
+#if defined(LEGACY_COMPONENTS)
+    std::unique_ptr<DobbyPluginManager> mPlugins;
+#endif // defined(LEGACY_COMPONENTS)
 
 private:
     std::list<std::shared_ptr<IDobbySysHook>> mSysHooks;

--- a/daemon/process/CMakeLists.txt
+++ b/daemon/process/CMakeLists.txt
@@ -85,7 +85,6 @@ target_link_libraries( # Specifies the target exec
         # Import the 3rd party libraries
         systemd
         JsonCpp::JsonCpp
-        CTemplate::libctemplate
         DBUS::libdbus
         LIBNL::libnl
         LIBNL::libnl-route
@@ -143,3 +142,10 @@ install(
 #            $DESTDIR/${CMAKE_INSTALL_PREFIX}/etc/systemd/system/multi-user.target.wants/sky-dobby.service \
 #            )" )
 
+
+if (LEGACY_COMPONENTS)
+        target_link_libraries( DobbyDaemon
+                # Import the 3rd party libraries
+                CTemplate::libctemplate
+        )
+endif()


### PR DESCRIPTION
Allows removal of ctemplate dependency for builds where dobby
specs are not needed.

With LEGACY_PLUGIN=OFF, Dobby syshooks, legacy plugins and dobby
specs no longer function.