### PR TITLE
Add cmake options to change dbus service name and object path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,11 +89,15 @@ option( ENABLE_LTO "Enable link time optimisation compiler flags" OFF )
 
 # Set default Dobby dbus service to org.rdk.dobby and add defines
 set( DOBBY_SERVICE "org.rdk.dobby" CACHE STRING "Dobby dbus service name")
-add_definitions( -DDOBBY_SERVICE="${DOBBY_SERVICE}")
+if(NOT DOBBY_SERVICE STREQUAL "org.rdk.dobby")
+    add_definitions( -DDOBBY_SERVICE_OVERRIDE="${DOBBY_SERVICE}")
+endif()
 
 # Set default Dobby dbus object path to /org/rdk/dobby and add defines
 set( DOBBY_OBJECT "/org/rdk/dobby" CACHE STRING "Dobby dbus object path")
-add_definitions( -DDOBBY_OBJECT="${DOBBY_OBJECT}" )
+if(NOT DOBBY_OBJECT STREQUAL "/org/rdk/dobby")
+    add_definitions( -DDOBBY_OBJECT_OVERRIDE="${DOBBY_OBJECT}")
+endif()
 
 # Enable C++14 support. The following tells cmake to always add the -std=c++14
 # flag (nb - if CMAKE_CXX_EXTENSIONS is ON then we'll get -std=gnu++14 instead)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,14 @@ option( LEGACY_COMPONENTS "Enable Dobby legacy components" ON )
 # See http://hubicka.blogspot.com/2018/06/gcc-8-link-time-and-interprocedural.html
 option( ENABLE_LTO "Enable link time optimisation compiler flags" OFF )
 
+# Set default Dobby dbus service to org.rdk.dobby and add defines
+set( DOBBY_SERVICE "org.rdk.dobby" CACHE STRING "Dobby dbus service name")
+add_definitions( -DDOBBY_SERVICE="${DOBBY_SERVICE}")
+
+# Set default Dobby dbus object path to /org/rdk/dobby and add defines
+set( DOBBY_OBJECT "/org/rdk/dobby" CACHE STRING "Dobby dbus object path")
+add_definitions( -DDOBBY_OBJECT="${DOBBY_OBJECT}" )
+
 # Enable C++14 support. The following tells cmake to always add the -std=c++14
 # flag (nb - if CMAKE_CXX_EXTENSIONS is ON then we'll get -std=gnu++14 instead)
 set( CMAKE_CXX_STANDARD          14  )

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Usage: DobbyDaemon <option(s)>
 
   -f, --settings-file=PATH      Path to a JSON dobby settings file [/etc/dobby.json]
   -a, --dbus-address=ADDRESS    The dbus address to put the admin service on [system bus]
-  -s, --service=SERVICE         The dbus service to put Dobby on [org.rdk.dobby]
   -p, --priority=PRIORITY       Sets the SCHED_RR priority of the daemon [RR,12]
   -n, --nofork                  Do not fork and daemonise the process
   -k, --noconsole               Disable console output

--- a/README.md
+++ b/README.md
@@ -36,12 +36,18 @@ During the CMake configure stage, CMake will also configure the `libocispec` sub
 If the schema files in the `bundle/runtime-schemas` directory are changed, then you will need to re-run CMake again to regenerate the headers.
 
 ### CMake Configuration Settings
-* `-DPLUGIN_PATH=""` - specifiy a different location to load RDK plugins from.
-* `-DRDK_PLATFORM=DEV_VM` - specifiy which platform Dobby is running on. Defaults to `XI6` if none specified. Valid options include
+* `-DPLUGIN_PATH=""` - specify a different location to load RDK plugins from.
+* `-DRDK_PLATFORM=DEV_VM` - specify which platform Dobby is running on. Defaults to `XI6` if none specified. Valid options include
   * `XI6`
   * `XI1`
   * `LLAMA`
   * `DEV_VM`
+* `-DLEGACY_COMPONENTS=[ON|OFF]` - option to enable or disable legacy components (legacy plugins, Dobby specs, ...)
+* `-DENABLE_LTO=[ON|OFF]` - option to enable or disable link time optimisation for Dobby.
+* `-DENABLE_PERFETTO_TRACING=[ON|OFF]` - option to enable or disable Perfetto tracing. Can not be enabled for release builds.
+* `-DDOBBY_SERVICE=""` - specify the Dobby dbus service name. Defaults to `org.rdk.dobby` if none specified.
+* `-DDOBBY_OBJECT=""` - specify the Dobby dbus object path. Defaults to `/org/rdk/dobby` if none specified.
+
 
 ## Development
 If you with to develop Dobby further, detailed instructions on setting up a development environment can be found in the `develop` directory in this repo, including a Vagrant VM with all the necessary dependencies pre-installed.

--- a/client/tool/source/Main.cpp
+++ b/client/tool/source/Main.cpp
@@ -61,7 +61,7 @@
 #define ARRAY_LENGTH(x)   (sizeof(x) / sizeof((x)[0]))
 
 //
-static std::string gDBusService("org.rdk.dobby.test");
+static std::string gDBusService(DOBBY_SERVICE ".test");
 
 //
 static char** gCmdlineArgv = NULL;
@@ -934,7 +934,6 @@ static void displayUsage()
     printf("\n");
     printf("  -a, --dbus-address=ADDRESS    The dbus address to talk to, if not set attempts\n");
     printf("                                to find the dbus socket in the usual places\n");
-    printf("  -s, --service=SERVICE         The dbus service the file mapper daemon is on [%s]\n", gDBusService.c_str());
     printf("\n");
 }
 
@@ -977,10 +976,6 @@ static void parseArgs(const int argc, char **argv)
             case 'V':
                 displayVersion();
                 exit(EXIT_SUCCESS);
-                break;
-
-            case 's':
-                gDBusService = reinterpret_cast<const char*>(optarg);
                 break;
 
             case '?':

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -80,8 +80,8 @@ Dobby::Dobby(const std::string& dbusAddress,
     , mWorkQueue(new DobbyWorkQueue)
     , mPluginWorkQueue(new DobbyWorkQueue)
     , mIpcService(ipcService)
-    , mService(settings->dbusServiceName())
-    , mObjectPath(settings->dbusObjectPath())
+    , mService(DOBBY_SERVICE)
+    , mObjectPath(DOBBY_OBJECT)
     , mShutdown(false)
     , mWatchdogTimerId(-1)
 {

--- a/daemon/process/CMakeLists.txt
+++ b/daemon/process/CMakeLists.txt
@@ -134,11 +134,11 @@ install(
         RENAME      dobby.json
         DESTINATION /etc/ )
 
-
+configure_file(dobby.service.in dobby.service @ONLY)
 
 # Install a systemd launch service config and enables it by default
 install(
-        FILES       dobby.service
+        FILES       ${CMAKE_CURRENT_BINARY_DIR}/dobby.service
         DESTINATION /lib/systemd/system/ )
 
 # The following doesn't seem to work in RDK, disabling for now

--- a/daemon/process/dobby.service.in
+++ b/daemon/process/dobby.service.in
@@ -36,7 +36,7 @@ Description=RDK Dobby (Container) daemon
 
 [Service]
 Type=dbus
-BusName=org.rdk.dobby
+BusName=@DOBBY_SERVICE@
 ExecStart=/usr/sbin/DobbyDaemon --nofork --noconsole --journald
 WatchdogSec=5
 Restart=on-failure

--- a/daemon/process/settings/dobby.dev_vm.json
+++ b/daemon/process/settings/dobby.dev_vm.json
@@ -1,9 +1,4 @@
 {
-    "dbus": {
-      "serviceName": "org.rdk.dobby",
-      "objectPath": "/org/rdk/dobby"
-    },
-
     "paths": {
       "workspaceDir": "/tmp/rdk",
       "persistentDir": "/opt/persistent/rdk"

--- a/daemon/process/settings/dobby.llama.json
+++ b/daemon/process/settings/dobby.llama.json
@@ -1,9 +1,4 @@
 {
-  "dbus": {
-    "serviceName": "org.rdk.dobby",
-    "objectPath": "/org/rdk/dobby"
-  },
-
   "paths": {
     "workspaceDir": "/tmp/rdk",
     "persistentDir": "/opt/persistent/rdk"

--- a/daemon/process/settings/dobby.xi1.json
+++ b/daemon/process/settings/dobby.xi1.json
@@ -1,9 +1,4 @@
 {
-  "dbus": {
-    "serviceName": "org.rdk.dobby",
-    "objectPath": "/org/rdk/dobby"
-  },
-
   "paths": {
     "workspaceDir": "/tmp/rdk",
     "persistentDir": "/opt/persistent/rdk"

--- a/daemon/process/settings/dobby.xi6.json
+++ b/daemon/process/settings/dobby.xi6.json
@@ -1,9 +1,4 @@
 {
-  "dbus": {
-    "serviceName": "org.rdk.dobby",
-    "objectPath": "/org/rdk/dobby"
-  },
-
   "paths": {
     "workspaceDir": "/var/volatile/rdk",
     "persistentDir": "/opt/persistent/rdk"

--- a/daemon/process/source/Main.cpp
+++ b/daemon/process/source/Main.cpp
@@ -79,9 +79,6 @@ static int gPrintPidFd = -1;
 static std::string gDbusAddress;
 
 //
-static std::string gDBusService;
-
-//
 static std::string gSettingsFilePath("/etc/dobby.json");
 
 
@@ -117,7 +114,6 @@ static void displayUsage()
     printf("\n");
     printf("  -f, --settings-file=PATH      Path to a JSON dobby settings file [%s]\n", gSettingsFilePath.c_str());
     printf("  -a, --dbus-address=ADDRESS    The dbus address to put the admin service on [system bus]\n");
-    printf("  -s, --service=SERVICE         The dbus service to put Dobby on [%s]\n", DOBBY_SERVICE);
     printf("  -p, --priority=PRIORITY       Sets the SCHED_RR priority of the daemon [RR,12]\n");
     printf("  -n, --nofork                  Do not fork and daemonise the process\n");
     printf("  -k, --noconsole               Disable console output\n");
@@ -150,7 +146,6 @@ static void parseArgs(int argc, char **argv)
         { "version",        no_argument,        nullptr,    (int)'V' },
         { "settings-file",  required_argument,  nullptr,    (int)'f' },
         { "dbus-address",   required_argument,  nullptr,    (int)'a' },
-        { "service",        required_argument,  nullptr,    (int)'s' },
         { "nofork",         no_argument,        nullptr,    (int)'n' },
         { "priority",       required_argument,  nullptr,    (int)'p' },
         { "noconsole",      no_argument,        nullptr,    (int)'k' },
@@ -199,10 +194,6 @@ static void parseArgs(int argc, char **argv)
                             gSettingsFilePath.c_str());
                     exit(EXIT_FAILURE);
                 }
-                break;
-
-            case 's':
-                gDBusService = reinterpret_cast<const char*>(optarg);
                 break;
 
             case 'n':
@@ -263,12 +254,6 @@ static std::shared_ptr<Settings> createSettings()
     {
         AI_LOG_WARN("missing or inaccessible settings file, using defaults");
         settings = Settings::defaultSettings();
-    }
-
-    // set the dbus details
-    if (!gDBusService.empty())
-    {
-        settings->setDBusServiceName(gDBusService);
     }
 
     // TODO remove
@@ -408,7 +393,7 @@ static std::string getAIDbusAddress(bool privateBus)
 
         globfree(&globbuf);
     }
-    
+
     return path;
 }
 #endif // (AI_BUILD_TYPE == AI_DEBUG)
@@ -499,18 +484,18 @@ int main(int argc, char * argv[])
     {
         AI_LOG_INFO("starting dbus service");
         AI_LOG_INFO("  dbus address '%s'", gDbusAddress.c_str());
-        AI_LOG_INFO("  service name '%s'", settings->dbusServiceName().c_str());
-        AI_LOG_INFO("  object name '%s'", settings->dbusObjectPath().c_str());
+        AI_LOG_INFO("  service name '%s'", DOBBY_SERVICE);
+        AI_LOG_INFO("  object name '%s'", DOBBY_OBJECT);
 
         // Create IPCServices that attach to the dbus daemons
         std::shared_ptr<AI_IPC::IIpcService> ipcService;
         if (gDbusAddress.empty())
         {
-            ipcService = AI_IPC::createSystemBusIpcService(settings->dbusServiceName());
+            ipcService = AI_IPC::createSystemBusIpcService(DOBBY_SERVICE);
         }
         else
         {
-            ipcService = AI_IPC::createIpcService(gDbusAddress, settings->dbusServiceName());
+            ipcService = AI_IPC::createIpcService(gDbusAddress, DOBBY_SERVICE);
         }
 
         if (!ipcService)

--- a/protocol/include/DobbyProtocol.h
+++ b/protocol/include/DobbyProtocol.h
@@ -24,10 +24,7 @@
 #define DOBBYPROTOCOL_H
 
 
-#define DOBBY_SERVICE                           "org.rdk.dobby"
-#define DOBBY_OBJECT                            "/org/rdk/dobby"
-
-#define DOBBY_ADMIN_INTERFACE                   "org.rdk.dobby.admin1"
+#define DOBBY_ADMIN_INTERFACE                   DOBBY_SERVICE ".admin1"
 #define DOBBY_ADMIN_METHOD_PING                     "Ping"
 #define DOBBY_ADMIN_METHOD_SHUTDOWN                 "Shutdown"
 #define DOBBY_ADMIN_METHOD_SET_LOG_METHOD           "SetLogMethod"
@@ -35,7 +32,7 @@
 #define DOBBY_ADMIN_METHOD_SET_AI_DBUS_ADDR         "SetAIDbusAddress"
 #define DOBBY_ADMIN_EVENT_READY                     "Ready"
 
-#define DOBBY_CTRL_INTERFACE                    "org.rdk.dobby.ctrl1"
+#define DOBBY_CTRL_INTERFACE                    DOBBY_SERVICE ".ctrl1"
 #define DOBBY_CTRL_METHOD_START                     "Start"
 #define DOBBY_CTRL_METHOD_START_FROM_SPEC           "StartFromSpec"
 #define DOBBY_CTRL_METHOD_START_FROM_BUNDLE         "StartFromBundle"
@@ -49,14 +46,14 @@
 #define DOBBY_CTRL_EVENT_STARTED                    "Started"
 #define DOBBY_CTRL_EVENT_STOPPED                    "Stopped"
 
-#define DOBBY_DEBUG_INTERFACE                   "org.rdk.dobby.debug1"
+#define DOBBY_DEBUG_INTERFACE                   DOBBY_SERVICE ".debug1"
 #define DOBBY_DEBUG_METHOD_CREATE_BUNDLE            "CreateBundle"
 #define DOBBY_DEBUG_METHOD_GET_SPEC                 "GetSpec"
 #define DOBBY_DEBUG_METHOD_GET_OCI_CONFIG           "GetOCIConfig"
 #define DOBBY_DEBUG_START_INPROCESS_TRACING         "StartInProcessTracing"
 #define DOBBY_DEBUG_STOP_INPROCESS_TRACING          "StopInProcessTracing"
 
-#define DOBBY_RDKPLUGIN_INTERFACE               "org.rdk.dobby.rdkplugin1"
+#define DOBBY_RDKPLUGIN_INTERFACE               DOBBY_SERVICE ".rdkplugin1"
 #define DOBBY_RDKPLUGIN_GET_BRIDGE_CONNECTIONS      "GetBridgeConnections"
 #define DOBBY_RDKPLUGIN_GET_ADDRESS                 "GetIpAddress"
 #define DOBBY_RDKPLUGIN_FREE_ADDRESS                "FreeIpAddress"

--- a/protocol/include/DobbyProtocol.h
+++ b/protocol/include/DobbyProtocol.h
@@ -23,6 +23,19 @@
 #ifndef DOBBYPROTOCOL_H
 #define DOBBYPROTOCOL_H
 
+// Use default service name and object path unless if overriden with
+// Dobby CMake options "DOBBY_SERVICE"/"DOBBY_OBJECT".
+#if defined(DOBBY_SERVICE_OVERRIDE)
+    #define DOBBY_SERVICE   DOBBY_SERVICE_OVERRIDE
+#else
+    #define DOBBY_SERVICE   "org.rdk.dobby"
+#endif
+#if defined(DOBBY_OBJECT_OVERRIDE)
+    #define DOBBY_OBJECT   DOBBY_OBJECT_OVERRIDE
+#else
+    #define DOBBY_OBJECT   "/org/rdk/dobby"
+#endif
+
 
 #define DOBBY_ADMIN_INTERFACE                   DOBBY_SERVICE ".admin1"
 #define DOBBY_ADMIN_METHOD_PING                     "Ping"

--- a/rdkPlugins/Networking/source/NetworkingPlugin.cpp
+++ b/rdkPlugins/Networking/source/NetworkingPlugin.cpp
@@ -28,7 +28,7 @@
 
 REGISTER_RDK_PLUGIN(NetworkingPlugin);
 
-static std::string gDBusService("org.rdk.dobby.plugin.networking");
+static std::string gDBusService(DOBBY_SERVICE ".plugin.networking");
 
 
 NetworkingPlugin::NetworkingPlugin(std::shared_ptr<rt_dobby_schema> &cfg,

--- a/settings/include/IDobbySettings.h
+++ b/settings/include/IDobbySettings.h
@@ -46,24 +46,6 @@ public:
     virtual ~IDobbySettings() = default;
 
 public:
-
-    // -------------------------------------------------------------------------
-    /**
-     *  @brief The name to use when registering the dbus service on the bus.
-     *
-     *
-     */
-    virtual std::string dbusServiceName() const = 0;
-
-    // -------------------------------------------------------------------------
-    /**
-     *  @brief The dbus object path under which the interfaces will be
-     *  registered.
-     *
-     *
-     */
-    virtual std::string dbusObjectPath() const = 0;
-
     // -------------------------------------------------------------------------
     /**
      *  @brief Should return the path to a directory used to store temporary

--- a/settings/include/Settings.h
+++ b/settings/include/Settings.h
@@ -58,13 +58,6 @@ public:
     static std::shared_ptr<Settings> defaultSettings();
 
 public:
-    void setDBusServiceName(const std::string& name);
-    std::string dbusServiceName() const override;
-
-    void setDBusObjectPath(const std::string& path);
-    std::string dbusObjectPath() const override;
-
-
     std::string workspaceDir() const override;
     std::string persistentDir() const override;
 
@@ -113,8 +106,6 @@ private:
                             const std::shared_ptr<const HardwareAccessSettings>& hwAccess) const;
 
 private:
-    std::string mDBusServiceName;
-    std::string mDBusObjectPath;
     std::string mWorkspaceDir;
     std::string mPersistentDir;
     std::string mConsoleSocketPath;

--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -110,27 +110,6 @@ Settings::Settings(const Json::Value& settings)
     // defaults first
     setDefaults();
 
-    // process dbus settings
-    {
-        Json::Value serviceName = Json::Path(".dbus.serviceName").resolve(settings);
-        if (!serviceName.isNull())
-        {
-            if (!serviceName.isString())
-                AI_LOG_ERROR("invalid dbus service name in JSON settings file");
-            else
-                mDBusServiceName = serviceName.asString();
-        }
-
-        Json::Value objectPath = Json::Path(".dbus.objectPath").resolve(settings);
-        if (!objectPath.isNull())
-        {
-            if (!objectPath.isString())
-                AI_LOG_ERROR("invalid dbus object path in JSON settings file");
-            else
-                mDBusObjectPath = objectPath.asString();
-        }
-    }
-
     // process the paths
     {
         Json::Value workspaceDir = Json::Path(".paths.workspaceDir").resolve(settings);
@@ -245,8 +224,6 @@ Settings::Settings(const Json::Value& settings)
  */
 void Settings::setDefaults()
 {
-    mDBusServiceName = DOBBY_SERVICE;
-    mDBusObjectPath = DOBBY_OBJECT;
     mConsoleSocketPath = "/tmp/dobbyPty.sock";
 
 #if defined(RDK)
@@ -256,46 +233,6 @@ void Settings::setDefaults()
     mWorkspaceDir = getPathFromEnv("AI_WORKSPACE_PATH", "/tmp/ai-workspace-fallback");
     mPersistentDir = getPathFromEnv("AI_PERSISTENT_PATH", "/tmp/ai-flash-fallback");
 #endif
-}
-
-// -----------------------------------------------------------------------------
-/**
- *  @brief
- *
- */
-void Settings::setDBusServiceName(const std::string& name)
-{
-    mDBusServiceName = name;
-}
-
-// -----------------------------------------------------------------------------
-/**
- *  @brief
- *
- */
-std::string Settings::dbusServiceName() const
-{
-    return mDBusServiceName;
-}
-
-// -----------------------------------------------------------------------------
-/**
- *  @brief
- *
- */
-void Settings::setDBusObjectPath(const std::string& path)
-{
-    mDBusObjectPath = path;
-}
-
-// -----------------------------------------------------------------------------
-/**
- *  @brief
- *
- */
-std::string Settings::dbusObjectPath() const
-{
-    return mDBusObjectPath;
 }
 
 // -----------------------------------------------------------------------------
@@ -398,9 +335,6 @@ void Settings::dump(int aiLogLevel) const
 {
     if (aiLogLevel < 0)
         aiLogLevel = AI_DEBUG_LEVEL_INFO;
-
-    __AI_LOG_PRINTF(aiLogLevel, "settings.dbus.serviceName='%s'", mDBusServiceName.c_str());
-    __AI_LOG_PRINTF(aiLogLevel, "settings.dbus.objectPath='%s'", mDBusObjectPath.c_str());
 
     __AI_LOG_PRINTF(aiLogLevel, "settings.paths.workspaceDir='%s'", mWorkspaceDir.c_str());
     __AI_LOG_PRINTF(aiLogLevel, "settings.paths.persistentDir='%s'", mPersistentDir.c_str());


### PR DESCRIPTION
This used to be in settings, but even then was only partially functional.

Now using the cmake options DOBBY_SERVICE and DOBBY_OBJECT, we can set
the dbus service name and object path across the project.