### PR TITLE
Little fixes for two tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,9 +256,9 @@ if( BUILD_TYPE STREQUAL "DEBUG")
 else()
     set( ENABLE_DOBBYTOOL_DEFAULT OFF )
 endif()
+option( ENABLE_DOBBYTOOL "Include DobbyTool" ${ENABLE_DOBBYTOOL_DEFAULT} )
 
-option(ENABLE_DOBBYTOOL "Include DobbyTool" ENABLE_DOBBYTOOL_DEFAULT)
-if(ENABLE_DOBBYTOOL)
+if( ENABLE_DOBBYTOOL )
     add_subdirectory( client/tool )
 endif()
 

--- a/pluginLauncher/tool/source/Main.cpp
+++ b/pluginLauncher/tool/source/Main.cpp
@@ -128,7 +128,7 @@ IDobbyRdkPlugin::HintFlags determineHookPoint(const std::string &hookName)
     std::unordered_map<std::string, IDobbyRdkPlugin::HintFlags> const hookMappings =
         {
             {"postinstallation", IDobbyRdkPlugin::HintFlags::PostInstallationFlag},
-            {"preCreation", IDobbyRdkPlugin::HintFlags::PreCreationFlag},
+            {"precreation", IDobbyRdkPlugin::HintFlags::PreCreationFlag},
             {"createruntime", IDobbyRdkPlugin::HintFlags::CreateRuntimeFlag},
             {"createcontainer", IDobbyRdkPlugin::HintFlags::CreateContainerFlag},
 #ifdef USE_STARTCONTAINER_HOOK


### PR DESCRIPTION
### Description
Fixed build switch logic for DobbyTool,
corrected hook point name letter casing in the pluginLauncher.

### Test Procedure
Check if DobbyTool is actually compiled in a debug build,
test if the pluginLauncher actually runs the preCreation hook.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)