### PR TITLE
RDK-29862 - Add rdkPlugins field to Dobby specs

### DIFF
--- a/bundle/lib/include/DobbySpecConfig.h
+++ b/bundle/lib/include/DobbySpecConfig.h
@@ -149,6 +149,9 @@ private:
                             ctemplate::TemplateDictionary* dictionary,
                             Json::Value& loopMntData);
 
+    bool processRdkPlugins(const Json::Value& value,
+                           ctemplate::TemplateDictionary* dictionary);
+
 private:
     template <std::size_t N>
     std::bitset<N> parseBitset(const std::string& str) const;
@@ -159,14 +162,7 @@ private:
                          const std::string &destination);
 
 private:
-    void addRdkPlugin(const std::string& pluginName,
-                      const bool pluginRequired,
-                      const Json::Value& pluginData);
-    std::string createRdkPluginDataString(const Json::Value& jsonObject);
-    void enableRdkPlugin(ctemplate::TemplateDictionary*& subDict, const std::string& pluginName, const bool required);
-
-private:
-    void enableLocaltimePlugin();
+    std::string jsonToString(const Json::Value& jsonObject);
 
 private:
     static void addGpuDevNodes(const std::shared_ptr<const IDobbySettings::HardwareAccessSettings> &settings,
@@ -186,6 +182,7 @@ private:
 
 private:
     Json::Value mSpec;
+    Json::Value mRdkPluginsJson;
     std::shared_ptr<rt_dobby_schema> mConf;
 
 private:

--- a/bundle/lib/include/DobbySpecConfig.h
+++ b/bundle/lib/include/DobbySpecConfig.h
@@ -149,6 +149,9 @@ private:
                             ctemplate::TemplateDictionary* dictionary,
                             Json::Value& loopMntData);
 
+private:
+    bool insertIntoRdkPluginJson(const std::string& pluginName,
+                                 const Json::Value& pluginData);
     bool processRdkPlugins(const Json::Value& value,
                            ctemplate::TemplateDictionary* dictionary);
 

--- a/bundle/lib/include/DobbySpecConfig.h
+++ b/bundle/lib/include/DobbySpecConfig.h
@@ -150,7 +150,7 @@ private:
                             Json::Value& loopMntData);
 
 private:
-    bool insertIntoRdkPluginJson(const std::string& pluginName,
+    void insertIntoRdkPluginJson(const std::string& pluginName,
                                  const Json::Value& pluginData);
     bool processRdkPlugins(const Json::Value& value,
                            ctemplate::TemplateDictionary* dictionary);

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -539,7 +539,7 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
         ProcessorMap::const_iterator fn = processors.find(it.name());
         if (fn != processors.end())
         {
-            AI_LOG_INFO("Processing %s", fn->first.c_str());
+            AI_LOG_DEBUG("Processing %s", fn->first.c_str());
             // the following is super ugly, but allows us to call the function
             // pointers as methods within our own class
             const ProcessorFunc& method = fn->second.second;

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -1977,7 +1977,7 @@ bool DobbySpecConfig::processMounts(const Json::Value& value,
     if (numLoopMounts > 0)
     {
         mRdkPluginsJson[RDK_STORAGE_PLUGIN_NAME]["data"] = rdkPluginData;
-        mRdkPluginsJson[RDK_NETWORK_PLUGIN_NAME]["required"] = false;
+        mRdkPluginsJson[RDK_STORAGE_PLUGIN_NAME]["required"] = false;
     }
 
     return true;
@@ -2529,7 +2529,7 @@ void DobbySpecConfig::insertIntoRdkPluginJson(const std::string& pluginName,
     Json::Value& existingData = mRdkPluginsJson[pluginName]["data"];
 
     // iterate through all data members in the RDK plugin's data field
-    for (auto dataMember : pluginData.getMemberNames())
+    for (const auto& dataMember : pluginData.getMemberNames())
     {
         if (!pluginData[dataMember].isArray())
         {
@@ -2541,7 +2541,7 @@ void DobbySpecConfig::insertIntoRdkPluginJson(const std::string& pluginName,
         {
             // plugin member is an array, so instead of overwriting, we should
             // append the new array members to the existing array
-            for (auto arrayElement : dataMember)
+            for (const auto& arrayElement : dataMember)
             {
                 existingData[dataMember].append(arrayElement);
             }
@@ -2577,7 +2577,7 @@ bool DobbySpecConfig::processRdkPlugins(const Json::Value& value,
             return false;
         }
 
-        for (auto pluginName : value.getMemberNames())
+        for (const auto& pluginName : value.getMemberNames())
         {
             // insert the rdkPlugins field into the json parsed from the spec
             insertIntoRdkPluginJson(pluginName, value[pluginName]["data"]);
@@ -2591,7 +2591,7 @@ bool DobbySpecConfig::processRdkPlugins(const Json::Value& value,
     }
 
     // process the final rdkPlugins from mRdkPluginsJson
-    for (auto pluginName : mRdkPluginsJson.getMemberNames())
+    for (const auto& pluginName : mRdkPluginsJson.getMemberNames())
     {
         const Json::Value pluginJson = mRdkPluginsJson[pluginName];
         const std::string pluginData = jsonToString(pluginJson["data"]);

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -2523,7 +2523,7 @@ bool DobbySpecConfig::processCapabilities(const Json::Value& value,
  *
  *  @return true if correctly processed the value, otherwise false.
  */
-bool DobbySpecConfig::insertIntoRdkPluginJson(const std::string& pluginName,
+void DobbySpecConfig::insertIntoRdkPluginJson(const std::string& pluginName,
                                               const Json::Value& pluginData)
 {
     Json::Value& existingData = mRdkPluginsJson[pluginName]["data"];
@@ -2573,7 +2573,7 @@ bool DobbySpecConfig::processRdkPlugins(const Json::Value& value,
     {
         if (!value.isObject())
         {
-            AI_LOG_ERROR("invalid rdkPlugins field");
+            AI_LOG_ERROR_EXIT("invalid rdkPlugins field");
             return false;
         }
 


### PR DESCRIPTION
### Description

Adds the ability to add 1-to-1 copy of the `rdkPlugins` field into Legacy Dobby specs.

### Test Procedure

Use `-DLEGACY_COMPONENTS=ON` flag.

Use `DobbyBundleGenerator` to generate bundles from specs. Test adding different RDK plugins into the  `rdkPlugins` field to see if they get merged in properly.

It's expected that any plugin data given in the `rdkPlugins` field is merged **over** the data that is processed from the other fields of the spec. I.e. if you have the following Dobby spec:

```
{
    ...,
    "network": "nat",
    "rdkPlugins": {
        "networking": {
            "required": true,
            "data": {
                "type": "open",
                "ipv6": true
            }
        }
    }
}
```

The output bundle's OCI config `rdkPlugins.network` field should be:

```
        "networking": {
            "required": true,
            "data": {
                "ipv4": true,
                "ipv6": true,
                "type": "open"
            }
        }
```
Note that the `required` field is also true since it was overwritten by the spec's `rdkPlugins` field.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)