### PR TITLE
Fix leaking file descriptors

### DIFF
--- a/bundle/lib/include/DobbyRootfs.h
+++ b/bundle/lib/include/DobbyRootfs.h
@@ -76,10 +76,10 @@ public:
 
     void unmountAllAt(const std::string& pathPrefix);
 
-#if defined(LEGACY_COMPONENTS)
 private:
-    void cleanUp(bool dontRemoveFiles);
+    void cleanUp();
 
+#if defined(LEGACY_COMPONENTS)
     bool createMountPoint(int dirfd, const std::string &path, bool isDirectory) const;
 
     bool createStandardMountPoints(int dirfd) const;

--- a/rdkPlugins/Logging/source/LoggingPlugin.cpp
+++ b/rdkPlugins/Logging/source/LoggingPlugin.cpp
@@ -157,6 +157,15 @@ void LoggingPlugin::LoggingLoop(ContainerInfo containerInfo,
         AI_LOG_SYS_ERROR(errno, "Failed to close connection");
     }
 
+    // If dumping a buffer, DobbyBufferStream will clean up after itself
+    if (!isBuffer && containerInfo.pttyFd > 0 && fcntl(containerInfo.pttyFd, F_GETFD) != -1)
+    {
+        if (close(containerInfo.pttyFd) != 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "Failed to close container ptty fd");
+        }
+    }
+
     AI_LOG_FN_EXIT();
 }
 


### PR DESCRIPTION
### Description
Stop Dobby leaking file descriptors.

The logging plugin and `DobbyRootfs` were not correctly closing open fds when containers exited, meaning the amount of fds in use by Dobby would increase by 2 each time a container was launched and stopped.

### Test Procedure
Run DobbyDaemon with the following valgrind command:
```
sudo valgrind --tool=memcheck --tool=callgrind --track-fds=yes DobbyDaemon -v --nofork
```
Launch and stop a number of containers repeatedly then close the daemon with Ctrl+C.

With the PR applied, Dobby should always exit with 11 open fds.
```
==30666== FILE DESCRIPTORS: 11 open at exit.
```

Without the PR, this number would increase by 2 for each container launched.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)