### PR TITLE
Fix CMake libocispec command sequence

### DIFF
--- a/cmake/libocispec.cmake
+++ b/cmake/libocispec.cmake
@@ -70,6 +70,10 @@ execute_process(
     WORKING_DIRECTORY ${LIBOCISPEC_DIR}
     COMMAND mkdir -p ./schemas/rt
     COMMAND mkdir -p ./schemas/img
+)
+
+execute_process(
+    WORKING_DIRECTORY ${LIBOCISPEC_DIR}
     COMMAND cp -r ./runtime-spec/schema/. ./schemas/rt/
     COMMAND cp -r ./image-spec/schema/. ./schemas/img/
 )


### PR DESCRIPTION
* commands in execute_process() are executed in parallel
  so making the target dirs and copying files in them
  must be sequential