### PR TITLE
Initialize apt before installing packages during Vagrant VM setup.

### DIFF
--- a/develop/vagrant/Vagrantfile
+++ b/develop/vagrant/Vagrantfile
@@ -68,7 +68,13 @@ Vagrant.configure("2") do |config|
         ssh-keyscan -Ht rsa github.com >> ~/.ssh/known_hosts
     SHELL
 
+    ##################################################
+    #
+    # Prepare to install dependencies
+    #
     config.vm.provision "shell", inline: <<-SHELL
+        sudo add-apt-repository ppa:deadsnakes/ppa
+        apt update && apt upgrade
         apt install figlet
     SHELL
 
@@ -79,8 +85,6 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: <<-SHELL
         figlet DEPENDENCIES  # ASCII banner
 
-        sudo add-apt-repository ppa:deadsnakes/ppa
-        apt update && apt upgrade
         apt install -y build-essential libctemplate-dev libjsoncpp-dev libjsoncpp1 libjsoncpp-doc libdbus-1-dev libdbus-cpp-dev dbus libdbus-c++-dev libnl-3-dev libnl-route-3-dev libsystemd-dev libcap-dev runc bison flex zlib1g-dev autoconf python-pip python3.7  pkgconf libtool seccomp libseccomp-dev libyajl2 libyajl-dev go-md2man python3-pip gdb libcurl4-openssl-dev libssl-dev libgpgme11-dev
         alias python=python3.7
         pip3 install jsonref


### PR DESCRIPTION
### Description
During the Vagrant VM setup, the figlet package `apt install` was executed before the `apt update`. `Apt` couldn't find the package and the VM setup aborted.
`apt update` is now executed before the figlet `apt install`.

### Test Procedure
Try to set up a new Vagrant VM (`vagrant up`).

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)