### PR TITLE
Fix invalid data for Local Time rdk plugin

### DIFF
--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -618,7 +618,8 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
     // step 6.5 - enable localtime rdk plugin by default if on Xi1. The
     // localtime plugin takes no input params, so we simply enable the
     // rdkPlugin rather than processing it via a processing function.
-    mRdkPluginsJson[RDK_LOCALTIME_PLUGIN_NAME]["data"] = "{}";
+    Json::Value rdkPluginData = Json::objectValue;
+    mRdkPluginsJson[RDK_LOCALTIME_PLUGIN_NAME]["data"] = rdkPluginData;
     mRdkPluginsJson[RDK_LOCALTIME_PLUGIN_NAME]["required"] = false;
 #endif
 


### PR DESCRIPTION
### Description
Fix issue where the data section of the `localtime` plugin was invalid, preventing container startup on Xi1

### Test Procedure
Attempt to start containers on Xi1. Containers should start without error, and the localtime plugin in the config.json should look as follows:

```json
"localtime":{
      "required":false,
      "data":{}
   }
```

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)