### PR TITLE
Always add /sys mount

### DIFF
--- a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
@@ -158,7 +158,7 @@ static const char* ociJsonTemplate = R"JSON(
                 "mode=1777",
                 "nr_inodes=8k"
             ]
-        },{{#NETNS_ENABLED}}
+        },
         {
             "destination": "/sys",
             "type": "sysfs",
@@ -169,7 +169,7 @@ static const char* ociJsonTemplate = R"JSON(
                 "nodev",
                 "ro"
             ]
-        },{{/NETNS_ENABLED}}
+        },
         {
             "destination": "/sys/fs/cgroup",
             "type": "cgroup",

--- a/rdkPlugins/Networking/include/NetworkSetup.h
+++ b/rdkPlugins/Networking/include/NetworkSetup.h
@@ -67,8 +67,6 @@ namespace NetworkSetup
     bool removeBridgeDevice(const std::shared_ptr<Netfilter> &netfilter,
                             const std::vector<std::string> &extIfaces);
 
-    void addSysfsMount(const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                       const std::shared_ptr<rt_dobby_schema> &cfg);
     void addResolvMount(const std::shared_ptr<DobbyRdkPluginUtils> &utils,
                         const std::shared_ptr<rt_dobby_schema> &cfg);
 

--- a/rdkPlugins/Networking/source/NetworkSetup.cpp
+++ b/rdkPlugins/Networking/source/NetworkSetup.cpp
@@ -1010,37 +1010,6 @@ bool NetworkSetup::removeBridgeDevice(const std::shared_ptr<Netfilter> &netfilte
 
 // -----------------------------------------------------------------------------
 /**
- *  @brief Adds a mount to sysfs in the OCI config
- *
- *  @param[in]  utils           Instance of DobbyRdkPluginUtils.
- *  @param[in]  cfg             Pointer to bundle config struct
- */
-void NetworkSetup::addSysfsMount(const std::shared_ptr<DobbyRdkPluginUtils> &utils,
-                                 const std::shared_ptr<rt_dobby_schema> &cfg)
-{
-    const std::string source = "sysfs";
-    const std::string destination = "/sys";
-
-    // iterate through the mounts to check that the mount doesn't already exist
-    for (int i=0; i < cfg->mounts_len; i++)
-    {
-        if (!strcmp(cfg->mounts[i]->source, source.c_str()) &&
-            !strcmp(cfg->mounts[i]->destination, destination.c_str()))
-        {
-            AI_LOG_DEBUG("sysfs mount already exists in the config");
-            return;
-        }
-    }
-
-    // add the mount
-    utils->addMount(source, destination, "sysfs",
-                    { "nosuid", "noexec", "nodev", "ro" }
-    );
-}
-
-
-// -----------------------------------------------------------------------------
-/**
  *  @brief Adds a mount to /etc/resolv.conf
  *
  *  @param[in]  utils           Instance of DobbyRdkPluginUtils.

--- a/rdkPlugins/Networking/source/NetworkingPlugin.cpp
+++ b/rdkPlugins/Networking/source/NetworkingPlugin.cpp
@@ -126,9 +126,6 @@ bool NetworkingPlugin::postInstallation()
     // if the network type is not 'open', enable network namespacing in OCI config
     if (mNetworkType != NetworkType::Open)
     {
-        // add mount to sysfs
-        NetworkSetup::addSysfsMount(mUtils, mContainerConfig);
-
         // add /etc/resolv.conf mount if not using dnsmasq. If dnsmasq is enabled,
         // a new /etc/resolv.conf is created rather than mounting the host's
         if (!mPluginData->dnsmasq)


### PR DESCRIPTION
### Description
The /sys mount was conditionally compiled out of the OCI config template
and then added by the Networking plugin if network namespacing was enabled.
Because of that, the /sys mount was appended to the end of the mounts array
and processed after the /sys/fs/cgroup mount. As a result, the /sys/fs/cgroup
mount was failing.

Remove the conditional include of the /sys mount from the template and
the mount logic from the Networking plugin. The mount is now always added
in the proper place of the mount config array, i.e. before the /sys/fs/cgroup
mount.

### Test Procedure
Create a container with a cgroup mount defined in the config, check if the cgroup
directory is visible in the container's file system.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)