### PR TITLE
Allow setting environment variable(s) when starting container

### DIFF
--- a/AppInfrastructure/Public/Dobby/IDobbyProxy.h
+++ b/AppInfrastructure/Public/Dobby/IDobbyProxy.h
@@ -123,14 +123,16 @@ public:
                                            const std::string& jsonSpec,
                                            const std::list<int>& files,
                                            const std::string& command = "",
-                                           const std::string& displaySocket = "") const = 0;
+                                           const std::string& displaySocket = "",
+                                           const std::vector<std::string>& envVars = std::vector<std::string>()) const = 0;
 
 
     virtual int32_t startContainerFromBundle(const std::string& id,
                                              const std::string& bundlePath,
                                              const std::list<int>& files,
                                              const std::string& command = "",
-                                             const std::string& displaySocket = "") const = 0;
+                                             const std::string& displaySocket = "",
+                                             const std::vector<std::string>& envVars = std::vector<std::string>()) const = 0;
 
     virtual bool stopContainer(int32_t descriptor,
                                bool withPrejudice) const = 0;

--- a/bundle/lib/include/DobbyConfig.h
+++ b/bundle/lib/include/DobbyConfig.h
@@ -124,6 +124,8 @@ public:
                   unsigned long mountFlags,
                   const std::list<std::string>& mountOptions);
     bool addEnvironmentVar(const std::string& envVar);
+    bool changeProcessArgs(const std::string& command);
+    bool addWesterosMount(const std::string& socketPath);
     bool writeConfigJson(const std::string& filePath) const;
 
     const std::string configJson() const;

--- a/client/lib/include/DobbyProxy.h
+++ b/client/lib/include/DobbyProxy.h
@@ -82,14 +82,16 @@ public:
                                    const std::string& jsonSpec,
                                    const std::list<int>& files,
                                    const std::string& command = "",
-                                   const std::string& displaySocket = "") const override;
+                                   const std::string& displaySocket = "",
+                                   const std::vector<std::string>& envVars = std::vector<std::string>()) const override;
 
 
     int32_t startContainerFromBundle(const std::string& id,
                                      const std::string& bundlePath,
                                      const std::list<int>& files,
                                      const std::string& command = "",
-                                     const std::string& displaySocket = "") const override;
+                                     const std::string& displaySocket = "",
+                                     const std::vector<std::string>& envVars = std::vector<std::string>()) const override;
 
     bool stopContainer(int32_t cd, bool withPrejudice) const override;
 

--- a/client/lib/source/DobbyProxy.cpp
+++ b/client/lib/source/DobbyProxy.cpp
@@ -546,7 +546,8 @@ int32_t DobbyProxy::startContainerFromSpec(const std::string& id,
                                            const std::string& jsonSpec,
                                            const std::list<int>& files /*= std::list<int>()*/,
                                            const std::string& command /*= ""*/,
-                                           const std::string& displaySocket /*= ""*/) const
+                                           const std::string& displaySocket /*= ""*/,
+                                           const std::vector<std::string>& envVars /*= std::vector<std::string>()*/) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -558,7 +559,7 @@ int32_t DobbyProxy::startContainerFromSpec(const std::string& id,
     }
 
     // send off the request
-    const AI_IPC::VariantList params = { id, jsonSpec, fds, command, displaySocket };
+    const AI_IPC::VariantList params = { id, jsonSpec, fds, command, displaySocket, envVars };
     AI_IPC::VariantList returns;
 
     int32_t result = -1;
@@ -601,7 +602,8 @@ int32_t DobbyProxy::startContainerFromBundle(const std::string& id,
                                              const std::string& bundlePath,
                                              const std::list<int>& files,
                                              const std::string& command /*= ""*/,
-                                             const std::string& displaySocket /*= ""*/) const
+                                             const std::string& displaySocket /*= ""*/,
+                                             const std::vector<std::string>& envVars /*= std::vector<std::string>()*/) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -613,7 +615,7 @@ int32_t DobbyProxy::startContainerFromBundle(const std::string& id,
     }
 
     // send off the request
-    const AI_IPC::VariantList params = { id, bundlePath, fds, command, displaySocket };
+    const AI_IPC::VariantList params = { id, bundlePath, fds, command, displaySocket, envVars };
     AI_IPC::VariantList returns;
 
     int32_t result = -1;

--- a/client/tool/source/Main.cpp
+++ b/client/tool/source/Main.cpp
@@ -208,6 +208,7 @@ static void startCommand(const std::shared_ptr<IDobbyProxy> &dobbyProxy,
     int i = 0;
     std::list<int> files;
     std::string displaySocketPath;
+    std::vector<std::string> envVars;
 
     // Command will be in the form "start --<option1> --<optionN> <id> <specfile> <commands>"
     while (i < args.size() && args[i].c_str()[0] == '-')
@@ -225,6 +226,15 @@ static void startCommand(const std::shared_ptr<IDobbyProxy> &dobbyProxy,
                 return;
             }
             displaySocketPath = westerosPath;
+        }
+        else if (args[i] == "--envvar")
+        {
+            // TODO:: This won't work if the arg is in the form --envvar=foo:bar
+            // The next arg should be the envvar
+            i++;
+
+            std::string var = args[i];
+            envVars.emplace_back(var);
         }
         else
         {
@@ -314,7 +324,7 @@ static void startCommand(const std::shared_ptr<IDobbyProxy> &dobbyProxy,
             return;
         }
 
-        cd = dobbyProxy->startContainerFromBundle(id, path, files, command, displaySocketPath);
+        cd = dobbyProxy->startContainerFromBundle(id, path, files, command, displaySocketPath, envVars);
     }
     else
     {
@@ -870,7 +880,8 @@ static void initCommands(const std::shared_ptr<IReadLine>& readLine,
                          "Starts a container using the given path. Can optionally specify the command "
                          "to run inside the container. Any arguments after command are treated as "
                          "arguments to the command.\n",
-                         "  --westeros-socket    Mount the specified westeros socket into the container\n");
+                         "  --westeros-socket    Mount the specified westeros socket into the container\n"
+                         "  --envvar             Add an environment variable for this container\n");
 
     readLine->addCommand("stop",
                          std::bind(stopCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -925,17 +925,18 @@ void Dobby::startFromSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
 {
     AI_LOG_FN_ENTRY();
 
-    // Expecting 3/5 args:
+    // Expecting 3/6 args:
     // (string id, string jsonSpec, vector<unixfd> files)
-    // (string id, string jsonSpec, vector<unixfd> files, string command, string displaySocket)
+    // (string id, string jsonSpec, vector<unixfd> files, string command, string displaySocket, vector<string> envVars)
     std::string id;
     std::string jsonSpec;
     std::vector<AI_IPC::UnixFd> files;
     std::string command;
     std::string displaySocket;
+    std::vector<std::string> envVars;
 
     // The command argument might not be sent at all (e.g. from AI) so we should
-    // be able to withstand receiving 3 or 4 arguments
+    // be able to withstand receiving 3 or 6 arguments
     bool parseArgsSuccess = false;
     if (replySender->getMethodCallArguments().size() == 3)
     {
@@ -944,14 +945,15 @@ void Dobby::startFromSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
                                                     std::vector<AI_IPC::UnixFd>>(
             replySender->getMethodCallArguments(), &id, &jsonSpec, &files);
     }
-    else if (replySender->getMethodCallArguments().size() == 5)
+    else if (replySender->getMethodCallArguments().size() == 6)
     {
         parseArgsSuccess = AI_IPC::parseVariantList<std::string,
                                                     std::string,
                                                     std::vector<AI_IPC::UnixFd>,
                                                     std::string,
-                                                    std::string>(
-            replySender->getMethodCallArguments(), &id, &jsonSpec, &files, &command, &displaySocket);
+                                                    std::string,
+                                                    std::vector<std::string>>(
+            replySender->getMethodCallArguments(), &id, &jsonSpec, &files, &command, &displaySocket, &envVars);
     }
 
     if (!parseArgsSuccess)
@@ -977,6 +979,7 @@ void Dobby::startFromSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
                  files = std::move(files),
                  command = std::move(command),
                  displaySocket = std::move(displaySocket),
+                 envVars = std::move(envVars),
                  replySender]()
                 {
                     // Convert the vector of AI_IPC::UnixFd to a list of plain
@@ -986,7 +989,7 @@ void Dobby::startFromSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
                         fileList.push_back(file.fd());
 
                     // try and start the container
-                    int32_t descriptor = manager->startContainerFromSpec(id, spec, fileList, command, displaySocket);
+                    int32_t descriptor = manager->startContainerFromSpec(id, spec, fileList, command, displaySocket, envVars);
 
                     // Fire off the reply
                     AI_IPC::VariantList results = { descriptor };
@@ -1028,14 +1031,15 @@ void Dobby::startFromBundle(std::shared_ptr<AI_IPC::IAsyncReplySender> replySend
 {
     AI_LOG_FN_ENTRY();
 
-    // Expecting 3/5 args:
+    // Expecting 3/6 args:
     // (string id, string bundlePath, vector<unixfd> files)
-    // (string id, string bundlePath, vector<unixfd> files, string command, string displaySocket)
+    // (string id, string bundlePath, vector<unixfd> files, string command, string displaySocket, vector<string> envVars)
     std::string id;
     std::string bundlePath;
     std::vector<AI_IPC::UnixFd> files;
     std::string command;
     std::string displaySocket;
+    std::vector<std::string> envVars;
 
     bool parseArgsSuccess = false;
 
@@ -1046,14 +1050,15 @@ void Dobby::startFromBundle(std::shared_ptr<AI_IPC::IAsyncReplySender> replySend
                                                     std::vector<AI_IPC::UnixFd>>(
             replySender->getMethodCallArguments(), &id, &bundlePath, &files);
     }
-    else if (replySender->getMethodCallArguments().size() == 5)
+    else if (replySender->getMethodCallArguments().size() == 6)
     {
         parseArgsSuccess = AI_IPC::parseVariantList<std::string,
                                                     std::string,
                                                     std::vector<AI_IPC::UnixFd>,
                                                     std::string,
-                                                    std::string>(
-            replySender->getMethodCallArguments(), &id, &bundlePath, &files, &command, &displaySocket);
+                                                    std::string,
+                                                    std::vector<std::string>>(
+            replySender->getMethodCallArguments(), &id, &bundlePath, &files, &command, &displaySocket, &envVars);
     }
 
     if (!parseArgsSuccess)
@@ -1079,6 +1084,7 @@ void Dobby::startFromBundle(std::shared_ptr<AI_IPC::IAsyncReplySender> replySend
                  files = std::move(files),
                  command = std::move(command),
                  displaySocket = std::move(displaySocket),
+                 envVars = std::move(envVars),
                  replySender]()
                 {
                     // Convert the vector of AI_IPC::UnixFd to a list of plain
@@ -1088,7 +1094,7 @@ void Dobby::startFromBundle(std::shared_ptr<AI_IPC::IAsyncReplySender> replySend
                         fileList.push_back(file.fd());
 
                     // try and start the container
-                    int32_t descriptor = manager->startContainerFromBundle(id, path, fileList, command, displaySocket);
+                    int32_t descriptor = manager->startContainerFromBundle(id, path, fileList, command, displaySocket, envVars);
 
                     // Fire off the reply
                     AI_IPC::VariantList results = { descriptor };

--- a/daemon/lib/source/DobbyManager.h
+++ b/daemon/lib/source/DobbyManager.h
@@ -101,14 +101,16 @@ public:
                                    const std::string& jsonSpec,
                                    const std::list<int>& files,
                                    const std::string& command,
-                                   const std::string& displaySocket);
+                                   const std::string& displaySocket,
+                                   const std::vector<std::string>& envVars);
 #endif //defined(LEGACY_COMPONENTS)
 
     int32_t startContainerFromBundle(const ContainerId& id,
                                      const std::string& bundlePath,
                                      const std::list<int>& files,
                                      const std::string& command,
-                                     const std::string& displaySocket);
+                                     const std::string& displaySocket,
+                                     const std::vector<std::string>& envVars);
 
     bool stopContainer(int32_t cd, bool withPrejudice);
 
@@ -151,14 +153,17 @@ private:
                         const std::list<int> &files);
 
     std::string createCustomConfig(const std::unique_ptr<DobbyContainer> &container,
+                                   const std::shared_ptr<DobbyConfig> &config,
                                    const std::string &command,
-                                   const std::string &displaySocket);
+                                   const std::string &displaySocket,
+                                   const std::vector<std::string> &envVars);
 
     bool createAndStartContainer(const ContainerId& id,
                                  const std::unique_ptr<DobbyContainer>& container,
                                  const std::list<int>& files,
                                  const std::string& command = "",
-                                 const std::string& displaySocket = "");
+                                 const std::string& displaySocket = "",
+                                 const std::vector<std::string>& envVars = std::vector<std::string>());
 
     bool restartContainer(const ContainerId& id,
                           const std::unique_ptr<DobbyContainer>& container);


### PR DESCRIPTION
### Description
Allow the user to add additional environment variables dynamically when starting a container.

Change is necessary to allow setting `PX_WAYLAND_CLIENT_REMOTE_OBJECT_NAME` when starting a container for rdkbrowser2

### Test Procedure
`DobbyTool start` command has new `--envvar` argument that can add environment variables. Argument can be repeated to add multiple environment variables. Example:

```
DobbyTool start --envvar "FOO=bar" --envvar "BAR=thing" sleep ./sleepybundle/ env
```

Can also be tested with OCIContainer Thunder Plugin with https://github.com/rdkcentral/rdkservices/pull/801

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)