### PR TITLE
RDK-30291 Fixed occasional temp mounts

### DIFF
--- a/bundle/lib/include/DobbyRootfs.h
+++ b/bundle/lib/include/DobbyRootfs.h
@@ -74,6 +74,8 @@ public:
 
     void setPersistence(bool persist);
 
+    void unmountAllAt(const std::string& pathPrefix);
+
 #if defined(LEGACY_COMPONENTS)
 private:
     void cleanUp(bool dontRemoveFiles);
@@ -90,7 +92,6 @@ private:
                               const std::string& fileContents,
                               mode_t mode = 0644) const;
 
-    void unmountAllAt(const std::string& pathPrefix);
 #endif //defined(LEGACY_COMPONENTS)
 
 private:

--- a/bundle/lib/source/DobbyRootfs.cpp
+++ b/bundle/lib/source/DobbyRootfs.cpp
@@ -145,6 +145,11 @@ DobbyRootfs::~DobbyRootfs()
 {
 #if defined(LEGACY_COMPONENTS)
     cleanUp(mPersist);
+#else
+    if (!mPath.empty())
+    {
+        unmountAllAt(mPath);
+    }
 #endif //defined(LEGACY_COMPONENTS)
 }
 
@@ -166,74 +171,6 @@ int DobbyRootfs::dirFd() const
 void DobbyRootfs::setPersistence(bool persist)
 {
     mPersist = persist;
-}
-
-#if defined(LEGACY_COMPONENTS)
-// -----------------------------------------------------------------------------
-/**
- *  @brief Removes the rootfs directory and all it's contents.
- *
- *
- *  @param[in]  dontRemoveFiles In true then the files and directory(s) are
- *                              left in place.  This may be useful for
- *                              re-creating containers for debugging runc issues
- *                              or for retaining bundles when started from a bundle
- *                              instead of a Dobby spec.
- *
- */
-void DobbyRootfs::cleanUp(bool dontRemoveFiles)
-{
-    AI_LOG_FN_ENTRY();
-
-    // before blindly doing a recursive delete of the directory make sure that
-    // nothing is mounted there.  This is to fix any bugs / sloppy plugins
-    // that do things like bind mounts inside the rootfs and then don't clean
-    // up after themselves
-    if (!mPath.empty())
-    {
-        unmountAllAt(mPath);
-    }
-
-    // if we want to leave the rootfs in place then skip the rest - this is a
-    // debugging feature used to help with diagnosing container issues
-    if (dontRemoveFiles)
-    {
-        AI_LOG_INFO("leaving rootfs in place @ '%s'", mPath.c_str());
-        mPath.clear();
-        return;
-    }
-
-    // can now remove the entire contents of the rootfs dir
-    if (mDirFd >= 0)
-    {
-        if (!mUtilities->rmdirContents(mDirFd))
-        {
-            AI_LOG_ERROR("failed to delete contents of rootfs dir");
-
-            // TODO: if something has gone wrong somewhere then it may not be
-            // possible to delete the rootfs dir as it could contain mount
-            // points ... one solution to this is to iterate through current
-            // mounts and umount anything in the rootfs and then try deleting
-            // again
-        }
-
-        if (close(mDirFd) != 0)
-        {
-            AI_LOG_SYS_ERROR(errno, "failed to close rootfs dir");
-        }
-
-        mDirFd = -1;
-    }
-
-    // the rootfs directory should now be empty, so can now delete it
-    if (!mPath.empty() && (rmdir(mPath.c_str()) != 0))
-    {
-        AI_LOG_SYS_ERROR(errno, "failed to delete rootfs dir");
-    }
-
-    mPath.clear();
-
-    AI_LOG_FN_EXIT();
 }
 
 // -----------------------------------------------------------------------------
@@ -311,6 +248,74 @@ void DobbyRootfs::unmountAllAt(const std::string& pathPrefix)
     }
 
     fclose(fp);
+
+    AI_LOG_FN_EXIT();
+}
+
+#if defined(LEGACY_COMPONENTS)
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Removes the rootfs directory and all it's contents.
+ *
+ *
+ *  @param[in]  dontRemoveFiles In true then the files and directory(s) are
+ *                              left in place.  This may be useful for
+ *                              re-creating containers for debugging runc issues
+ *                              or for retaining bundles when started from a bundle
+ *                              instead of a Dobby spec.
+ *
+ */
+void DobbyRootfs::cleanUp(bool dontRemoveFiles)
+{
+    AI_LOG_FN_ENTRY();
+
+    // before blindly doing a recursive delete of the directory make sure that
+    // nothing is mounted there.  This is to fix any bugs / sloppy plugins
+    // that do things like bind mounts inside the rootfs and then don't clean
+    // up after themselves
+    if (!mPath.empty())
+    {
+        unmountAllAt(mPath);
+    }
+
+    // if we want to leave the rootfs in place then skip the rest - this is a
+    // debugging feature used to help with diagnosing container issues
+    if (dontRemoveFiles)
+    {
+        AI_LOG_INFO("leaving rootfs in place @ '%s'", mPath.c_str());
+        mPath.clear();
+        return;
+    }
+
+    // can now remove the entire contents of the rootfs dir
+    if (mDirFd >= 0)
+    {
+        if (!mUtilities->rmdirContents(mDirFd))
+        {
+            AI_LOG_ERROR("failed to delete contents of rootfs dir");
+
+            // TODO: if something has gone wrong somewhere then it may not be
+            // possible to delete the rootfs dir as it could contain mount
+            // points ... one solution to this is to iterate through current
+            // mounts and umount anything in the rootfs and then try deleting
+            // again
+        }
+
+        if (close(mDirFd) != 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to close rootfs dir");
+        }
+
+        mDirFd = -1;
+    }
+
+    // the rootfs directory should now be empty, so can now delete it
+    if (!mPath.empty() && (rmdir(mPath.c_str()) != 0))
+    {
+        AI_LOG_SYS_ERROR(errno, "failed to delete rootfs dir");
+    }
+
+    mPath.clear();
 
     AI_LOG_FN_EXIT();
 }

--- a/rdkPlugins/Storage/source/LoopMountDetails.cpp
+++ b/rdkPlugins/Storage/source/LoopMountDetails.cpp
@@ -307,6 +307,15 @@ bool LoopMountDetails::removeNonPersistentImage()
 
     bool success = true;
 
+    // There could be situation where container was created but not started, as
+    // the cleanup is done after container start it would mean that we could
+    // left temp directories mounted. As postStop is done always we need to
+    // check if we have already cleaned up, and if not then clean temp.
+    if (access(mTempMountPointOutsideContainer.c_str(), F_OK) != -1)
+    {
+        success = cleanupTempDirectory();
+    }
+
     if (!mMount.persistent)
     {
         if (unlink(mMount.fsImagePath.c_str()))


### PR DESCRIPTION
### Description
There was an issue where container was created and not run, it was resulting in temp mount being left because cleaning up was done in post start hook, which wasn't run as container wasn't start.
Fixed by checking if cleaning was done on post stop hook which should be run all the times.

This ticket is fix for problem found while doing RDK-30291.

### Test Procedure
Create container with storage plugin on, but without "post start" hook. It shouldn't left mount to `directory.temp`.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [x] No