### PR TITLE
RDK-31481: Destroy correct veth at container exit

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -703,9 +703,9 @@ int32_t DobbyManager::startContainerFromSpec(const ContainerId &id,
         const std::string rootfsPath = rootfs->path();
 
         std::shared_ptr<rt_dobby_schema> containerConfig(config->config());
-        std::shared_ptr<DobbyRdkPluginUtils> rdkPluginUtils = std::make_shared<DobbyRdkPluginUtils>();
+        std::shared_ptr<DobbyRdkPluginUtils> rdkPluginUtils = std::make_shared<DobbyRdkPluginUtils>(config->config());
         std::shared_ptr<DobbyRdkPluginManager> rdkPluginManager =
-            std::make_shared<DobbyRdkPluginManager>(containerConfig, rootfsPath, "", PLUGIN_PATH, rdkPluginUtils);
+            std::make_shared<DobbyRdkPluginManager>(containerConfig, rootfsPath, PLUGIN_PATH, rdkPluginUtils);
 
         std::vector<std::string> loadedPlugins = rdkPluginManager->listLoadedPlugins();
         AI_LOG_DEBUG("Loaded %zd RDK plugins\n", loadedPlugins.size());
@@ -867,9 +867,9 @@ int32_t DobbyManager::startContainerFromBundle(const ContainerId &id,
         const std::string rootfsPath = rootfs->path();
 
         std::shared_ptr<rt_dobby_schema> containerConfig(config->config());
-        std::shared_ptr<DobbyRdkPluginUtils> rdkPluginUtils = std::make_shared<DobbyRdkPluginUtils>();
+        std::shared_ptr<DobbyRdkPluginUtils> rdkPluginUtils = std::make_shared<DobbyRdkPluginUtils>(config->config());
         std::shared_ptr<DobbyRdkPluginManager> rdkPluginManager =
-            std::make_shared<DobbyRdkPluginManager>(containerConfig, rootfsPath, "", PLUGIN_PATH, rdkPluginUtils);
+            std::make_shared<DobbyRdkPluginManager>(containerConfig, rootfsPath, PLUGIN_PATH, rdkPluginUtils);
 
         std::vector<std::string> loadedPlugins = rdkPluginManager->listLoadedPlugins();
         AI_LOG_DEBUG("Loaded %zd RDK plugins\n", loadedPlugins.size());

--- a/pluginLauncher/lib/include/DobbyRdkPluginManager.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginManager.h
@@ -76,7 +76,6 @@ private:
     const std::string mPluginPath;
     const std::string mRootfsPath;
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
-
     std::shared_ptr<rt_dobby_schema> mContainerConfig;
 };
 

--- a/pluginLauncher/lib/include/DobbyRdkPluginManager.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginManager.h
@@ -47,7 +47,6 @@ class DobbyRdkPluginManager
 public:
     DobbyRdkPluginManager(std::shared_ptr<rt_dobby_schema> containerConfig,
                           const std::string &rootfsPath,
-                          const std::string &hookStdin,
                           const std::string &pluginPath,
                           const std::shared_ptr<DobbyRdkPluginUtils> &utils);
     ~DobbyRdkPluginManager();
@@ -76,8 +75,8 @@ private:
     std::map<std::string, std::pair<void *, std::shared_ptr<IDobbyRdkPlugin>>> mPlugins;
     const std::string mPluginPath;
     const std::string mRootfsPath;
-    const std::string mHookStdin;
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
+
     std::shared_ptr<rt_dobby_schema> mContainerConfig;
 };
 

--- a/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
@@ -24,6 +24,7 @@
 #define DOBBYRDKPLUGINUTILS_H
 
 #include "rt_dobby_schema.h"
+#include "rt_state_schema.h"
 
 #include <sys/types.h>
 #include <string>
@@ -43,7 +44,9 @@
 class DobbyRdkPluginUtils
 {
 public:
-    DobbyRdkPluginUtils();
+    DobbyRdkPluginUtils(const std::shared_ptr<rt_dobby_schema> &cfg);
+    DobbyRdkPluginUtils(const std::shared_ptr<rt_dobby_schema> &cfg,
+                        const std::shared_ptr<const rt_state_schema> &state);
     ~DobbyRdkPluginUtils();
 
     // -------------------------------------------------------------------------
@@ -84,7 +87,9 @@ public:
     void nsThread(int newNsFd, int nsType, bool* success,
                   std::function<bool()>& func) const;
 
-    pid_t getContainerPid(const std::string &stdin) const;
+    pid_t getContainerPid() const;
+
+    std::string getContainerId() const;
 
     bool writeTextFile(const std::string &path,
                        const std::string &str,
@@ -93,18 +98,20 @@ public:
 
     std::string readTextFile(const std::string &path) const;
 
-    bool addMount(const std::shared_ptr<rt_dobby_schema> &cfg,
-                  const std::string &source,
+    bool addMount(const std::string &source,
                   const std::string &target,
                   const std::string &fsType,
                   const std::list<std::string> &mountOptions) const;
 
     static bool mkdirRecursive(const std::string& path, mode_t mode);
 
-    bool addEnvironmentVar(const std::shared_ptr<rt_dobby_schema> &cfg,
-                           const std::string& envVar) const;
+    bool addEnvironmentVar(const std::string& envVar) const;
 
     mutable std::mutex mLock;
+
+private:
+    std::shared_ptr<rt_dobby_schema> mConf;
+    std::shared_ptr<const rt_state_schema> mState;
 };
 
 #endif // !defined(DOBBYRDKPLUGINUTILS_H)

--- a/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
@@ -34,6 +34,14 @@
 #include <list>
 #include <mutex>
 
+#define ADDRESS_FILE_PREFIX       "/tmp/dobbyAddress_"
+
+typedef struct ContainerNetworkInfo
+{
+    std::string vethName;
+    std::string ipAddress;
+} ContainerNetworkInfo;
+
 // -----------------------------------------------------------------------------
 /**
  *  @class DobbyRdkPluginUtils
@@ -87,9 +95,10 @@ public:
     void nsThread(int newNsFd, int nsType, bool* success,
                   std::function<bool()>& func) const;
 
-    pid_t getContainerPid() const;
 
+    pid_t getContainerPid() const;
     std::string getContainerId() const;
+    bool getContainerNetworkInfo(ContainerNetworkInfo &networkInfo);
 
     bool writeTextFile(const std::string &path,
                        const std::string &str,
@@ -107,6 +116,7 @@ public:
 
     bool addEnvironmentVar(const std::string& envVar) const;
 
+private:
     mutable std::mutex mLock;
 
 private:

--- a/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
@@ -34,6 +34,8 @@
 #include <list>
 #include <mutex>
 
+// TODO:: This would be better stored in the dobby workspace dir rather than /tmp,
+// but we don't programatically know the workspace dir in this code.
 #define ADDRESS_FILE_PREFIX       "/tmp/dobbyAddress_"
 
 typedef struct ContainerNetworkInfo

--- a/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
@@ -119,7 +119,6 @@ public:
 private:
     mutable std::mutex mLock;
 
-private:
     std::shared_ptr<rt_dobby_schema> mConf;
     std::shared_ptr<const rt_state_schema> mState;
 };

--- a/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
+++ b/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
@@ -78,10 +78,10 @@ public:
  *
  */
 #define REGISTER_RDK_LOGGER(_class)                                                                                                                                                                                                        \
-    extern "C" PUBLIC_FN IDobbyRdkLoggingPlugin *createIDobbyRdkLogger(std::shared_ptr<rt_dobby_schema> &containerConfig, const std::shared_ptr<DobbyRdkPluginUtils> &utils, const std::string &rootfsPath, const std::string &hookStdin); \
-    extern "C" PUBLIC_FN IDobbyRdkLoggingPlugin *createIDobbyRdkLogger(std::shared_ptr<rt_dobby_schema> &containerConfig, const std::shared_ptr<DobbyRdkPluginUtils> &utils, const std::string &rootfsPath, const std::string &hookStdin)  \
+    extern "C" PUBLIC_FN IDobbyRdkLoggingPlugin *createIDobbyRdkLogger(std::shared_ptr<rt_dobby_schema> &containerConfig, const std::shared_ptr<DobbyRdkPluginUtils> &utils, const std::string &rootfsPath); \
+    extern "C" PUBLIC_FN IDobbyRdkLoggingPlugin *createIDobbyRdkLogger(std::shared_ptr<rt_dobby_schema> &containerConfig, const std::shared_ptr<DobbyRdkPluginUtils> &utils, const std::string &rootfsPath)  \
     {                                                                                                                                                                                                                                      \
-        return new _class(containerConfig, utils, rootfsPath, hookStdin);                                                                                                                                                                  \
+        return new _class(containerConfig, utils, rootfsPath);                                                                                                                                                                  \
     }                                                                                                                                                                                                                                      \
     extern "C" PUBLIC_FN void destroyIDobbyRdkLogger(_class const *_plugin);                                                                                                                                                               \
     extern "C" PUBLIC_FN void destroyIDobbyRdkLogger(_class const *_plugin)                                                                                                                                                                \

--- a/pluginLauncher/lib/include/IDobbyRdkPlugin.h
+++ b/pluginLauncher/lib/include/IDobbyRdkPlugin.h
@@ -146,10 +146,10 @@ public:
  *
  */
 #define REGISTER_RDK_PLUGIN(_class)                                                                                                                                                                                                    \
-    extern "C" PUBLIC_FN IDobbyRdkPlugin *createIDobbyRdkPlugin(std::shared_ptr<rt_dobby_schema>& containerConfig, const std::shared_ptr<DobbyRdkPluginUtils> &utils, const std::string& rootfsPath, const std::string &hookStdin);    \
-    extern "C" PUBLIC_FN IDobbyRdkPlugin *createIDobbyRdkPlugin(std::shared_ptr<rt_dobby_schema>& containerConfig, const std::shared_ptr<DobbyRdkPluginUtils> &utils, const std::string& rootfsPath, const std::string &hookStdin)     \
+    extern "C" PUBLIC_FN IDobbyRdkPlugin *createIDobbyRdkPlugin(std::shared_ptr<rt_dobby_schema>& containerConfig, const std::shared_ptr<DobbyRdkPluginUtils> &utils, const std::string& rootfsPath);    \
+    extern "C" PUBLIC_FN IDobbyRdkPlugin *createIDobbyRdkPlugin(std::shared_ptr<rt_dobby_schema>& containerConfig, const std::shared_ptr<DobbyRdkPluginUtils> &utils, const std::string& rootfsPath)     \
 {                                                                                                                                                                                                                                      \
-        return new _class(containerConfig, utils, rootfsPath, hookStdin);                                                                                                                                                              \
+        return new _class(containerConfig, utils, rootfsPath);                                                                                                                                                              \
     }                                                                                                                                                                                                                                  \
     extern "C" PUBLIC_FN void destroyIDobbyRdkPlugin(_class const *_plugin);                                                                                                                                                           \
     extern "C" PUBLIC_FN void destroyIDobbyRdkPlugin(_class const *_plugin)                                                                                                                                                            \

--- a/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
@@ -48,12 +48,10 @@
  */
 DobbyRdkPluginManager::DobbyRdkPluginManager(std::shared_ptr<rt_dobby_schema> containerConfig,
                                              const std::string &rootfsPath,
-                                             const std::string &hookStdin,
                                              const std::string &pluginPath,
                                              const std::shared_ptr<DobbyRdkPluginUtils> &utils)
     : mContainerConfig(containerConfig),
       mRootfsPath(rootfsPath),
-      mHookStdin(hookStdin),
       mPluginPath(pluginPath),
       mUtils(utils)
 {
@@ -199,14 +197,13 @@ void DobbyRdkPluginManager::loadPlugins()
             // execute the register function ... fingers crossed
             typedef IDobbyRdkPlugin *(*CreatePluginFunction)(std::shared_ptr<rt_dobby_schema>& containerConfig,
                                                             const std::shared_ptr<DobbyRdkPluginUtils> &util,
-                                                            const std::string &rootfsPath,
-                                                            const std::string &hookStdin);
+                                                            const std::string &rootfsPath);
             typedef void (*DestroyPluginFunction)(IDobbyRdkPlugin *);
 
             CreatePluginFunction createFunc = reinterpret_cast<CreatePluginFunction>(libCreateFn);
             DestroyPluginFunction destroyFunc = reinterpret_cast<DestroyPluginFunction>(libDestroyFn);
 
-            std::shared_ptr<IDobbyRdkPlugin> loadedPlugin(createFunc(mContainerConfig, mUtils, mRootfsPath, mHookStdin),
+            std::shared_ptr<IDobbyRdkPlugin> loadedPlugin(createFunc(mContainerConfig, mUtils, mRootfsPath),
                                                     destroyFunc);
 
             plugin = std::move(loadedPlugin);
@@ -216,17 +213,16 @@ void DobbyRdkPluginManager::loadPlugins()
             // execute the register function ... fingers crossed
             typedef IDobbyRdkLoggingPlugin *(*CreateLoggerFunction)(std::shared_ptr<rt_dobby_schema>& containerConfig,
                                                             const std::shared_ptr<DobbyRdkPluginUtils> &util,
-                                                            const std::string &rootfsPath,
-                                                            const std::string &hookStdin);
+                                                            const std::string &rootfsPath);
             typedef void (*DestroyLoggerFunction)(IDobbyRdkLoggingPlugin *);
 
             CreateLoggerFunction createFunc = reinterpret_cast<CreateLoggerFunction>(libCreateLoggerFn);
             DestroyLoggerFunction destroyFunc = reinterpret_cast<DestroyLoggerFunction>(libDestroyLoggerFn);
 
-            std::shared_ptr<IDobbyRdkPlugin> loadedPlugin(createFunc(mContainerConfig, mUtils, mRootfsPath, mHookStdin),
+            std::shared_ptr<IDobbyRdkPlugin> loadedPlugin(createFunc(mContainerConfig, mUtils, mRootfsPath),
                                                     destroyFunc);
 
-            std::shared_ptr<IDobbyRdkLoggingPlugin> loadedLogger(createFunc(mContainerConfig, mUtils, mRootfsPath, mHookStdin),
+            std::shared_ptr<IDobbyRdkLoggingPlugin> loadedLogger(createFunc(mContainerConfig, mUtils, mRootfsPath),
                                                      destroyFunc);
 
             logger = std::move(loadedLogger);
@@ -374,7 +370,7 @@ std::shared_ptr<IDobbyRdkLoggingPlugin> DobbyRdkPluginManager::getContainerLogge
 
     if (!containerLogger)
     {
-        AI_LOG_WARN("No suitable logging plugin found for container '%s'", mContainerConfig->hostname);
+        AI_LOG_WARN("No suitable logging plugin found for container '%s'", mUtils->getContainerId().c_str());
     }
     return containerLogger;
 }

--- a/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
@@ -112,15 +112,16 @@ std::string DobbyRdkPluginUtils::getContainerId() const
 
 // -------------------------------------------------------------------------
 /**
- *  @brief Gets the container ID
+ *  @brief Gets network info about the container (veth/IP)
  *
- *  Since Dobby sets the container hostname to match the container ID, we can
- *  use the hostname. Ideally we'd use the state from stdin, but that's only
- *  available during OCI hooks.
+ * Designed to allow other plugins to create their own iptables rules once the
+ * networking plugin has run.
  *
- *  @return Container ID as string
+ * @params[out] networkInfo     struct containing veth/ip address
+ *
+ * @returns true if successfully got info, false for failure
  */
-bool DobbyRdkPluginUtils::getContainerNetworkInfo(ContainerNetworkInfo& networkInfo)
+bool DobbyRdkPluginUtils::getContainerNetworkInfo(ContainerNetworkInfo &networkInfo)
 {
     // Attempt to find the file
     const std::string containerId = getContainerId();
@@ -144,7 +145,8 @@ bool DobbyRdkPluginUtils::getContainerNetworkInfo(ContainerNetworkInfo& networkI
     if (addressFileStr.empty())
     {
         AI_LOG_ERROR_EXIT("failed to get IP address and veth name assigned to"
-                     "container from %s", fileName.c_str());
+                          "container from %s",
+                          fileName.c_str());
         return false;
     }
 

--- a/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
@@ -46,7 +46,8 @@ DobbyRdkPluginUtils::DobbyRdkPluginUtils(const std::shared_ptr<rt_dobby_schema> 
 
 DobbyRdkPluginUtils::DobbyRdkPluginUtils(const std::shared_ptr<rt_dobby_schema> &cfg,
                                          const std::shared_ptr<const rt_state_schema> &state)
-    : mConf(cfg), mState(state)
+    : mConf(cfg)
+    , mState(state)
 {
     AI_LOG_FN_ENTRY();
 
@@ -180,8 +181,8 @@ bool DobbyRdkPluginUtils::getContainerNetworkInfo(ContainerNetworkInfo &networkI
  *                          was the success.
  *  @param[in]  func        The function to execute in the new namespace.
  */
-void DobbyRdkPluginUtils::nsThread(int newNsFd, int nsType, bool *success,
-                                   std::function<bool()> &func) const
+void DobbyRdkPluginUtils::nsThread(int newNsFd, int nsType, bool* success,
+                                   std::function<bool()>& func) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -232,7 +233,7 @@ void DobbyRdkPluginUtils::nsThread(int newNsFd, int nsType, bool *success,
  *  @return true if successifully entered the namespace, otherwise false.
  */
 bool DobbyRdkPluginUtils::callInNamespaceImpl(pid_t pid, int nsType,
-                                              const std::function<bool()> &func) const
+                                     const std::function<bool()>& func) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -242,18 +243,18 @@ bool DobbyRdkPluginUtils::callInNamespaceImpl(pid_t pid, int nsType,
     // determine the type of namespace to enter
     switch (nsType)
     {
-    case CLONE_NEWIPC:
-        strcpy(nsName, "ipc");
-        break;
-    case CLONE_NEWNET:
-        strcpy(nsName, "net");
-        break;
-    case CLONE_NEWNS:
-        strcpy(nsName, "mnt");
-        break;
-    // the following namespaces are tricky and have special restrictions,
-    // at the moment no hook should be using them so disable until needed
-    /*
+        case CLONE_NEWIPC:
+            strcpy(nsName, "ipc");
+            break;
+        case CLONE_NEWNET:
+            strcpy(nsName, "net");
+            break;
+        case CLONE_NEWNS:
+            strcpy(nsName, "mnt");
+            break;
+        // the following namespaces are tricky and have special restrictions,
+        // at the moment no hook should be using them so disable until needed
+        /*
         case CLONE_NEWPID:
             strcpy(nsName, "pid");
             break;
@@ -264,14 +265,14 @@ bool DobbyRdkPluginUtils::callInNamespaceImpl(pid_t pid, int nsType,
             strcpy(nsName, "uts");
             break;
         */
-    case CLONE_NEWPID:
-    case CLONE_NEWUSER:
-    case CLONE_NEWUTS:
-        AI_LOG_ERROR_EXIT("unsupported nsType (%d)", nsType);
-        return false;
-    default:
-        AI_LOG_ERROR_EXIT("invalid nsType (%d)", nsType);
-        return false;
+        case CLONE_NEWPID:
+        case CLONE_NEWUSER:
+        case CLONE_NEWUTS:
+            AI_LOG_ERROR_EXIT("unsupported nsType (%d)", nsType);
+            return false;
+        default:
+            AI_LOG_ERROR_EXIT("invalid nsType (%d)", nsType);
+            return false;
     }
 
     bool success;
@@ -336,7 +337,7 @@ bool DobbyRdkPluginUtils::writeTextFile(const std::string &path,
         return false;
     }
 
-    const char *size = str.c_str();
+    const char* size = str.c_str();
     ssize_t remaining = static_cast<ssize_t>(str.length());
 
     while (remaining > 0)
@@ -396,8 +397,8 @@ std::string DobbyRdkPluginUtils::readTextFile(const std::string &path) const
  *  @brief Public api to allow for adding additional mounts to a container's
  *  config file.
  *
- *  \warning This can only obviously be called before the config file is persisted to
- *  disk (i.e. during the postInstallation hook)
+ *  This can only obviously be called before the config file is persisted to
+ *  disk.
  *
  *  @param[in]  source          The mount source
  *  @param[in]  destination     The mount destination
@@ -416,9 +417,9 @@ bool DobbyRdkPluginUtils::addMount(const std::string &source,
     AI_LOG_FN_ENTRY();
 
     // allocate memory for mount
-    rt_defs_mount *newMount = (rt_defs_mount *)calloc(1, sizeof(rt_defs_mount));
+    rt_defs_mount *newMount = (rt_defs_mount*)calloc(1, sizeof(rt_defs_mount));
     newMount->options_len = mountOptions.size();
-    newMount->options = (char **)calloc(newMount->options_len, sizeof(char *));
+    newMount->options = (char**)calloc(newMount->options_len, sizeof(char*));
 
     // add mount options to bundle config
     int i = 0;
@@ -434,8 +435,8 @@ bool DobbyRdkPluginUtils::addMount(const std::string &source,
 
     // allocate memory for new mount and place it in the config struct
     mConf->mounts_len++;
-    mConf->mounts = (rt_defs_mount **)realloc(mConf->mounts, sizeof(rt_defs_mount *) * mConf->mounts_len);
-    mConf->mounts[mConf->mounts_len - 1] = newMount;
+    mConf->mounts = (rt_defs_mount**)realloc(mConf->mounts, sizeof(rt_defs_mount *) * mConf->mounts_len);
+    mConf->mounts[mConf->mounts_len-1] = newMount;
 
     AI_LOG_FN_EXIT();
     return true;
@@ -456,7 +457,7 @@ bool DobbyRdkPluginUtils::addMount(const std::string &source,
  *
  *  @return true on success, false on failure.
  */
-bool DobbyRdkPluginUtils::mkdirRecursive(const std::string &path, mode_t mode)
+bool DobbyRdkPluginUtils::mkdirRecursive(const std::string& path, mode_t mode)
 {
     AI_LOG_FN_ENTRY();
 
@@ -512,7 +513,7 @@ bool DobbyRdkPluginUtils::mkdirRecursive(const std::string &path, mode_t mode)
  *
  *  @return true if the env var was added, otherwise false.
  */
-bool DobbyRdkPluginUtils::addEnvironmentVar(const std::string &envVar) const
+bool DobbyRdkPluginUtils::addEnvironmentVar(const std::string& envVar) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -531,8 +532,8 @@ bool DobbyRdkPluginUtils::addEnvironmentVar(const std::string &envVar) const
     mConf->process->env_len += 1;
 
     // Update env var in OCI bundle config
-    mConf->process->env = (char **)realloc(mConf->process->env, sizeof(char *) * mConf->process->env_len);
-    mConf->process->env[mConf->process->env_len - 1] = strdup(envVar.c_str());
+    mConf->process->env = (char**)realloc(mConf->process->env, sizeof(char*) * mConf->process->env_len);
+    mConf->process->env[mConf->process->env_len-1] = strdup(envVar.c_str());
 
     AI_LOG_FN_EXIT();
     return true;

--- a/pluginLauncher/tool/source/Main.cpp
+++ b/pluginLauncher/tool/source/Main.cpp
@@ -20,6 +20,8 @@
  * Dobby Plugin Launcher tool
  */
 #include <rt_dobby_schema.h>
+#include <rt_state_schema.h>
+
 #include "IDobbyRdkPlugin.h"
 #include "DobbyRdkPluginManager.h"
 #include "DobbyRdkPluginUtils.h"
@@ -150,31 +152,31 @@ IDobbyRdkPlugin::HintFlags determineHookPoint(const std::string &hookName)
 
 // -----------------------------------------------------------------------------
 /**
- *  @brief Get stdin from hookpoint.
- *
- *  Returns a json file containing information of the container such as id, pid,
- *  rootfs etc.
+ *  @brief Gets the state of the container as defined in the OCI spec here:
+ *  https://github.com/opencontainers/runtime-spec/blob/master/runtime.md#state
  *
  *  Only available with OCI container hooks.
  *
- *  @return content of stdin, empty on failure.
+ *  @return State object. nullptr if not available
  */
-std::string getOCIHookStdin()
+std::shared_ptr<const rt_state_schema> getContainerState()
 {
     std::mutex lock;
     std::lock_guard<std::mutex> locker(lock);
 
     char buf[1000];
+    bzero(buf, sizeof(buf));
 
     if (read(STDIN_FILENO, buf, sizeof(buf)) < 0)
     {
         AI_LOG_SYS_ERROR(errno, "failed to read stdin");
-        return std::string();
+        return nullptr;
     }
 
     // Occasionally, there's some extra special characters after the json.
     // We need to clear them out of the string.
     std::string hookStdin(buf);
+
     if (hookStdin[hookStdin.length()-1] != '}')
     {
         size_t pos = hookStdin.rfind('}');
@@ -185,7 +187,18 @@ std::string getOCIHookStdin()
         }
     }
 
-    return hookStdin;
+    parser_error err;
+    auto state = std::shared_ptr<const rt_state_schema>(
+                    rt_state_schema_parse_data(hookStdin.c_str(), nullptr, &err),
+                    free_rt_state_schema);
+
+    if (state.get() == nullptr || err)
+    {
+        AI_LOG_ERROR_EXIT("Failed to parse container state, err '%s'", err);
+        return nullptr;
+    }
+
+    return state;
 }
 
 /**
@@ -203,16 +216,16 @@ bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint, std::shared_ptr<rt_
     AI_LOG_DEBUG("Loading plugins from %s", PLUGIN_PATH);
 
     // Get the OCI hook stdin for the plugins to use
-    const std::string hookStdin = getOCIHookStdin();
-    if (hookStdin.empty())
+    std::shared_ptr<const rt_state_schema> state = getContainerState();
+    if (!state)
     {
-        AI_LOG_ERROR_EXIT("empty hook stdin, nothing to pass to plugins");
+        AI_LOG_ERROR_EXIT("Failed to get container state");
         return false;
     }
 
     // Create an instance of pluginManager to load the plugins
-    std::shared_ptr<DobbyRdkPluginUtils> rdkPluginUtils = std::make_shared<DobbyRdkPluginUtils>();
-    DobbyRdkPluginManager pluginManager(containerConfig, rootfsPath, hookStdin, PLUGIN_PATH, rdkPluginUtils);
+    std::shared_ptr<DobbyRdkPluginUtils> rdkPluginUtils = std::make_shared<DobbyRdkPluginUtils>(containerConfig, state);
+    DobbyRdkPluginManager pluginManager(containerConfig, rootfsPath, PLUGIN_PATH, rdkPluginUtils);
 
     std::vector<std::string> loadedPlugins = pluginManager.listLoadedPlugins();
     std::vector<std::string> loadedLoggers = pluginManager.listLoadedLoggers();
@@ -299,7 +312,6 @@ int main(int argc, char *argv[])
     std::shared_ptr<rt_dobby_schema> containerConfig(
         rt_dobby_schema_parse_file(configPath.c_str(), NULL, &err),
         free_rt_dobby_schema);
-
 
     if (containerConfig == nullptr)
     {

--- a/pluginLauncher/tool/source/Main.cpp
+++ b/pluginLauncher/tool/source/Main.cpp
@@ -176,7 +176,6 @@ std::shared_ptr<const rt_state_schema> getContainerState()
     // Occasionally, there's some extra special characters after the json.
     // We need to clear them out of the string.
     std::string hookStdin(buf);
-
     if (hookStdin[hookStdin.length()-1] != '}')
     {
         size_t pos = hookStdin.rfind('}');
@@ -217,14 +216,17 @@ bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint, std::shared_ptr<rt_
 
     // Get the OCI hook stdin for the plugins to use
     std::shared_ptr<const rt_state_schema> state = getContainerState();
-    if (!state)
+    std::shared_ptr<DobbyRdkPluginUtils> rdkPluginUtils;
+    if (state)
     {
-        AI_LOG_ERROR_EXIT("Failed to get container state");
-        return false;
+        rdkPluginUtils = std::make_shared<DobbyRdkPluginUtils>(containerConfig, state);
+    }
+    else
+    {
+        AI_LOG_WARN("Failed to get container state from stdin");
+        rdkPluginUtils = std::make_shared<DobbyRdkPluginUtils>(containerConfig);
     }
 
-    // Create an instance of pluginManager to load the plugins
-    std::shared_ptr<DobbyRdkPluginUtils> rdkPluginUtils = std::make_shared<DobbyRdkPluginUtils>(containerConfig, state);
     DobbyRdkPluginManager pluginManager(containerConfig, rootfsPath, PLUGIN_PATH, rdkPluginUtils);
 
     std::vector<std::string> loadedPlugins = pluginManager.listLoadedPlugins();

--- a/plugins/AppServices/source/AppServicesPlugin.cpp
+++ b/plugins/AppServices/source/AppServicesPlugin.cpp
@@ -403,10 +403,9 @@ bool AppServicesPlugin::preStart(const ContainerId& id,
 
     (void) pid;
 
-    // get the ip address and veth name assigned to the container. These are
-    // available in the "/dobbyaddress" file in the container rootfs, supplied
-    // by the networking plugin
-    const std::string addrFilePath = rootfsPath + "/dobbyaddress";
+    // TODO:: When this is replaced with RDK plugin, use utils->getContainerNetworkInfo()
+    // method instead
+    const std::string addrFilePath = "/tmp/dobbyAddress_" + id.str();
     const std::string addressFileStr = mUtilities->readTextFile(addrFilePath, 100);
     if (addressFileStr.empty())
     {

--- a/rdkPlugins/GPU/source/GpuPlugin.h
+++ b/rdkPlugins/GPU/source/GpuPlugin.h
@@ -46,8 +46,7 @@ class GpuPlugin : public RdkPluginBase
 public:
     GpuPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
               const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-              const std::string &rootfsPath,
-              const std::string &hookStdin);
+              const std::string &rootfsPath);
 
 public:
     inline std::string name() const override
@@ -76,8 +75,6 @@ private:
     std::shared_ptr<rt_dobby_schema> mContainerConfig;
     const std::string mRootfsPath;
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
-    const std::string mContainerId;
-    const std::string mHookStdin;
 };
 
 #endif // !defined(GPUPLUGIN_H)

--- a/rdkPlugins/HttpProxy/source/HttpProxyPlugin.cpp
+++ b/rdkPlugins/HttpProxy/source/HttpProxyPlugin.cpp
@@ -31,8 +31,7 @@ REGISTER_RDK_PLUGIN(HttpProxyPlugin);
 
 HttpProxyPlugin::HttpProxyPlugin(std::shared_ptr<rt_dobby_schema> &cfg,
                                  const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                                 const std::string &rootfsPath,
-                                 const std::string &hookStdin)
+                                 const std::string &rootfsPath)
     : mName("HttpProxy"),
       mContainerConfig(cfg),
       mUtils(utils),
@@ -198,7 +197,7 @@ bool HttpProxyPlugin::setupHttpProxy()
     if (!noProxyList.empty())
     {
         std::string noProxyEnvVar = std::string("no_proxy=") + noProxyList;
-        if (!mUtils->addEnvironmentVar(mContainerConfig, noProxyEnvVar))
+        if (!mUtils->addEnvironmentVar(noProxyEnvVar))
         {
             AI_LOG_ERROR_EXIT("failed to add no_proxy environment variable");
             return false;
@@ -209,7 +208,7 @@ bool HttpProxyPlugin::setupHttpProxy()
     char httpProxyEnvVar[256];
     snprintf(httpProxyEnvVar, sizeof(httpProxyEnvVar), "http_proxy=http://%s:%d",
              proxyHost.c_str(), proxyPort);
-    if (!mUtils->addEnvironmentVar(mContainerConfig, httpProxyEnvVar))
+    if (!mUtils->addEnvironmentVar(httpProxyEnvVar))
     {
         AI_LOG_ERROR_EXIT("failed to add httpproxy environment variable");
         return false;
@@ -236,7 +235,7 @@ bool HttpProxyPlugin::addCACertificateMount()
 
     // add a bind mount to the ca-certificates.crt file in the container's
     // bundle. This file is created in the preCreation hook.
-    if (!mUtils->addMount(mContainerConfig, mMountedCACertsPath, hostCACertsPath, "bind",
+    if (!mUtils->addMount(mMountedCACertsPath, hostCACertsPath, "bind",
                          { "bind", "ro" }))
     {
         AI_LOG_ERROR_EXIT("failed to add bind mount from '%s' to '%s'",

--- a/rdkPlugins/HttpProxy/source/HttpProxyPlugin.h
+++ b/rdkPlugins/HttpProxy/source/HttpProxyPlugin.h
@@ -45,8 +45,7 @@ class HttpProxyPlugin : public RdkPluginBase
 public:
     HttpProxyPlugin(std::shared_ptr<rt_dobby_schema>& containerConfig,
                     const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                    const std::string &rootfsPath,
-                    const std::string &hookStdin);
+                    const std::string &rootfsPath);
 
 public:
     inline std::string name() const override

--- a/rdkPlugins/IPC/source/IpcPlugin.cpp
+++ b/rdkPlugins/IPC/source/IpcPlugin.cpp
@@ -41,8 +41,7 @@ REGISTER_RDK_PLUGIN(IpcPlugin);
  */
 IpcPlugin::IpcPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
                              const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                             const std::string &rootfsPath,
-                             const std::string &hookStdin)
+                             const std::string &rootfsPath)
     : mName("ipc"),
       mContainerConfig(containerConfig),
       mRootfsPath(rootfsPath),
@@ -120,11 +119,9 @@ bool IpcPlugin::postInstallation()
     // set the environment vars for dbus to fix issues with userns and
     // the dbus AUTH EXTERNAL protocol
 #if defined(RDK)
-    mUtils->addEnvironmentVar(mContainerConfig,
-                              "SKY_DBUS_DISABLE_UID_IN_EXTERNAL_AUTH=1");
+    mUtils->addEnvironmentVar("SKY_DBUS_DISABLE_UID_IN_EXTERNAL_AUTH=1");
 #else
-    mUtils->addEnvironmentVar(mContainerConfig,
-                              "DBUS_ID_MAPPING=1");
+    mUtils->addEnvironmentVar("DBUS_ID_MAPPING=1");
 #endif
 
     // create the directory in the rootfs for the mount
@@ -254,8 +251,7 @@ bool IpcPlugin::addSocketAndEnv(const std::shared_ptr<DobbyRdkPluginUtils> utils
     }
 
     // create a mount point for the socket
-    if (!utils->addMount(containerConfig,
-                        busStr,
+    if (!utils->addMount(busStr,
                         "/" + socketPath,
                         "bind",
                         {"bind", "nodev","nosuid", "noexec" }))
@@ -265,7 +261,7 @@ bool IpcPlugin::addSocketAndEnv(const std::shared_ptr<DobbyRdkPluginUtils> utils
         return false;
     }
 
-    utils->addEnvironmentVar(containerConfig, envVar);
+    utils->addEnvironmentVar(envVar);
     return true;
 }
 

--- a/rdkPlugins/IPC/source/IpcPlugin.h
+++ b/rdkPlugins/IPC/source/IpcPlugin.h
@@ -43,8 +43,7 @@ class IpcPlugin : public RdkPluginBase
 public:
     IpcPlugin(std::shared_ptr<rt_dobby_schema>& containerConfig,
                   const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                  const std::string &rootfsPath,
-                  const std::string &hookStdin);
+                  const std::string &rootfsPath);
 
 public:
     inline std::string name() const override

--- a/rdkPlugins/LocalTime/source/LocalTimePlugin.cpp
+++ b/rdkPlugins/LocalTime/source/LocalTimePlugin.cpp
@@ -29,8 +29,7 @@ REGISTER_RDK_PLUGIN(LocalTimePlugin);
 
 LocalTimePlugin::LocalTimePlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
                                  const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                                 const std::string &rootfsPath,
-                                 const std::string &hookStdin)
+                                 const std::string &rootfsPath)
     : mName("LocalTime"),
       mRootfsPath(rootfsPath)
 {

--- a/rdkPlugins/LocalTime/source/LocalTimePlugin.h
+++ b/rdkPlugins/LocalTime/source/LocalTimePlugin.h
@@ -34,8 +34,7 @@ class LocalTimePlugin : public RdkPluginBase
 public:
     LocalTimePlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
                     const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                    const std::string &rootfsPath,
-                    const std::string &hookStdin);
+                    const std::string &rootfsPath);
 
 public:
     inline std::string name() const override

--- a/rdkPlugins/Logging/source/LoggingPlugin.h
+++ b/rdkPlugins/Logging/source/LoggingPlugin.h
@@ -36,8 +36,7 @@ class LoggingPlugin : public DobbyLoggerBase
 public:
     LoggingPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
                   const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                  const std::string &rootfsPath,
-                  const std::string &hookStdin);
+                  const std::string &rootfsPath);
 
 public:
     inline std::string name() const override

--- a/rdkPlugins/Networking/include/NetworkSetup.h
+++ b/rdkPlugins/Networking/include/NetworkSetup.h
@@ -56,8 +56,7 @@ namespace NetworkSetup
                    const std::shared_ptr<NetworkingHelper> &helper,
                    const std::string &rootfsPath,
                    const std::string &containerId,
-                   const NetworkType networkType,
-                   const std::string &hookStdin);
+                   const NetworkType networkType);
 
     bool removeVethPair(const std::shared_ptr<Netfilter> &netfilter,
                         const std::shared_ptr<NetworkingHelper> &helper,

--- a/rdkPlugins/Networking/include/NetworkingHelper.h
+++ b/rdkPlugins/Networking/include/NetworkingHelper.h
@@ -23,10 +23,6 @@
 #include <netinet/in.h>
 #include <string>
 
-// TODO:: This would be better stored in the dobby workspace dir rather than /tmp,
-// but we don't programatically know the workspace dir in this code.
-#define ADDRESS_FILE_PREFIX       "/tmp/dobbyAddress_"
-
 #define BRIDGE_NAME             "dobby0"
 
 enum class NetworkType { None, Nat, Open };

--- a/rdkPlugins/Networking/include/NetworkingHelper.h
+++ b/rdkPlugins/Networking/include/NetworkingHelper.h
@@ -23,8 +23,9 @@
 #include <netinet/in.h>
 #include <string>
 
-// path to file in container rootfs where the container's ip address is stored
-#define ADDRESS_FILE_PATH       "/dobbyaddress"
+// TODO:: This would be better stored in the dobby workspace dir rather than /tmp,
+// but we don't programatically know the workspace dir in this code.
+#define ADDRESS_FILE_PREFIX       "/tmp/dobbyAddress_"
 
 #define BRIDGE_NAME             "dobby0"
 

--- a/rdkPlugins/Networking/include/NetworkingPlugin.h
+++ b/rdkPlugins/Networking/include/NetworkingPlugin.h
@@ -41,8 +41,7 @@ class NetworkingPlugin : public RdkPluginBase
 public:
     NetworkingPlugin(std::shared_ptr<rt_dobby_schema> &cfg,
                      const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                     const std::string &rootfsPath,
-                     const std::string &hookStdin);
+                     const std::string &rootfsPath);
     ~NetworkingPlugin();
 
 public:
@@ -68,11 +67,8 @@ private:
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
     const std::string mName;
     const std::string mRootfsPath;
-    const std::string mContainerId;
     NetworkType mNetworkType;
     std::shared_ptr<Netfilter> mNetfilter;
-    const std::string mHookStdin;
-
 
     std::shared_ptr<DobbyRdkPluginProxy> mDobbyProxy;
     std::shared_ptr<AI_IPC::IIpcService> mIpcService;

--- a/rdkPlugins/Networking/include/NetworkingPluginCommon.h
+++ b/rdkPlugins/Networking/include/NetworkingPluginCommon.h
@@ -22,9 +22,6 @@
 
 #include <netinet/in.h>
 
-// path to file in container rootfs where the container's ip address is stored
-#define ADDRESS_FILE_PATH       "/dobbyaddress"
-
 #define BRIDGE_NAME             "dobby0"
 
 #if defined(DEV_VM)

--- a/rdkPlugins/Networking/source/Netlink.cpp
+++ b/rdkPlugins/Networking/source/Netlink.cpp
@@ -1667,8 +1667,13 @@ bool Netlink::delIfaceFromBridge(const std::string& bridgeName,
                 ret = rtnl_link_release(mSocket, iface);
                 if (ret != 0)
                 {
-                    AI_LOG_NL_ERROR(ret, "failed to release '%s' from bridge '%s'",
+                    // If device not found, ignore - the veth must have been
+                    // automatically cleaned up in the time it took to get here...
+                    if (-ret != NLE_NODEV)
+                    {
+                        AI_LOG_NL_ERROR(ret, "failed to release '%s' from bridge '%s'",
                                  ifaceName.c_str(), bridgeName.c_str());
+                    }
                 }
                 else
                 {

--- a/rdkPlugins/Networking/source/NetworkSetup.cpp
+++ b/rdkPlugins/Networking/source/NetworkSetup.cpp
@@ -500,24 +500,6 @@ bool NetworkSetup::setupBridgeDevice(const std::shared_ptr<DobbyRdkPluginUtils> 
     return true;
 }
 
-bool bindMountDobbyAddress(const std::shared_ptr<DobbyRdkPluginUtils> &utils, const std::string &rootfsPath, const std::string &source)
-{
-    AI_LOG_FN_ENTRY();
-
-    std::string path = rootfsPath + "/dobbyaddress";
-
-    // try and do the bind mount
-    if (mount(source.c_str(), path.c_str(), nullptr, MS_BIND | MS_RDONLY, nullptr) < 0)
-    {
-        AI_LOG_SYS_ERROR_EXIT(errno, "failed to bind mount '%s' to %s",
-                         source.c_str(), path.c_str());
-        return false;
-    }
-
-    AI_LOG_FN_EXIT();
-    return true;
-}
-
 // -----------------------------------------------------------------------------
 /**
  *  @brief Saves an ip address to a container and register the veth name to it.
@@ -565,15 +547,6 @@ bool saveContainerAddress(const std::shared_ptr<DobbyRdkPluginUtils> &utils,
     if (!utils->writeTextFile(tmpFilename, fileContent, O_CREAT | O_TRUNC, 0644))
     {
         AI_LOG_ERROR_EXIT("failed to write ip address file");
-        return false;
-    }
-
-    // Bind mount our dobby address file into the container so other plugins
-    // can find out our IP/veth (needed if they need to manipulate iptables)
-    if (!utils->callInNamespace(utils->getContainerPid(), CLONE_NEWNS,
-                                 &bindMountDobbyAddress, utils, rootfsPath, tmpFilename))
-    {
-        AI_LOG_ERROR_EXIT("hook failed to enter mount namespace");
         return false;
     }
 

--- a/rdkPlugins/Networking/source/NetworkingPlugin.cpp
+++ b/rdkPlugins/Networking/source/NetworkingPlugin.cpp
@@ -140,14 +140,6 @@ bool NetworkingPlugin::postInstallation()
         NetworkSetup::addNetworkNamespace(mContainerConfig);
     }
 
-    // Create a blank /dobbyaddress file in rootfs that will have the actual
-    // info mounted on
-    if (!mUtils->writeTextFile(std::string(mRootfsPath + "/dobbyaddress"), "", O_CREAT | O_TRUNC, 0644))
-    {
-        AI_LOG_ERROR_EXIT("Failed to create /dobbyaddress file in rootfs");
-        return false;
-    }
-
     AI_LOG_FN_EXIT();
     return true;
 }
@@ -287,9 +279,8 @@ bool NetworkingPlugin::postHalt()
         return false;
     }
 
-    // get address from a file in the container
+    // get address from a file
     const std::string addressFilePath = ADDRESS_FILE_PREFIX + mUtils->getContainerId();
-
     const std::string addressFileStr = mUtils->readTextFile(addressFilePath);
     if (addressFileStr.empty())
     {

--- a/rdkPlugins/RtScheduling/source/RtSchedulingPlugin.cpp
+++ b/rdkPlugins/RtScheduling/source/RtSchedulingPlugin.cpp
@@ -33,13 +33,11 @@ REGISTER_RDK_PLUGIN(RtSchedulingPlugin);
 
 RtSchedulingPlugin::RtSchedulingPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
                                        const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                                       const std::string &rootfsPath,
-                                       const std::string &hookStdin)
+                                       const std::string &rootfsPath)
     : mName("RtScheduling"),
       mUtils(utils),
       mConfig(containerConfig),
-      mRootfsPath(rootfsPath),
-      mHookStdin(hookStdin)
+      mRootfsPath(rootfsPath)
 {
     AI_LOG_FN_ENTRY();
     AI_LOG_FN_EXIT();
@@ -144,7 +142,7 @@ bool RtSchedulingPlugin::createRuntime()
     }
 
     // get the container pid
-    pid_t containerPid = mUtils->getContainerPid(mHookStdin);
+    pid_t containerPid = mUtils->getContainerPid();
     if (!containerPid)
     {
         AI_LOG_ERROR_EXIT("couldn't find container pid");

--- a/rdkPlugins/RtScheduling/source/RtSchedulingPlugin.h
+++ b/rdkPlugins/RtScheduling/source/RtSchedulingPlugin.h
@@ -40,8 +40,7 @@ class RtSchedulingPlugin : public RdkPluginBase
 public:
     RtSchedulingPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
                     const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                    const std::string &rootfsPath,
-                    const std::string &hookStdin);
+                    const std::string &rootfsPath);
 
 public:
     inline std::string name() const override
@@ -60,7 +59,6 @@ private:
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
     std::shared_ptr<rt_dobby_schema> mConfig;
     const std::string mRootfsPath;
-    const std::string mHookStdin;
 };
 
 #endif // !defined(RTSCHEDULINGPLUGIN_H)

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -41,8 +41,7 @@ REGISTER_RDK_PLUGIN(Storage);
  */
 Storage::Storage(std::shared_ptr<rt_dobby_schema> &containerSpec,
                 const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                const std::string &rootfsPath,
-                const std::string &hookStdin)
+                const std::string &rootfsPath)
     : mName("Storage"),
       mContainerConfig(containerSpec),
       mRootfsPath(rootfsPath),

--- a/rdkPlugins/Storage/source/Storage.h
+++ b/rdkPlugins/Storage/source/Storage.h
@@ -43,8 +43,7 @@ class Storage : public RdkPluginBase
 public:
     Storage(std::shared_ptr<rt_dobby_schema>& containerConfig,
             const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-            const std::string &rootfsPath,
-            const std::string &hookStdin);
+            const std::string &rootfsPath);
 
 public:
     inline std::string name() const override

--- a/rdkPlugins/TestPlugin/source/TestRdkPlugin.cpp
+++ b/rdkPlugins/TestPlugin/source/TestRdkPlugin.cpp
@@ -35,8 +35,7 @@ REGISTER_RDK_PLUGIN(TestRdkPlugin);
  */
 TestRdkPlugin::TestRdkPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
                              const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                             const std::string &rootfsPath,
-                             const std::string &hookStdin)
+                             const std::string &rootfsPath)
     : mName("TestRdkPlugin"),
       mContainerConfig(containerConfig),
       mRootfsPath(rootfsPath),
@@ -81,7 +80,7 @@ bool TestRdkPlugin::postInstallation()
         return false;
     }
 
-    AI_LOG_INFO("This hook is running for container with hostname %s", mContainerConfig->hostname);
+    AI_LOG_INFO("This hook is running for container with hostname %s", mUtils->getContainerId().c_str());
     return true;
 }
 
@@ -98,7 +97,7 @@ bool TestRdkPlugin::preCreation()
         return false;
     }
 
-    AI_LOG_INFO("This hook is running for container with hostname %s", mContainerConfig->hostname);
+    AI_LOG_INFO("This hook is running for container with hostname %s", mUtils->getContainerId().c_str());
     return true;
 }
 
@@ -115,7 +114,7 @@ bool TestRdkPlugin::createRuntime()
         return false;
     }
 
-    AI_LOG_INFO("This hook is running for container with hostname %s", mContainerConfig->hostname);
+    AI_LOG_INFO("This hook is running for container with hostname %s", mUtils->getContainerId().c_str());
     return true;
 }
 
@@ -132,10 +131,11 @@ bool TestRdkPlugin::createContainer()
         return false;
     }
 
-    AI_LOG_INFO("This hook is running for container with hostname %s", mContainerConfig->hostname);
+    AI_LOG_INFO("This hook is running for container with hostname %s", mUtils->getContainerId().c_str());
     return true;
 }
 
+#ifdef USE_STARTCONTAINER_HOOK
 /**
  * @brief OCI Hook - Run in container namespace
  */
@@ -149,9 +149,10 @@ bool TestRdkPlugin::startContainer()
         return false;
     }
 
-    AI_LOG_INFO("This hook is running for container with hostname %s", mContainerConfig->hostname);
+    AI_LOG_INFO("This hook is running for container with hostname %s", mUtils->getContainerId().c_str());
     return true;
 }
+#endif
 
 /**
  * @brief OCI Hook - Run in host namespace once container has started
@@ -166,7 +167,7 @@ bool TestRdkPlugin::postStart()
         return false;
     }
 
-    AI_LOG_INFO("This hook is running for container with hostname %s", mContainerConfig->hostname);
+    AI_LOG_INFO("This hook is running for container with hostname %s", mUtils->getContainerId().c_str());
     return true;
 }
 
@@ -183,7 +184,7 @@ bool TestRdkPlugin::postHalt()
         return false;
     }
 
-    AI_LOG_INFO("This hook is running for container with hostname %s", mContainerConfig->hostname);
+    AI_LOG_INFO("This hook is running for container with hostname %s", mUtils->getContainerId().c_str());
     return true;
 }
 
@@ -200,7 +201,7 @@ bool TestRdkPlugin::postStop()
         return false;
     }
 
-    AI_LOG_INFO("This hook is running for container with hostname %s", mContainerConfig->hostname);
+    AI_LOG_INFO("This hook is running for container with hostname %s", mUtils->getContainerId().c_str());
     return true;
 }
 

--- a/rdkPlugins/TestPlugin/source/TestRdkPlugin.h
+++ b/rdkPlugins/TestPlugin/source/TestRdkPlugin.h
@@ -45,8 +45,7 @@ class TestRdkPlugin : public RdkPluginBase
 public:
     TestRdkPlugin(std::shared_ptr<rt_dobby_schema>& containerConfig,
                   const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                  const std::string &rootfsPath,
-                  const std::string &hookStdin);
+                  const std::string &rootfsPath);
 
 public:
     inline std::string name() const override


### PR DESCRIPTION
### Description
* Move `/dobbyaddress` to `/tmp/dobbyAddress_<containerid>`. This prevents it being overridden when another container is started from the same bundle
   * Add new getContainerNetworkInfo() method in utils to read/parse this file
* When launching multiple container instances from the same bundle, make sure the correct veth is destroyed on exit
* Switch to using `libocispec` to parse state from stdin instead of manually parsing JSON
    * Don't pass stdin directly to plugins - allow them to access state struct via utils clas instead

Marked as breaking due to:
* Removal of raw stdin from plugins means the plugin constructor has changed. All plugins have been updated to reflect this change. 
* /dobbyaddress file has moved, plugins depending on it need to be updated

### Test Procedure
Create a simple "sleepy" bundle with NAT networking. Start two containers from the same bundle simultaneously.

Check that the correct IP/veth is available in the `/dobbyaddress` file within the container - e.g.
```
100.64.11.2/veth0
```
```
100.64.11.3/veth1
```

When stopping one of the two containers, ensure the correct veth is destroyed and network access is not broken in the other container. When both containers are stopped, all veths should be destroyed.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)