### PR TITLE
Improve logging when pause/resume containers

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1217,7 +1217,15 @@ bool DobbyManager::pauseContainer(int32_t cd)
         return false;
     }
 
-    AI_LOG_WARN("Container '%s' was not running so could not be paused", id.c_str());
+    if (container->state == DobbyContainer::State::Paused)
+    {
+        AI_LOG_WARN("Container '%s' is already paused", id.c_str());
+    }
+    else
+    {
+        AI_LOG_WARN("Container '%s' is not running so could not be paused", id.c_str());
+    }
+
     AI_LOG_FN_EXIT();
     return false;
 }
@@ -1270,7 +1278,7 @@ bool DobbyManager::resumeContainer(int32_t cd)
         return false;
     }
 
-    AI_LOG_WARN("Container '%s' was not running so could not be paused", id.c_str());
+    AI_LOG_WARN("Container '%s' is not paused so could not be resumed", id.c_str());
     AI_LOG_FN_EXIT();
     return false;
 }


### PR DESCRIPTION
### Description
Change log messages when pausing/resuming container to be more accurate

### Test Procedure
Start then pause/resume containers

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above catagories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)