### PR TITLE
Always set the container hostname to container ID

### DIFF
--- a/bundle/lib/include/DobbyConfig.h
+++ b/bundle/lib/include/DobbyConfig.h
@@ -142,6 +142,9 @@ protected:
     bool updateBundleConfig(const ContainerId& id,
                             std::shared_ptr<rt_dobby_schema> cfg,
                             const std::string& bundlePath);
+    bool setHostnameToContainerId(const ContainerId& id,
+                            std::shared_ptr<rt_dobby_schema> cfg,
+                            const std::string& bundlePath);
     bool convertToCompliant(const ContainerId& id,
                             std::shared_ptr<rt_dobby_schema> cfg,
                             const std::string& bundlePath);

--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -520,6 +520,8 @@ bool DobbyConfig::setHostnameToContainerId(const ContainerId& id, std::shared_pt
     {
         return true;
     }
+
+    free(cfg->hostname);
     cfg->hostname = strdup(id.c_str());
 
     // write the new config.json to a file


### PR DESCRIPTION
### Description
Always set the hostname of the container to the container ID

### Test Procedure
Start a container from the same bundle multiple times, each with a different ID. The hostname of the container should always match the ID

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)