### PR TITLE
Correctly reported paused container state

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1506,6 +1506,9 @@ std::string DobbyManager::statsOfContainer(int32_t cd) const
             case DobbyContainer::State::Stopping:
                 jsonStats["state"] = "stopping";
                 break;
+            case DobbyContainer::State::Paused:
+                jsonStats["state"] = "paused";
+                break;
         }
 
         // convert the json stats to a string and return


### PR DESCRIPTION
### Description
Correctly report a container state as paused

### Test Procedure
Start & pause a container, then get it's info. The state will show as paused correctly

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above catagories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)