### PR TITLE
RDKCMF-8664: fix for configs with zero rdk plugins

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -752,9 +752,12 @@ int32_t DobbyManager::startContainerFromSpec(const ContainerId &id,
         else
         {
             // Run preCreation hook
-            if (!onPreCreationHook(container))
+            if (rdkPlugins.size() > 0)
             {
-                pluginFailure = true;
+                if (!onPreCreationHook(container))
+                {
+                    pluginFailure = true;
+                }
             }
 
             if (!pluginFailure)
@@ -933,9 +936,12 @@ int32_t DobbyManager::startContainerFromBundle(const ContainerId &id,
             }
 
             // Run preCreation hook
-            if (!onPreCreationHook(container))
+            if (rdkPlugins.size() > 0)
             {
-                pluginFailure = true;
+                if (!onPreCreationHook(container))
+                {
+                    pluginFailure = true;
+                }
             }
 
             if (!pluginFailure)


### PR DESCRIPTION
* without this patch I would get this error when using a config
  with zero plugins:
  "Could not run preCreation hook as plugin manager is null"