### PR TITLE
Check compatiblity when removing multicast forwarder rules in postHalt

### DIFF
--- a/rdkPlugins/Networking/source/MulticastForwarder.cpp
+++ b/rdkPlugins/Networking/source/MulticastForwarder.cpp
@@ -154,6 +154,13 @@ bool MulticastForwarder::removeRules(const std::shared_ptr<Netfilter> &netfilter
 {
     AI_LOG_FN_ENTRY();
 
+    // before attempting to remove rules, check that the required programs exist
+    if (!checkCompatibility())
+    {
+        AI_LOG_FN_EXIT();
+        return false;
+    }
+
     std::mutex lock;
     std::lock_guard<std::mutex> locker(lock);
 

--- a/rdkPlugins/Networking/source/NetworkingPlugin.cpp
+++ b/rdkPlugins/Networking/source/NetworkingPlugin.cpp
@@ -369,7 +369,7 @@ bool NetworkingPlugin::postHalt()
     {
         if (!MulticastForwarder::removeRules(mNetfilter, mPluginData, mHelper->vethName(), mContainerId, extIfaces))
         {
-            AI_LOG_ERROR_EXIT("failed to add multicast forwards");
+            AI_LOG_ERROR_EXIT("failed to remove multicast forwards");
             return false;
         }
     }


### PR DESCRIPTION
### Description
Add a check in MulticastForwarder to check compatibility when removing rules. Previously only checked compatibility when adding the rules.

### Test Procedure
Start/stop a container when `smcroute` isn't installed. Without the patch, you will see the following error in DobbyDaemon when stopping the container:

```
sh: 1: /usr/sbin/smcroutectl: not found
sh: 1: /usr/sbin/smcroutectl: not found
Sorry, rule does not exist.
```

With the patch, you will see a nicer error:

```
Multicast forwarding not supported - smcroutectl not found in PATH (2 - No such file or directory)
```

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)