### PR TITLE
[RDK-3029] Ensure smcroute config file is closed properly

### DIFF
--- a/rdkPlugins/Networking/source/MulticastForwarder.cpp
+++ b/rdkPlugins/Networking/source/MulticastForwarder.cpp
@@ -371,6 +371,8 @@ bool addSmcrouteRules(const std::vector<std::string> &extIfaces, const std::stri
     // Add a comment to mark the end of this container's rules
     configFile << "#END:" << containerId << "\n";
 
+    configFile.close();
+
     // Rules written, reload smcroute
     if (!executeCommand(SMCROUTECTL_PATH " restart"))
     {
@@ -437,6 +439,8 @@ bool removeSmcrouteRules(const std::string& containerId)
     {
         updatedConfigFile << rule << "\n";
     }
+
+    updatedConfigFile.close();
 
     // Rules written, reload smcroute
     if (!executeCommand(SMCROUTECTL_PATH " restart"))


### PR DESCRIPTION
### Description
Ensure the smcroute config file is closed and fully written to before attempting to reload smcroute to prevent smcroute restarting before the file is written.

### Test Procedure
Ensure smcroute always loads the config file correctly.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)