### PR TITLE
Fix XDG_RUNTIME_DIR not set

### DIFF
--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -350,7 +350,7 @@ bool DobbyConfig::addWesterosMount(const std::string& socketPath)
         return false;
     }
 
-    if (!addEnvironmentVar("WAYLAND_DISPLAY=westeros") && !addEnvironmentVar("XDG_RUNTIME_DIR=/tmp"))
+    if (!addEnvironmentVar("WAYLAND_DISPLAY=westeros") || !addEnvironmentVar("XDG_RUNTIME_DIR=/tmp"))
     {
         AI_LOG_ERROR("Failed to set westeros environment variables");
         return false;


### PR DESCRIPTION
### Description
XDG_RUNTIME_DIR was not set when adding westeros socket during container startup

### Test Procedure
Add westeros socket using DobbyTool/OCIContainer when starting container. `XDG_RUNTIME_DIR` should be set to `/tmp` inside the container 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)