### PR TITLE
Fix DobbyTool missing in debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,7 @@ else()
     set( ENABLE_DOBBYTOOL_DEFAULT OFF )
 endif()
 
-option(ENABLE_DOBBYTOOL "Include DobbyTool" ENABLE_DOBBYTOOL_DEFAULT)
+option(ENABLE_DOBBYTOOL "Include DobbyTool" ${ENABLE_DOBBYTOOL_DEFAULT})
 if(ENABLE_DOBBYTOOL)
     add_subdirectory( client/tool )
 endif()


### PR DESCRIPTION
### Description
Fix DobbyTool not being build by default in Debug builds

### Test Procedure
Build Debug build - DobbyTool should be built.
Build Release build - DobbyTool should not be built.

Setting `-DENABLE_DOBBYTOOL` should always override the default.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)