### PR TITLE
BD-821-BLDK-734: Updates In Licences Header

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-This component contains software that is Copyright (c) 2020 RDK Management.
+This component contains software that is Copyright (c) 2020 Sky UK
 The component is licensed to you under the Apache License, Version 2.0 (the "License").
 You may not use the component except in compliance with the License.
 
@@ -6,9 +6,6 @@ The component may include material which is licensed under other licenses / copy
 listed below. Your use of this material within the component is also subject to the terms and
 conditions of these licenses. The LICENSE file contains the text of all the licenses which apply
 within this component.
-
-Copyright 2013-2020 Sky UK
-Licensed under the Apache License, Version 2.0
 
 Alexander Peslyak, better known as Solar Designer <solar at openwall.com>
 This software was written by Alexander Peslyak in 2001.  No copyright is


### PR DESCRIPTION
Updated License header (removal)  RDK Management copyrights which should be changed to Sky UK and the second one then removed