### PR TITLE
Added new crun version.

### DIFF
--- a/develop/vagrant/0001-container-truncate-pid-file-before-writing-it.patch
+++ b/develop/vagrant/0001-container-truncate-pid-file-before-writing-it.patch
@@ -1,0 +1,81 @@
+From bc1d44460cc92a734b9999042dfeef8c6be3fd9c Mon Sep 17 00:00:00 2001
+From: Giuseppe Scrivano <giuseppe@scrivano.org>
+Date: Thu, 24 Sep 2020 18:00:18 +0200
+Subject: [PATCH] container: truncate pid file before writing it
+
+Closes: https://github.com/containers/crun/issues/504
+
+Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>
+---
+ src/libcrun/container.c |  4 ++--
+ src/libcrun/utils.c     | 10 ++++++++--
+ src/libcrun/utils.h     |  2 ++
+ 3 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/src/libcrun/container.c b/src/libcrun/container.c
+index 109f533..927986a 100644
+--- a/src/libcrun/container.c
++++ b/src/libcrun/container.c
+@@ -1230,7 +1230,7 @@ wait_for_process (pid_t pid, libcrun_context_t *context, int terminal_fd, int no
+     {
+       char buf[12];
+       size_t buf_len = sprintf (buf, "%d", pid);
+-      ret = write_file (context->pid_file, buf, buf_len, err);
++      ret = write_file_with_flags (context->pid_file, O_CREAT | O_TRUNC, buf, buf_len, err);
+       if (UNLIKELY (ret < 0))
+         return ret;
+     }
+@@ -2864,7 +2864,7 @@ libcrun_container_restore (libcrun_context_t *context, const char *id, libcrun_c
+     {
+       char buf[12];
+       size_t buf_len = sprintf (buf, "%d", status.pid);
+-      ret = write_file (context->pid_file, buf, buf_len, err);
++      ret = write_file_with_flags (context->pid_file, O_CREAT | O_TRUNC, buf, buf_len, err);
+       if (UNLIKELY (ret < 0))
+         return ret;
+     }
+diff --git a/src/libcrun/utils.c b/src/libcrun/utils.c
+index e2d5991..b1df0fe 100644
+--- a/src/libcrun/utils.c
++++ b/src/libcrun/utils.c
+@@ -111,9 +111,9 @@ write_file_at (int dirfd, const char *name, const void *data, size_t len, libcru
+ }
+ 
+ int
+-write_file (const char *name, const void *data, size_t len, libcrun_error_t *err)
++write_file_with_flags (const char *name, int flags, const void *data, size_t len, libcrun_error_t *err)
+ {
+-  cleanup_close int fd = open (name, O_WRONLY | O_CREAT, 0700);
++  cleanup_close int fd = open (name, O_WRONLY | flags, 0700);
+   int ret;
+   if (UNLIKELY (fd < 0))
+     return crun_make_error (err, errno, "opening file `%s` for writing", name);
+@@ -125,6 +125,12 @@ write_file (const char *name, const void *data, size_t len, libcrun_error_t *err
+   return ret;
+ }
+ 
++int
++write_file (const char *name, const void *data, size_t len, libcrun_error_t *err)
++{
++  return write_file_with_flags (name, O_CREAT, data, len, err);
++}
++
+ int
+ detach_process ()
+ {
+diff --git a/src/libcrun/utils.h b/src/libcrun/utils.h
+index 8f77820..178a957 100644
+--- a/src/libcrun/utils.h
++++ b/src/libcrun/utils.h
+@@ -149,6 +149,8 @@ int xasprintf (char **str, const char *fmt, ...);
+ 
+ int crun_path_exists (const char *path, libcrun_error_t *err);
+ 
++int write_file_with_flags (const char *name, int flags, const void *data, size_t len, libcrun_error_t *err);
++
+ int write_file (const char *name, const void *data, size_t len, libcrun_error_t *err);
+ 
+ int write_file_at (int dirfd, const char *name, const void *data, size_t len, libcrun_error_t *err);
+-- 
+2.17.1
+

--- a/develop/vagrant/Vagrantfile
+++ b/develop/vagrant/Vagrantfile
@@ -136,6 +136,11 @@ Vagrant.configure("2") do |config|
         mkdir ~/crun
         cd ~/crun
         git clone --depth 1 --branch 0.15 https://github.com/containers/crun.git .
+
+        # Apply patch for pid file not being created properly
+        cp /vagrant/0001-container-truncate-pid-file-before-writing-it.patch ./
+        patch -p1 < 0001-container-truncate-pid-file-before-writing-it.patch
+
         ./autogen.sh
         ./configure --disable-systemd
         sudo make install -j$(nproc)

--- a/develop/vagrant/Vagrantfile
+++ b/develop/vagrant/Vagrantfile
@@ -135,7 +135,7 @@ Vagrant.configure("2") do |config|
         figlet CRUN  # ASCII banner
         mkdir ~/crun
         cd ~/crun
-        git clone --depth 1 --branch 0.14.1 https://github.com/containers/crun.git .
+        git clone --depth 1 --branch 0.15 https://github.com/containers/crun.git .
         ./autogen.sh
         ./configure --disable-systemd
         sudo make install -j$(nproc)


### PR DESCRIPTION
### Description
Added new crun version v0.15 instead of v0.14.1

### Test Procedure
-

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The new crun recipe should be added (`meta-rdk-ext/recipes-containers/crun/crun_0.15.bb`) instead of old one  (`meta-rdk-ext/recipes-containers/crun/crun_0.14.1.bb`) 