### PR TITLE
Enable multicast forwarding on localhost

### DIFF
--- a/rdkPlugins/Networking/source/MulticastForwarder.cpp
+++ b/rdkPlugins/Networking/source/MulticastForwarder.cpp
@@ -362,6 +362,12 @@ bool addSmcrouteRules(const std::vector<std::string> &extIfaces, const std::stri
        configFile << rule << "\n";
     }
 
+    // For multicast, we also want to forward multicast on localhost (needed for
+    // rtremote). lo must have multicast enabled, otherwise smcroute will ignore
+    // the iface
+    std::string loRule = constructSmcrouteRules("lo", address);
+    configFile << loRule << "\n";
+
     // Add a comment to mark the end of this container's rules
     configFile << "#END:" << containerId << "\n";
 


### PR DESCRIPTION
### Description
Multicast forwarder should forward packets sent on the localhost interface to `dobby0`. 

This is necessary for rtRemote which uses the localhost to send multicast packets between processes on a single host.

### Test Procedure
Same test procedure as per https://github.com/rdkcentral/Dobby/pull/63. The `lo` interface should also be added to the smcroute.conf file:

```
mroute from lo group 224.10.0.12 to dobby0
```

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)