### PR TITLE
Fix writing arrays to OCI plugin specs

### DIFF
--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -2541,10 +2541,17 @@ void DobbySpecConfig::insertIntoRdkPluginJson(const std::string& pluginName,
         else
         {
             // plugin member is an array, so instead of overwriting, we should
-            // append the new array members to the existing array
-            for (const auto& arrayElement : dataMember)
+            // append the new array members to the existing array if there is one
+            if (!existingData[dataMember].isNull())
             {
-                existingData[dataMember].append(arrayElement);
+                for (const auto& arrayElement : pluginData[dataMember])
+                {
+                    existingData[dataMember].append(arrayElement);
+                }
+            }
+            else
+            {
+                existingData[dataMember] = pluginData[dataMember];
             }
         }
     }


### PR DESCRIPTION
### Description
When rewriting arrays from Dobby plugin specs to OCI plugin specs, source array was iterated over wrong elements, append was tried on the destination array even if it didn't exist. This resulted in invalid data being written to the OCI plugin spec.

### Test Procedure
Prepare a Dobby plugin spec which contains a non-empty array, run it through DobbyBundleGenerator and check the output config file.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)