### PR TITLE
Adjust permissions on created directories for storage plugin

### DIFF
--- a/rdkPlugins/Storage/source/LoopMountDetails.cpp
+++ b/rdkPlugins/Storage/source/LoopMountDetails.cpp
@@ -128,12 +128,12 @@ bool LoopMountDetails::doLoopMount(const std::string& loopDevice)
     bool status = false;
 
     // step 1 - create directories within the rootfs
-    if (!DobbyRdkPluginUtils::mkdirRecursive(mTempMountPointOutsideContainer, 0700))
+    if (!DobbyRdkPluginUtils::mkdirRecursive(mTempMountPointOutsideContainer, 0755))
     {
         // logging already provided by mkdirRecursive
         return false;
     }
-    else if (!DobbyRdkPluginUtils::mkdirRecursive(mMountPointOutsideContainer, 0700))
+    else if (!DobbyRdkPluginUtils::mkdirRecursive(mMountPointOutsideContainer, 0755))
     {
         // logging already provided by mkdirRecursive
         return false;


### PR DESCRIPTION
### Description
Fix issue where Storage plugin would fail to mount the img file when using a deeply nested path as the destination

### Test Procedure
Create a loopback mount with the following config:

```
"loopback": [
    {
        "destination": "/home/private/test/long/path",
        "flags": 14,
        "fstype": "ext4",
        "source": "/tmp/data/data.img"
    }
]
```

The storage plugin should run successfully. Without this PR a permission denied error will be seen.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)