### PR TITLE
Run plugin hooks in order determined by dependencies

### DIFF
--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -141,6 +141,8 @@ static const ctemplate::StaticTemplateString RDK_PLUGIN_DATA =
     STS_INIT(RDK_PLUGIN_DATA, "RDK_PLUGIN_DATA");
 static const ctemplate::StaticTemplateString RDK_PLUGIN_REQUIRED =
     STS_INIT(RDK_PLUGIN_REQUIRED, "RDK_PLUGIN_REQUIRED");
+static const ctemplate::StaticTemplateString RDK_PLUGIN_DEPENDS_ON =
+    STS_INIT(RDK_PLUGIN_DEPENDS_ON, "RDK_PLUGIN_DEPENDS_ON");
 
 static const ctemplate::StaticTemplateString ENABLE_LEGACY_PLUGINS =
     STS_INIT(ENABLE_LEGACY_PLUGINS, "ENABLE_LEGACY_PLUGINS");
@@ -2588,6 +2590,11 @@ bool DobbySpecConfig::processRdkPlugins(const Json::Value& value,
             {
                 mRdkPluginsJson[pluginName]["required"] = value[pluginName]["required"];
             }
+            // write the "dependsOn" field
+            if (!value[pluginName]["dependsOn"].isNull())
+            {
+                mRdkPluginsJson[pluginName]["dependsOn"] = value[pluginName]["dependsOn"];
+            }
         }
     }
 
@@ -2597,6 +2604,7 @@ bool DobbySpecConfig::processRdkPlugins(const Json::Value& value,
         const Json::Value pluginJson = mRdkPluginsJson[pluginName];
         const std::string pluginData = jsonToString(pluginJson["data"]);
         bool pluginRequired = pluginJson["required"].asBool();
+        const std::string pluginDependsOn = (pluginJson["dependsOn"].isNull() ? "[]" : jsonToString(pluginJson["dependsOn"]));
 
         // add parsed rdkPlugin into mRdkPlugins for Dobby hooks
         mRdkPlugins.emplace(pluginName, pluginJson);
@@ -2606,6 +2614,7 @@ bool DobbySpecConfig::processRdkPlugins(const Json::Value& value,
         subDict->SetValue(RDK_PLUGIN_NAME, pluginName.c_str());
         subDict->SetValue(RDK_PLUGIN_DATA, pluginData.c_str());
         subDict->SetValue(RDK_PLUGIN_REQUIRED, pluginRequired ? "true": "false");
+        subDict->SetValue(RDK_PLUGIN_DEPENDS_ON, pluginDependsOn.c_str());
     }
 
     // we no longer need mRdkPluginsJson, so we can safely clear it

--- a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
@@ -381,6 +381,7 @@ static const char* ociJsonTemplate = R"JSON(
         {{#RDK_PLUGIN_SECTION}}
         "{{RDK_PLUGIN_NAME}}": {
             "required": {{RDK_PLUGIN_REQUIRED}},
+            "dependsOn": {{RDK_PLUGIN_DEPENDS_ON}},
             "data": {{RDK_PLUGIN_DATA}}
         }{{#RDK_PLUGIN_SECTION_separator}},{{/RDK_PLUGIN_SECTION_separator}}
         {{/RDK_PLUGIN_SECTION}}

--- a/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
@@ -392,6 +392,7 @@ static const char* ociJsonTemplate = R"JSON(
         {{#RDK_PLUGIN_SECTION}}
         "{{RDK_PLUGIN_NAME}}": {
             "required": {{RDK_PLUGIN_REQUIRED}},
+            "dependsOn": {{RDK_PLUGIN_DEPENDS_ON}},
             "data": {{RDK_PLUGIN_DATA}}
         }{{#RDK_PLUGIN_SECTION_separator}},{{/RDK_PLUGIN_SECTION_separator}}
         {{/RDK_PLUGIN_SECTION}}

--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -51,6 +51,9 @@
                 "required": {
                     "type": "boolean"
                 },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
+                },
                 "data": {
                     "type": "object",
                     "properties": {
@@ -70,6 +73,9 @@
             "properties": {
                 "required": {
                     "type": "boolean"
+                },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
                 },
                 "data": {
                     "type": "object",
@@ -96,6 +102,9 @@
             "properties": {
                 "required": {
                     "type": "boolean"
+                },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
                 },
                 "data": {
                     "type": "object",
@@ -145,6 +154,9 @@
             "properties": {
                 "required": {
                     "type": "boolean"
+                },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
                 },
                 "data": {
                     "type": "object",
@@ -232,6 +244,9 @@
                 "required": {
                     "type": "boolean"
                 },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
+                },
                 "data": {
                     "type": "object",
                     "properties": {
@@ -283,6 +298,9 @@
                 "required": {
                     "type": "boolean"
                 },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
+                },
                 "data": {
                     "type": "object",
                     "properties": {
@@ -299,6 +317,9 @@
             "properties": {
                 "required": {
                     "type": "boolean"
+                },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
                 },
                 "data": {
                     "type": "object",
@@ -321,6 +342,9 @@
             "properties": {
                 "required": {
                     "type": "boolean"
+                },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
                 },
                 "data": {
                     "type": "object",
@@ -362,6 +386,9 @@
             "properties": {
                 "required": {
                     "type": "boolean"
+                },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
                 },
                 "data": {
                     "type": "object",

--- a/pluginLauncher/lib/CMakeLists.txt
+++ b/pluginLauncher/lib/CMakeLists.txt
@@ -18,6 +18,7 @@
 project(DobbyPluginLauncherLib)
 
 add_library(${PROJECT_NAME} STATIC
+    source/DobbyRdkPluginDependencySolver.cpp
     source/DobbyRdkPluginManager.cpp
     source/DobbyRdkPluginUtils.cpp
 )

--- a/pluginLauncher/lib/include/DobbyRdkPluginDependencySolver.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginDependencySolver.h
@@ -1,0 +1,59 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2021 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File:   DobbyRdkPluginDependencySolver.h
+ *
+ */
+#ifndef DOBBYRDKPLUGINDEPENDENCYSOLVER_H
+#define DOBBYRDKPLUGINDEPENDENCYSOLVER_H
+
+#include <string>
+#include <vector>
+
+#include <boost/graph/adjacency_list.hpp>
+
+// -----------------------------------------------------------------------------
+/**
+ *  @class DobbyRdkPluginDependencySolver
+ *  @brief Class that tracks dependencies between plugins.
+ *
+ *  It can be used to get the order in which the plugins should be launched.
+ *
+ */
+class DobbyRdkPluginDependencySolver
+{
+public:
+    bool addPlugin(const std::string &name);
+    bool addDependency(const std::string &pluginName, const std::string &dependencyName);
+
+    std::vector<std::string> getOrderOfDependency() const;
+    std::vector<std::string> getReversedOrderOfDependency() const;
+
+private:
+    using VertexIndexProperty = boost::property<boost::vertex_index_t, std::size_t>;
+    using VertexNameProperty = boost::property<boost::vertex_name_t, std::string, VertexIndexProperty>;
+    using Graph = boost::adjacency_list<boost::setS, boost::vecS, boost::directedS, VertexNameProperty>;
+    using VertexDescriptor = Graph::vertex_descriptor;
+    using StringVertexDescriptorMap = std::map<std::string, VertexDescriptor>;
+
+    Graph mDependencyGraph;
+    StringVertexDescriptorMap mDescriptorMap;
+};
+
+#endif // !defined(DOBBYRDKPLUGINDEPENDENCYSOLVER_H)

--- a/pluginLauncher/lib/include/DobbyRdkPluginManager.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginManager.h
@@ -25,6 +25,7 @@
 
 #include "IDobbyRdkPlugin.h"
 #include "IDobbyRdkLoggingPlugin.h"
+#include "DobbyRdkPluginDependencySolver.h"
 
 #include <sys/types.h>
 #include <map>
@@ -52,7 +53,6 @@ public:
     ~DobbyRdkPluginManager();
 
 public:
-    void loadPlugins();
     const std::vector<std::string> listLoadedPlugins() const;
     const std::vector<std::string> listLoadedLoggers() const;
     bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint) const;
@@ -61,22 +61,27 @@ public:
     std::shared_ptr<IDobbyRdkLoggingPlugin> getContainerLogger() const;
 
 private:
+    void loadPlugins();
+    bool preprocessPlugins();
     bool executeHook(const std::string &pluginName,
                      const IDobbyRdkPlugin::HintFlags hook) const;
 
     bool implementsHook(const std::string &pluginName,
                         const IDobbyRdkPlugin::HintFlags hook) const;
     bool isLoaded(const std::string &pluginName) const;
+    bool isRequired(const std::string &pluginName) const;
     inline std::shared_ptr<IDobbyRdkPlugin> getPlugin(const std::string &name) const;
     inline std::shared_ptr<IDobbyRdkLoggingPlugin> getLogger(const std::string &name) const;
 
 private:
     std::map<std::string, std::pair<void *, std::shared_ptr<IDobbyRdkLoggingPlugin>>> mLoggers;
     std::map<std::string, std::pair<void *, std::shared_ptr<IDobbyRdkPlugin>>> mPlugins;
+    std::set<std::string> mRequiredPlugins;
     const std::string mPluginPath;
     const std::string mRootfsPath;
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
     std::shared_ptr<rt_dobby_schema> mContainerConfig;
+    DobbyRdkPluginDependencySolver mDependencySolver;
 };
 
 #endif // !defined(DOBBYRDKPLUGINMANAGER_H)

--- a/pluginLauncher/lib/include/DobbyRdkPluginManager.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginManager.h
@@ -61,7 +61,7 @@ public:
     std::shared_ptr<IDobbyRdkLoggingPlugin> getContainerLogger() const;
 
 private:
-    void loadPlugins();
+    bool loadPlugins();
     bool preprocessPlugins();
     bool executeHook(const std::string &pluginName,
                      const IDobbyRdkPlugin::HintFlags hook) const;
@@ -74,6 +74,7 @@ private:
     inline std::shared_ptr<IDobbyRdkLoggingPlugin> getLogger(const std::string &name) const;
 
 private:
+    bool mValid;
     std::map<std::string, std::pair<void *, std::shared_ptr<IDobbyRdkLoggingPlugin>>> mLoggers;
     std::map<std::string, std::pair<void *, std::shared_ptr<IDobbyRdkPlugin>>> mPlugins;
     std::set<std::string> mRequiredPlugins;

--- a/pluginLauncher/lib/include/IDobbyRdkPlugin.h
+++ b/pluginLauncher/lib/include/IDobbyRdkPlugin.h
@@ -31,8 +31,9 @@
 #include <json/json.h>
 #include <sys/types.h>
 
-#include <string>
 #include <memory>
+#include <string>
+#include <vector>
 
 // -----------------------------------------------------------------------------
 /**
@@ -118,6 +119,17 @@ public:
 
     // OCI Hook (called after delete)
     virtual bool postStop() = 0;
+
+public:
+    /**
+     * @brief Should return the names of the plugins this plugin depends on.
+     *
+     * This can be used to determine the order in which the plugins should be
+     * processed when running hooks.
+     *
+     * @return Names of the plugins this plugin depends on.
+     */
+    virtual std::vector<std::string> getDependencies() const = 0;
 };
 
 // -----------------------------------------------------------------------------

--- a/pluginLauncher/lib/source/DobbyRdkPluginDependencySolver.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginDependencySolver.cpp
@@ -42,18 +42,22 @@
 bool DobbyRdkPluginDependencySolver::addPlugin(const std::string &name)
 {
     AI_LOG_FN_ENTRY();
+    // Plugins names are case-insensitive - use lowercase.
+    std::string lowercaseName;
+    lowercaseName.resize(name.length());
+    std::transform(name.begin(), name.end(), lowercaseName.begin(), ::tolower);
 
-    if (mDescriptorMap.count(name) != 0)
+    if (mDescriptorMap.count(lowercaseName) != 0)
     {
-        AI_LOG_WARN("Plugin %s already added to the solver", name.c_str());
+        AI_LOG_WARN("Plugin %s already added to the solver", lowercaseName.c_str());
         return false;
     }
 
     // Each plugin is represented by a vertex of a directed graph.
     const VertexDescriptor descriptor = boost::add_vertex(mDependencyGraph);
     // Store the name of the plugin as a property of the vertex.
-    boost::put(boost::vertex_name_t{}, mDependencyGraph, descriptor, name);
-    mDescriptorMap.insert(StringVertexDescriptorMap::value_type{ name, descriptor });
+    boost::put(boost::vertex_name_t{}, mDependencyGraph, descriptor, lowercaseName);
+    mDescriptorMap.insert(StringVertexDescriptorMap::value_type{ lowercaseName, descriptor });
 
     AI_LOG_FN_EXIT();
     return true;
@@ -76,20 +80,26 @@ bool DobbyRdkPluginDependencySolver::addPlugin(const std::string &name)
 bool DobbyRdkPluginDependencySolver::addDependency(const std::string &pluginName, const std::string &dependencyName)
 {
     AI_LOG_FN_ENTRY();
+    // Plugins names are case-insensitive - use lowercase.
+    std::string lowercaseName, lowercasedependencyName;
+    lowercaseName.resize(pluginName.length());
+    std::transform(pluginName.begin(), pluginName.end(), lowercaseName.begin(), ::tolower);
+    lowercasedependencyName.resize(dependencyName.length());
+    std::transform(dependencyName.begin(), dependencyName.end(), lowercasedependencyName.begin(), ::tolower);
 
-    if (mDescriptorMap.count(pluginName) == 0)
+    if (mDescriptorMap.count(lowercaseName) == 0)
     {
-        AI_LOG_ERROR("Plugin %s unknown", pluginName.c_str());
+        AI_LOG_ERROR("Plugin %s unknown", lowercaseName.c_str());
         return false;
     }
-    if (mDescriptorMap.count(dependencyName) == 0)
+    if (mDescriptorMap.count(lowercasedependencyName) == 0)
     {
-        AI_LOG_ERROR("Plugin %s unknown", dependencyName.c_str());
+        AI_LOG_ERROR("Plugin %s unknown", lowercasedependencyName.c_str());
         return false;
     }
 
     // Our dependency relation is represented by a directed edge (pluginName->dependencyName) of the graph.
-    boost::add_edge(mDescriptorMap.at(pluginName), mDescriptorMap.at(dependencyName), mDependencyGraph);
+    boost::add_edge(mDescriptorMap.at(lowercaseName), mDescriptorMap.at(lowercasedependencyName), mDependencyGraph);
 
     AI_LOG_FN_EXIT();
     return true;

--- a/pluginLauncher/lib/source/DobbyRdkPluginDependencySolver.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginDependencySolver.cpp
@@ -1,0 +1,181 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2021 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File:   DobbyRdkPluginDependencySolver.cpp
+ *
+ */
+#include "DobbyRdkPluginDependencySolver.h"
+
+#include <Logging.h>
+
+#include <boost/graph/topological_sort.hpp>
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Adds a plugin to the solver.
+ *
+ * Each plugin must be known to the solver - added by this method before its dependencies
+ * are tracked.
+ *
+ * @param[in]   name   Name of the plugin
+ *
+ * @return True if the plugin has been added successfully,
+ * false otherwise (the plugin had already been added).
+ *
+ */
+bool DobbyRdkPluginDependencySolver::addPlugin(const std::string &name)
+{
+    AI_LOG_FN_ENTRY();
+
+    if (mDescriptorMap.count(name) != 0)
+    {
+        AI_LOG_WARN("Plugin %s already added to the solver", name.c_str());
+        return false;
+    }
+
+    // Each plugin is represented by a vertex of a directed graph.
+    const VertexDescriptor descriptor = boost::add_vertex(mDependencyGraph);
+    // Store the name of the plugin as a property of the vertex.
+    boost::put(boost::vertex_name_t{}, mDependencyGraph, descriptor, name);
+    mDescriptorMap.insert(StringVertexDescriptorMap::value_type{ name, descriptor });
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Adds a dependency between two plugins to the solver.
+ *
+ * If plugin A depends on plugin B, then the call is:
+ * @code addDependency(A, B); @endcode
+ *
+ * @param[in]   pluginName       The name of the plugin which depends on @p dependencyName.
+ * @param[in]   dependencyName   The name of the plugin on which @p pluginName depends.
+ *
+ * @return True if the dependency has been added successfully,
+ * false otherwise (one of the plugins had not been added to the solver).
+ *
+ */
+bool DobbyRdkPluginDependencySolver::addDependency(const std::string &pluginName, const std::string &dependencyName)
+{
+    AI_LOG_FN_ENTRY();
+
+    if (mDescriptorMap.count(pluginName) == 0)
+    {
+        AI_LOG_ERROR("Plugin %s unknown", pluginName.c_str());
+        return false;
+    }
+    if (mDescriptorMap.count(dependencyName) == 0)
+    {
+        AI_LOG_ERROR("Plugin %s unknown", dependencyName.c_str());
+        return false;
+    }
+
+    // Our dependency relation is represented by a directed edge (pluginName->dependencyName) of the graph.
+    boost::add_edge(mDescriptorMap.at(pluginName), mDescriptorMap.at(dependencyName), mDependencyGraph);
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Gets the names of the plugins in order of their dependency.
+ *
+ * "Order of dependency" here means that if plugin A depends on plugin B, plugin B will be placed
+ * before plugin A in the returned vector, e.g. with this code:
+ * @code
+ * DobbyRdkPluginDependencySolver solver;
+ * solver.addPlugin("AppServices");
+ * solver.addPlugin("Networking");
+ * solver.addPlugin("IPC");
+ * solver.addDependency("AppServices", "Networking");
+ * solver.addDependency("Networking", "IPC");
+ *
+ * const std::vector<std::string> inOrder = solver.getOrderOfDependency();
+ * @endcode,
+ * @code inOrder @endcode is @code { "IPC", "Networking", "AppServices" } @endcode.
+ *
+ * If there is a dependency cycle, an error message is printed and the function returns an empty vector.
+ *
+ * @return Names of the plugins in order of dependency. Empty vector if no plugins have been added or a
+ * dependency cycle has been detected. Vector with plugin names in the same order in which they were added
+ * if no dependencies have been added).
+ */
+std::vector<std::string> DobbyRdkPluginDependencySolver::getOrderOfDependency() const
+{
+    AI_LOG_FN_ENTRY();
+
+    std::vector<std::string> namesInOrder;
+    std::vector<VertexDescriptor> descriptorsInOrder;
+    try
+    {
+        // If edge (u, v) appears in the graph, a topological sort will put v before u. This is our order of dependency.
+        boost::topological_sort(mDependencyGraph, std::back_inserter(descriptorsInOrder));
+    }
+    catch(const boost::not_a_dag &e)
+    {
+        // Thrown when a graph is not a directed acyclic graph (DAG). In our case that means we have a dependency cycle.
+        AI_LOG_ERROR("Dependency cycle detected");
+        return namesInOrder;
+    }
+
+    // boost::topological_sort returns vertex descriptors. Convert them to our plugin names.
+    const auto nameMap = boost::get(boost::vertex_name, mDependencyGraph);
+    std::transform(descriptorsInOrder.begin(), descriptorsInOrder.end(), std::back_inserter(namesInOrder),
+                   [&nameMap](const VertexDescriptor &d) -> std::string { return nameMap[d]; });
+
+    AI_LOG_FN_EXIT();
+    return namesInOrder;
+}
+
+/**
+ * @brief Gets the names of the plugins in reversed order of their dependency.
+ *
+ * "Reversed order of dependency" here means that if plugin A depends on plugin B, plugin B will be placed
+ * after plugin A in the returned vector, e.g. with this code:
+ * @code
+ * DobbyRdkPluginDependencySolver solver;
+ * solver.addPlugin("AppServices");
+ * solver.addPlugin("Networking");
+ * solver.addPlugin("IPC");
+ * solver.addDependency("AppServices", "Networking");
+ * solver.addDependency("Networking", "IPC");
+ *
+ * const std::vector<std::string> inReversedOrder = solver.getReversedOrderOfDependency();
+ * @endcode,
+ * @code inOrder @endcode is @code { "AppServices", "Networking", "IPC" } @endcode.
+ *
+ * If there is a dependency cycle, an error message is printed and the function returns an empty vector.
+ *
+ * @return Names of the plugins in reversed order of dependency. Empty vector if no plugins have been added or a
+ * dependency cycle has been detected. Vector with plugin names in the same order in which they were added
+ * if no dependencies have been added).
+ */
+std::vector<std::string> DobbyRdkPluginDependencySolver::getReversedOrderOfDependency() const
+{
+    AI_LOG_FN_ENTRY();
+
+    std::vector<std::string> namesInReversedOrder = getOrderOfDependency();
+    std::reverse(namesInReversedOrder.begin(), namesInReversedOrder.end());
+
+    AI_LOG_FN_EXIT();
+    return namesInReversedOrder;
+}

--- a/rdkPlugins/Common/include/DobbyLoggerBase.h
+++ b/rdkPlugins/Common/include/DobbyLoggerBase.h
@@ -180,6 +180,21 @@ public:
     {
         return true;
     };
+
+public:
+    /**
+     * @brief Should return the names of the plugins this plugin depends on.
+     *
+     * This can be used to determine the order in which the plugins should be
+     * processed when running hooks.
+     *
+     * @return Names of the plugins this plugin depends on.
+     */
+    std::vector<std::string> getDependencies() const override
+    {
+        std::vector<std::string> noDependencies;
+        return noDependencies;
+    }
 };
 
 #endif // !defined(DOBBYLOGGERBASE_H)

--- a/rdkPlugins/Common/include/RdkPluginBase.h
+++ b/rdkPlugins/Common/include/RdkPluginBase.h
@@ -188,6 +188,21 @@ public:
     {
         return true;
     };
+
+public:
+    /**
+     * @brief Should return the names of the plugins this plugin depends on.
+     *
+     * This can be used to determine the order in which the plugins should be
+     * processed when running hooks.
+     *
+     * @return Names of the plugins this plugin depends on.
+     */
+    std::vector<std::string> getDependencies() const override
+    {
+        std::vector<std::string> noDependencies;
+        return noDependencies;
+    }
 };
 
 #endif // !defined(RDKPLUGINBASE_H)

--- a/rdkPlugins/GPU/source/GpuPlugin.cpp
+++ b/rdkPlugins/GPU/source/GpuPlugin.cpp
@@ -133,6 +133,27 @@ bool GpuPlugin::postStop()
 
 // End hook methods
 
+/**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> GpuPlugin::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+    const rt_defs_plugins_gpu* pluginConfig = mContainerConfig->rdk_plugins->gpu;
+
+    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    {
+        dependencies.push_back(pluginConfig->depends_on[i]);
+    }
+
+    return dependencies;
+}
+
 // Begin private methods
 
 // -----------------------------------------------------------------------------

--- a/rdkPlugins/GPU/source/GpuPlugin.h
+++ b/rdkPlugins/GPU/source/GpuPlugin.h
@@ -60,6 +60,9 @@ public:
     bool createRuntime() override;
     bool postStop() override;
 
+public:
+    std::vector<std::string> getDependencies() const override;
+
 private:
     std::string getGpuCgroupMountPoint();
 

--- a/rdkPlugins/HttpProxy/source/HttpProxyPlugin.cpp
+++ b/rdkPlugins/HttpProxy/source/HttpProxyPlugin.cpp
@@ -151,6 +151,28 @@ bool HttpProxyPlugin::postHalt()
 
 // -----------------------------------------------------------------------------
 /**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> HttpProxyPlugin::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+    const rt_defs_plugins_http_proxy* pluginConfig = mContainerConfig->rdk_plugins->httpproxy;
+
+    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    {
+        dependencies.push_back(pluginConfig->depends_on[i]);
+    }
+
+    return dependencies;
+}
+
+// -----------------------------------------------------------------------------
+/**
  *  @brief Adds the httpproxy and no_proxy environment variables to the
  *  container.
  *

--- a/rdkPlugins/HttpProxy/source/HttpProxyPlugin.h
+++ b/rdkPlugins/HttpProxy/source/HttpProxyPlugin.h
@@ -60,6 +60,8 @@ public:
     bool preCreation() override;
     bool postHalt() override;
 
+public:
+    std::vector<std::string> getDependencies() const override;
 
 private:
     bool setupHttpProxy();

--- a/rdkPlugins/IPC/source/IpcPlugin.cpp
+++ b/rdkPlugins/IPC/source/IpcPlugin.cpp
@@ -165,6 +165,27 @@ bool IpcPlugin::postInstallation()
 
 // End hook methods
 
+/**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> IpcPlugin::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+    const rt_defs_plugins_ipc* pluginConfig = mContainerConfig->rdk_plugins->ipc;
+
+    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    {
+        dependencies.push_back(pluginConfig->depends_on[i]);
+    }
+
+    return dependencies;
+}
+
 // Begin private methods
 
 

--- a/rdkPlugins/IPC/source/IpcPlugin.h
+++ b/rdkPlugins/IPC/source/IpcPlugin.h
@@ -57,6 +57,9 @@ public:
 public:
     bool postInstallation() override;
 
+public:
+    std::vector<std::string> getDependencies() const override;
+
 private:
     bool addSocketAndEnv(const std::shared_ptr<DobbyRdkPluginUtils> utils,
                         const std::string& rootfsPath,

--- a/rdkPlugins/LocalTime/source/LocalTimePlugin.cpp
+++ b/rdkPlugins/LocalTime/source/LocalTimePlugin.cpp
@@ -31,7 +31,8 @@ LocalTimePlugin::LocalTimePlugin(std::shared_ptr<rt_dobby_schema> &containerConf
                                  const std::shared_ptr<DobbyRdkPluginUtils> &utils,
                                  const std::string &rootfsPath)
     : mName("LocalTime"),
-      mRootfsPath(rootfsPath)
+      mRootfsPath(rootfsPath),
+      mContainerConfig(containerConfig)
 {
     AI_LOG_FN_ENTRY();
     AI_LOG_FN_EXIT();
@@ -82,3 +83,23 @@ bool LocalTimePlugin::postInstallation()
     return true;
 }
 
+/**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> LocalTimePlugin::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+    const rt_defs_plugins_local_time* pluginConfig = mContainerConfig->rdk_plugins->localtime;
+
+    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    {
+        dependencies.push_back(pluginConfig->depends_on[i]);
+    }
+
+    return dependencies;
+}

--- a/rdkPlugins/LocalTime/source/LocalTimePlugin.h
+++ b/rdkPlugins/LocalTime/source/LocalTimePlugin.h
@@ -47,9 +47,13 @@ public:
 public:
     bool postInstallation() override;
 
+public:
+    std::vector<std::string> getDependencies() const override;
+
 private:
     const std::string mName;
     const std::string mRootfsPath;
+    std::shared_ptr<rt_dobby_schema> mContainerConfig;
 };
 
 #endif // !defined(LOCALTIMEPLUGIN_H)

--- a/rdkPlugins/Logging/source/LoggingPlugin.cpp
+++ b/rdkPlugins/Logging/source/LoggingPlugin.cpp
@@ -93,6 +93,27 @@ bool LoggingPlugin::postInstallation()
 }
 
 /**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> LoggingPlugin::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+    const rt_defs_plugins_logging* pluginConfig = mContainerConfig->rdk_plugins->logging;
+
+    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    {
+        dependencies.push_back(pluginConfig->depends_on[i]);
+    }
+
+    return dependencies;
+}
+
+/**
  * @brief Public method called by DobbyLogger to start running the logging
  * loop. Destination of the logs depends on the settings in the config file.
  *

--- a/rdkPlugins/Logging/source/LoggingPlugin.h
+++ b/rdkPlugins/Logging/source/LoggingPlugin.h
@@ -50,6 +50,9 @@ public:
     bool postInstallation() override;
 
 public:
+    std::vector<std::string> getDependencies() const override;
+
+public:
     // Logging Specific Methods
     void LoggingLoop(IDobbyRdkLoggingPlugin::ContainerInfo containerInfo,
                      const bool isBuffer,

--- a/rdkPlugins/Networking/include/NetworkingPlugin.h
+++ b/rdkPlugins/Networking/include/NetworkingPlugin.h
@@ -57,6 +57,9 @@ public:
     bool createRuntime() override;
     bool postHalt() override;
 
+public:
+    std::vector<std::string> getDependencies() const override;
+
 private:
     bool createRemoteService();
 

--- a/rdkPlugins/Networking/source/NetworkingPlugin.cpp
+++ b/rdkPlugins/Networking/source/NetworkingPlugin.cpp
@@ -377,6 +377,27 @@ bool NetworkingPlugin::postHalt()
 
 // End hook methods
 
+/**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> NetworkingPlugin::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+    const rt_defs_plugins_networking* pluginConfig = mContainerConfig->rdk_plugins->networking;
+
+    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    {
+        dependencies.push_back(pluginConfig->depends_on[i]);
+    }
+
+    return dependencies;
+}
+
 // Begin private methods
 
 /**

--- a/rdkPlugins/RtScheduling/source/RtSchedulingPlugin.cpp
+++ b/rdkPlugins/RtScheduling/source/RtSchedulingPlugin.cpp
@@ -161,3 +161,25 @@ bool RtSchedulingPlugin::createRuntime()
     AI_LOG_FN_EXIT();
     return true;
 }
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> RtSchedulingPlugin::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+    const rt_defs_plugins_rt_scheduling* pluginConfig = mConfig->rdk_plugins->rtscheduling;
+
+    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    {
+        dependencies.push_back(pluginConfig->depends_on[i]);
+    }
+
+    return dependencies;
+}

--- a/rdkPlugins/RtScheduling/source/RtSchedulingPlugin.h
+++ b/rdkPlugins/RtScheduling/source/RtSchedulingPlugin.h
@@ -54,6 +54,9 @@ public:
     bool postInstallation() override;
     bool createRuntime() override;
 
+public:
+    std::vector<std::string> getDependencies() const override;
+
 private:
     const std::string mName;
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -206,6 +206,28 @@ bool Storage::postStop()
 
 // End hook methods
 
+// -----------------------------------------------------------------------------
+/**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> Storage::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+    const rt_defs_plugins_storage* pluginConfig = mContainerConfig->rdk_plugins->storage;
+
+    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    {
+        dependencies.push_back(pluginConfig->depends_on[i]);
+    }
+
+    return dependencies;
+}
+
 // Begin private methods
 
 // -----------------------------------------------------------------------------

--- a/rdkPlugins/Storage/source/Storage.h
+++ b/rdkPlugins/Storage/source/Storage.h
@@ -78,6 +78,9 @@ public:
     // persistent option is selected
     bool postStop() override;
 
+public:
+    std::vector<std::string> getDependencies() const override;
+
     std::vector<LoopMountDetails::LoopMount> getLoopMounts();
     std::vector<std::unique_ptr<LoopMountDetails>> getLoopDetails();
 

--- a/rdkPlugins/TestPlugin/source/TestRdkPlugin.cpp
+++ b/rdkPlugins/TestPlugin/source/TestRdkPlugin.cpp
@@ -207,4 +207,25 @@ bool TestRdkPlugin::postStop()
 
 // End hook methods
 
+/**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> TestRdkPlugin::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+    const rt_defs_plugins_test_rdk_plugin* pluginConfig = mContainerConfig->rdk_plugins->testrdkplugin;
+
+    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    {
+        dependencies.push_back(pluginConfig->depends_on[i]);
+    }
+
+    return dependencies;
+}
+
 // Begin private methods

--- a/rdkPlugins/TestPlugin/source/TestRdkPlugin.h
+++ b/rdkPlugins/TestPlugin/source/TestRdkPlugin.h
@@ -76,6 +76,8 @@ public:
 
     bool postStop() override;
 
+public:
+    std::vector<std::string> getDependencies() const override;
 
 private:
     const std::string mName;


### PR DESCRIPTION
### Description
DobbyRdkPluginManager now processes RDK plugins for a given hook according to the order of plugin dependency. 
Before this change, RDK plugins were processed according to the order in which they are declared in the "RdkPlugins" section of the "defs-plugins" schema file. This can result in hook execution failures when plugin A which depends on plugin B is processed before plugin B. 

After the change, if plugin A depends on plugin B, hooks for plugin B will be run before hooks for plugin A.
This is inverted (A before B) for postHalt and postStop so that the plugins on which other plugins depend are shut down later.

The dependencies can be defined in the container spec. Each plugin spec now contains a "dependsOn" array.
If, for example, plugin A depends on plugins B and C, then plugin A's spec can look like this:
"a": {
    "required": false,
    "dependsOn": [ "b", "c" ],
    "data": {}
}

Dependency cycles are detected and make DobbyRdkPluginManager abort before it starts running the plugin hooks.

### Test Procedure
Create a container spec with "dependsOn" clauses defined for some plugins, use DobbyPluginLauncher to check if hooks are executed according to the order of dependency.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)