### PR TITLE
RDK-32028: Add ION Memory Plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ option(PLUGIN_GPU "Include GPU plugin" OFF)
 option(PLUGIN_LOCALTIME "Include LocalTime plugin" OFF)
 option(PLUGIN_RTSCHEDULING "Include RtScheduling plugin" OFF)
 option(PLUGIN_HTTPPROXY "Include HttpProxy plugin" OFF)
+option(PLUGIN_IONMEMORY "Include ION Memory plugin" ON)
 
 if(PLUGIN_TESTPLUGIN)
     add_subdirectory(rdkPlugins/TestPlugin)
@@ -321,6 +322,10 @@ endif()
 
 if(PLUGIN_HTTPPROXY)
     add_subdirectory(rdkPlugins/HttpProxy)
+endif()
+
+if(PLUGIN_IONMEMORY)
+    add_subdirectory(rdkPlugins/IONMemory)
 endif()
 
 # Export targets in Dobby package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ option(PLUGIN_LOCALTIME "Include LocalTime plugin" OFF)
 option(PLUGIN_RTSCHEDULING "Include RtScheduling plugin" OFF)
 option(PLUGIN_HTTPPROXY "Include HttpProxy plugin" OFF)
 option(PLUGIN_APPSERVICES "Include AppServices plugin" OFF)
-option(PLUGIN_IONMEMORY "Include ION Memory plugin" ON)
+option(PLUGIN_IONMEMORY "Include ION Memory plugin" OFF)
 
 if(PLUGIN_TESTPLUGIN)
     add_subdirectory(rdkPlugins/TestPlugin)

--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -61,6 +61,44 @@
                 }
             }
         },
+        "IONMemory": {
+            "type": "object",
+            "required": [
+                "required",
+                "data"
+            ],
+            "properties": {
+                "required": {
+                    "type": "boolean"
+                },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "defaultLimit": {
+                            "$ref": "defs.json#/definitions/uint64"
+                        },
+                        "heaps": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "name",
+                                    "limit"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "limit": {
+                                        "$ref": "defs.json#/definitions/uint64"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "IPC": {
             "type": "object",
             "required": [
@@ -392,6 +430,9 @@
                 },
                 "gpu": {
                     "$ref": "#/definitions/GPU"
+                },
+                "ionmemory": {
+                    "$ref": "#/definitions/IONMemory"
                 },
                 "logging": {
                     "$ref": "#/definitions/Logging"

--- a/rdkPlugins/GPU/README.md
+++ b/rdkPlugins/GPU/README.md
@@ -22,3 +22,4 @@ If you already have other RDK plugins in the bundle, then just add the gpu plugi
 
 The GPU plugin assumes that a custom `gpu` cgroup is in place, with the graphics drivers supporting the behaviour of using at least `gpu.limit_in_bytes` to limit the gpu memory.
 
+Requires a version of crun with [PR 609](https://github.com/containers/crun/pull/609) applied to ensure cgroup controllers are mounted correctly.

--- a/rdkPlugins/GPU/source/GpuPlugin.cpp
+++ b/rdkPlugins/GPU/source/GpuPlugin.cpp
@@ -218,61 +218,16 @@ std::string GpuPlugin::getGpuCgroupMountPoint()
 
 // -----------------------------------------------------------------------------
 /**
- *  @brief Called in the mount namespace of the container
- *
- *  crun mounts the gpu cgroup in the container, but it's the root of the
- *  cgroup tree rather than the cgroup created for the container.
- *
- *  For example this is the mount layout setup by crun:
- *
- *      /sys/fs/cgroup/cpu/<ID>    -> <ROOTFS>/sys/fs/cgroup/freezer
- *      /sys/fs/cgroup/memory/<ID> -> <ROOTFS>/sys/fs/cgroup/memory
- *      /sys/fs/cgroup/gpu         -> <ROOTFS>/sys/fs/cgroup/gpu
- *      ...
- *
- *  We want it to be:
- *
- *      /sys/fs/cgroup/gpu/<ID>    -> <ROOTFS>/sys/fs/cgroup/gpu
- *      ...
- *
- *  So we need to replace the existing gpu mount with the cgroup for this
- *  container.
- *
- *  NB: this is not a security thing, but if we don't do this, the app inside
- *  the container would have to know it's container id to monitor its own usage
- *  usage. This is a problem for apps which expect the cgroup to be mounted for
- *  the container only.
- *
- *  @param[in]  source      The source path of the cgroup.
- *  @param[in]  target      The target mount point.
- *
- *  @return true if successful, otherwise false.
- */
-bool GpuPlugin::bindMountGpuCgroup(const std::string &source,
-                                   const std::string &target)
-{
-    AI_LOG_FN_ENTRY();
-
-    // try and do the bind mount
-    if (mount(source.c_str(), target.c_str(), nullptr, MS_BIND, nullptr) < 0)
-    {
-        AI_LOG_SYS_ERROR(errno, "failed to bind mount '%s' to '%s'",
-                         source.c_str(), target.c_str());
-        return false;
-    }
-
-    AI_LOG_DEBUG("bind mounted '%s' to '%s'", source.c_str(), target.c_str());
-
-    AI_LOG_FN_EXIT();
-    return true;
-}
-
-// -----------------------------------------------------------------------------
-/**
  *  @brief Creates a gpu cgroup for the container and moves the container into
  *  it.
  *
  *  The cgroup is given the same name as the container.
+ *
+ *  @warning This requires a version of crun with the following PR:
+ *  https://github.com/containers/crun/pull/609 to ensure cgroup controllers are
+ *  correctly mounted. Without the PR applied, the GPU cgroup is mounted incorrectly,
+ *  see https://github.com/containers/crun/issues/625 for more info
+ *
  *
  *  @param[in]  cgroupDirPath   Path to the gpu cgroup directory.
  *  @param[in]  containerPid    The pid of the process in the container.
@@ -286,14 +241,11 @@ bool GpuPlugin::setupContainerGpuLimit(const std::string cgroupDirPath,
 {
     AI_LOG_FN_ENTRY();
 
-    // setup the paths for the bind mount, i.e.
-    //   source:   "/sys/fs/cgroup/gpu/<id>"
-    //   target:   "/sys/fs/cgroup/gpu"
-    const std::string sourcePath(cgroupDirPath + "/" + mUtils->getContainerId());
-    const std::string targetPath(cgroupDirPath);
+    // setup the paths for the cgroup, i.e. "/sys/fs/cgroup/gpu/<id>"
+    const std::string cgroupPath(cgroupDirPath + "/" + mUtils->getContainerId());
 
     // create a new cgroup (we're ok with it already existing)
-    if ((mkdir(sourcePath.c_str(), 0755) != 0) && (errno != EEXIST))
+    if ((mkdir(cgroupPath.c_str(), 0755) != 0) && (errno != EEXIST))
     {
         AI_LOG_SYS_ERROR_EXIT(errno, "failed to create gpu cgroup dir '%s'",
                               mUtils->getContainerId().c_str());
@@ -301,7 +253,7 @@ bool GpuPlugin::setupContainerGpuLimit(const std::string cgroupDirPath,
     }
 
     // move the containered pid into the new cgroup
-    const std::string procsPath = sourcePath + "/cgroup.procs";
+    const std::string procsPath = cgroupPath + "/cgroup.procs";
     if (!mUtils->writeTextFile(procsPath, std::to_string(containerPid),
                                O_CREAT | O_TRUNC, 0700))
     {
@@ -311,21 +263,12 @@ bool GpuPlugin::setupContainerGpuLimit(const std::string cgroupDirPath,
     }
 
     // set the gpu memory limit on the container
-    const std::string gpulimitPath = sourcePath + "/gpu.limit_in_bytes";
+    const std::string gpulimitPath = cgroupPath + "/gpu.limit_in_bytes";
     if (!mUtils->writeTextFile(gpulimitPath, std::to_string(memoryLimit),
                                O_CREAT | O_TRUNC, 0700))
     {
         AI_LOG_ERROR_EXIT("failed to set the gpu memory limit for container "
                           "'%s'", mUtils->getContainerId().c_str());
-        return false;
-    }
-
-    // bind mount the container specific cgroup into the container
-    if (!mUtils->callInNamespace(containerPid, CLONE_NEWNS,
-                                 &GpuPlugin::bindMountGpuCgroup,
-                                 this, sourcePath, targetPath))
-    {
-        AI_LOG_ERROR_EXIT("hook failed to enter mount namespace");
         return false;
     }
 

--- a/rdkPlugins/IONMemory/CMakeLists.txt
+++ b/rdkPlugins/IONMemory/CMakeLists.txt
@@ -1,0 +1,39 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2021 Sky UK
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reference CMake file for the simplest Dobby RDK Plugin
+
+# Project name should match the name of the plugin
+# CMake will prefix this with "lib"
+project(IonMemoryPlugin)
+
+add_library( ${PROJECT_NAME}
+        SHARED
+        source/IonMemoryPlugin.cpp
+        )
+
+install(
+        TARGETS ${PROJECT_NAME}
+        LIBRARY DESTINATION lib/plugins/dobby
+        NAMELINK_SKIP
+        )
+
+target_link_libraries(${PROJECT_NAME}
+        DobbyRdkPluginCommonLib
+)
+
+set_target_properties( ${PROJECT_NAME} PROPERTIES SOVERSION 1 )

--- a/rdkPlugins/IONMemory/README.md
+++ b/rdkPlugins/IONMemory/README.md
@@ -1,0 +1,40 @@
+# Dobby RDK ION Memory Limits Plugin
+
+## Quick Start
+Add the following section to your OCI runtime configuration `config.json` file to set gpu memory limits for your container. This will create a gpu cgroup for the container and set limits
+
+```json
+{
+    "rdkPlugins": {
+        "ionmemory": {
+            "required": true,
+            "data": {
+                "defaultLimit": 0,
+                "heaps": [
+                    {
+                        "name": "System",
+                        "limit": 64345345
+                    }
+                ]
+            }
+        }
+    }
+}
+```
+
+If you already have other RDK plugins in the bundle, then just add the ionmemory plugin. Do not create multiple `rdkPlugin` sections.
+
+## Prerequisites
+ION is a large memory allocator driver that is used on Android and other platforms to allocate big chunks of memory for media and graphics buffers. It divides memory into pools / heaps and allows both kernel drivers and userspace apps to allocate memory buffers.  The buffers can then be passed around and mapped using file descriptors.  More information on ION is available [here](https://lwn.net/Articles/480055/).
+
+The ION plugin assumes that a custom `ion` cgroup is in place, with the kernel supporting the behaviour of using at least `ion.<HEAP>.limit_in_bytes` to limit the memory allocated from the given heap.
+
+Requires a version of crun with [PR 609](https://github.com/containers/crun/pull/609) applied to ensure cgroup controllers are mounted correctly.
+
+## Options
+
+### Default Limit [Required]
+This limit (in bytes) applies to all heaps by default. If a specific heap limit is not provided, the heap limit is set to this value.
+
+### Heaps
+An array of heaps with their name and the memory limit (in bytes) for that specific heap. This overrides the default limit for that heap.

--- a/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
+++ b/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
@@ -220,7 +220,6 @@ std::string IonMemoryPlugin::findIonCGroupMountPoint() const
             continue;
 
         AI_LOG_INFO("found ION cgroup mounted @ '%s'", mnt->mnt_dir);
-        AI_LOG_WARN("found ION cgroup mounted @ '%s'", mnt->mnt_dir);
 
         path = mnt->mnt_dir;
         break;
@@ -243,7 +242,7 @@ std::string IonMemoryPlugin::findIonCGroupMountPoint() const
  *
  *  @param[in]  id              The id of the container.
  *  @param[in]  containerPid    The pid of the process in the container.
- *  @param[in]  heapLimits      Map of the heap name to it's limits.
+ *  @param[in]  heapLimits      Map of the heap name to its limits.
  *  @param[in]  defaultLimit    The default limit to set on a heap if not in the
  *                              heapLimits map.
  *
@@ -297,7 +296,7 @@ bool IonMemoryPlugin::setupContainerIonLimits(const std::string &cGroupDirPath,
 
     // loop through all the heaps and set either the default limit or the
     // individual heap limit
-    const std::regex limitRegex(R"regex(^ion\.\w+\.limit_in_bytes$)regex");
+    const std::regex limitRegex(R"regex(^ion\.\(w+)\.limit_in_bytes$)regex");
 
     struct dirent *entry;
     while ((entry = readdir(dir)) != nullptr)
@@ -323,27 +322,14 @@ bool IonMemoryPlugin::setupContainerIonLimits(const std::string &cGroupDirPath,
             {
                 AI_LOG_INFO("setting no limit on ION heap '%s' for container '%s'",
                             heapName.c_str(), containerId.c_str());
-                AI_LOG_WARN("setting no limit on ION heap '%s' for container '%s'",
-                            heapName.c_str(), containerId.c_str());
             }
             else
             {
                 AI_LOG_INFO("setting ion heap '%s' limit to %llukb for container '%s'",
                             heapName.c_str(), limit / 1024, containerId.c_str());
-                AI_LOG_WARN("setting ion heap '%s' limit to %llukb for container '%s'",
-                            heapName.c_str(), limit / 1024, containerId.c_str());
             }
 
             // set the ION heap memory limit on the container
-#if 0
-            if (!writeCgroupFile(dirfd(dir), entry->d_name, limit))
-            {
-                AI_LOG_ERROR("failed to set the ion heap '%s' memory limit for container "
-                             "'%s'", heapName.c_str(), containerId.c_str());
-
-                // FIXME: if a failure should we abort container start?
-            }
-#else
             const std::string filePath = sourcePath + "/" + entry->d_name;
             if (!mUtils->writeTextFile(filePath, std::to_string(limit),
                                O_CREAT | O_TRUNC, 0700))
@@ -352,7 +338,6 @@ bool IonMemoryPlugin::setupContainerIonLimits(const std::string &cGroupDirPath,
                              "'%s'", heapName.c_str(), containerId.c_str());
                 return false;
             }
-#endif
         }
 
     }
@@ -396,8 +381,8 @@ bool IonMemoryPlugin::setupContainerIonLimits(const std::string &cGroupDirPath,
  *  for this container.
  *
  *  Nb this is not a security thing, but if we don't do this the app inside
- *  the container would have to know it's container id so it could monitor
- *  it's own usage, this is a problem for existing sky apps (like the EPG)
+ *  the container would have to know its container id so it could monitor
+ *  its own usage, this is a problem for existing sky apps (like the EPG)
  *  which expects the cgroup to be mounted for the container only.
  *
  *  @param[in]  source      The source path of the cgroup.

--- a/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
+++ b/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
@@ -297,7 +297,7 @@ bool IonMemoryPlugin::setupContainerIonLimits(const std::string &cGroupDirPath,
 
     // loop through all the heaps and set either the default limit or the
     // individual heap limit
-    const std::regex limitRegex(R"regex(^ion\.\(w+)\.limit_in_bytes$)regex");
+    const std::regex limitRegex(R"regex((ion\.)(\w+)(\.limit_in_bytes))regex");
 
     struct dirent *entry;
     while ((entry = readdir(dir)) != nullptr)
@@ -309,9 +309,10 @@ bool IonMemoryPlugin::setupContainerIonLimits(const std::string &cGroupDirPath,
         // check if it is a heap's limit file
         std::cmatch matches;
         if (std::regex_match(entry->d_name, matches, limitRegex) &&
-            (matches.size() == 2))
+            (matches.size() == 4))
         {
-            const std::string heapName = matches.str(1);
+            const std::string heapName = matches.str(2);
+
             uint64_t limit = defaultLimit;
 
             // get the limit for this heap

--- a/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
+++ b/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
@@ -1,0 +1,435 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2021 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "IonMemoryPlugin.h"
+
+#include <map>
+#include <regex>
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <mntent.h>
+#include <unistd.h>
+#include <linux/limits.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+/**
+ * Need to do this at the start of every plugin to make sure the correct
+ * C methods are visible to allow PluginLauncher to find the plugin
+ */
+REGISTER_RDK_PLUGIN(IonMemoryPlugin);
+
+/**
+ * @brief Constructor - called when plugin is loaded by PluginLauncher
+ *
+ * Do not change the parameters for this constructor - must match C methods
+ * created by REGISTER_RDK_PLUGIN macro
+ *
+ * Note plugin name is not case sensitive
+ */
+IonMemoryPlugin::IonMemoryPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
+                                 const std::shared_ptr<DobbyRdkPluginUtils> &utils,
+                                 const std::string &rootfsPath)
+    : mName("IonMemory"),
+      mContainerConfig(containerConfig),
+      mUtils(utils),
+      mRootfsPath(rootfsPath)
+{
+    AI_LOG_FN_ENTRY();
+
+    if (mContainerConfig == nullptr ||
+        mContainerConfig->rdk_plugins->ionmemory == nullptr ||
+        mContainerConfig->rdk_plugins->ionmemory->data == nullptr)
+    {
+        AI_LOG_ERROR_EXIT("Invalid container config");
+        mValid = false;
+    }
+    else
+    {
+        mPluginData = mContainerConfig->rdk_plugins->ionmemory->data;
+        mValid = true;
+    }
+
+    AI_LOG_FN_EXIT();
+}
+
+/**
+ * @brief Set the bit flags for which hooks we're going to use
+ *
+ */
+unsigned IonMemoryPlugin::hookHints() const
+{
+    return (
+        IDobbyRdkPlugin::HintFlags::CreateRuntimeFlag |
+        IDobbyRdkPlugin::HintFlags::PostStopFlag);
+}
+
+//
+/**
+ *  @brief Attempts to get the mount points of the ION cgroup filesystem.
+ *
+ *  This scans the mount table looking for the cgroups mounts. This is typically
+ *  the name of the cgroup prefixed with "/sys/fs/cgroup"
+ *
+ *  @return path to the ION cgroup mount, or empty string if failed to find it.
+ */
+std::string IonMemoryPlugin::findIonCGroupMountPoint() const
+{
+    AI_LOG_FN_ENTRY();
+
+    // try and open /proc/mounts for scanning the current mount table
+    FILE* procMounts = setmntent("/proc/mounts", "r");
+    if (procMounts == nullptr)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "failed to open '/proc/mounts' file");
+        return std::string();
+    }
+
+    // loop over all the mounts
+    struct mntent mntBuf;
+    struct mntent* mnt;
+    char buf[PATH_MAX + 256];
+    std::string path;
+
+    while ((mnt = getmntent_r(procMounts, &mntBuf, buf, sizeof(buf))) != nullptr)
+    {
+        // skip entries that don't have a mountpount, type or options
+        if (!mnt->mnt_type || !mnt->mnt_dir || !mnt->mnt_opts)
+            continue;
+
+        // skip non-cgroup mounts
+        if (strcmp(mnt->mnt_type, "cgroup") != 0)
+            continue;
+
+        // check if the ion cgroup
+        char* mntopt = hasmntopt(mnt, "ion");
+        if (!mntopt || (strcmp(mntopt, "ion") != 0))
+            continue;
+
+        AI_LOG_INFO("found ION cgroup mounted @ '%s'", mnt->mnt_dir);
+        AI_LOG_WARN("found ION cgroup mounted @ '%s'", mnt->mnt_dir);
+
+        path = mnt->mnt_dir;
+        break;
+    }
+
+    endmntent(procMounts);
+
+    AI_LOG_FN_EXIT();
+    return path;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Creates a ion cgroup for the container and moves the container into
+ *  it.
+ *
+ *  The amount of memory to assign is retrieved from the config object.
+ *
+ *  The cgroup is given the same name as the container.
+ *
+ *  @param[in]  id              The id of the container.
+ *  @param[in]  containerPid    The pid of the process in the container.
+ *  @param[in]  heapLimits      Map of the heap name to it's limits.
+ *  @param[in]  defaultLimit    The default limit to set on a heap if not in the
+ *                              heapLimits map.
+ *
+ *  @return true if successful otherwise false.
+ */
+bool IonMemoryPlugin::setupContainerIonLimits(const std::string &cGroupDirPath,
+                                              pid_t containerPid,
+                                              const std::map<std::string, uint64_t> &heapLimits,
+                                              uint64_t defaultLimit)
+{
+    const std::string containerId = mUtils->getContainerId();
+    // setup the paths for the bind mount, i.e.
+    //   source:   "/sys/fs/cgroup/ion/<id>"
+    //   target:   "/sys/fs/cgroup/ion"
+    const std::string sourcePath(cGroupDirPath + "/" + containerId);
+    const std::string targetPath(cGroupDirPath);
+
+    // create a new cgroup (we're 'sort of' ok with it already existing)
+    if ((mkdir(sourcePath.c_str(), 0755) != 0) && (errno != EEXIST))
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "failed to create gpu cgroup dir '%s'",
+                              containerId.c_str());
+        return false;
+    }
+
+    // move the containered pid into the new cgroup
+    const std::string procsPath = sourcePath + "/cgroup.procs";
+    if (!mUtils->writeTextFile(procsPath, std::to_string(containerPid),
+                               O_CREAT | O_TRUNC, 0700))
+    {
+        AI_LOG_ERROR_EXIT("failed to put the container '%s' into the cgroup",
+                          containerId.c_str());
+        return false;
+    }
+
+    // open the directory to iterate through all the heaps
+    int dirFd = open(sourcePath.c_str(),O_CLOEXEC | O_DIRECTORY);
+    if (dirFd < 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "failed to re-open the ion cgroup dir?");
+        return false;
+    }
+
+    DIR *dir = fdopendir(dirFd);
+    if (!dir)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "failed to re-open the ion cgroup dir?");
+        close(dirFd);
+        return false;
+    }
+
+    // loop through all the heaps and set either the default limit or the
+    // individual heap limit
+    const std::regex limitRegex(R"regex(^ion\.\w+\.limit_in_bytes$)regex");
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != nullptr)
+    {
+        // only care about sysfs files
+        if (entry->d_type != DT_REG)
+            continue;
+
+        // check if it is a heap's limit file
+        std::cmatch matches;
+        if (std::regex_match(entry->d_name, matches, limitRegex) &&
+            (matches.size() == 2))
+        {
+            const std::string heapName = matches.str(1);
+            uint64_t limit = defaultLimit;
+
+            // get the limit for this heap
+            auto it = heapLimits.find(heapName);
+            if (it != heapLimits.end())
+                limit = it->second;
+
+            if (limit == UINT64_MAX)
+            {
+                AI_LOG_INFO("setting no limit on ION heap '%s' for container '%s'",
+                            heapName.c_str(), containerId.c_str());
+                AI_LOG_WARN("setting no limit on ION heap '%s' for container '%s'",
+                            heapName.c_str(), containerId.c_str());
+            }
+            else
+            {
+                AI_LOG_INFO("setting ion heap '%s' limit to %llukb for container '%s'",
+                            heapName.c_str(), limit / 1024, containerId.c_str());
+                AI_LOG_WARN("setting ion heap '%s' limit to %llukb for container '%s'",
+                            heapName.c_str(), limit / 1024, containerId.c_str());
+            }
+
+            // set the ION heap memory limit on the container
+#if 0
+            if (!writeCgroupFile(dirfd(dir), entry->d_name, limit))
+            {
+                AI_LOG_ERROR("failed to set the ion heap '%s' memory limit for container "
+                             "'%s'", heapName.c_str(), containerId.c_str());
+
+                // FIXME: if a failure should we abort container start?
+            }
+#else
+            const std::string filePath = sourcePath + "/" + entry->d_name;
+            if (!mUtils->writeTextFile(filePath, std::to_string(limit),
+                               O_CREAT | O_TRUNC, 0700))
+            {
+                AI_LOG_ERROR("failed to set the ion heap '%s' memory limit for container "
+                             "'%s'", heapName.c_str(), containerId.c_str());
+                return false;
+            }
+#endif
+        }
+
+    }
+
+    // clean the dir iterator
+    closedir(dir);
+
+    // bind mount the container specific cgroup into the container
+    if (!mUtils->callInNamespace(containerPid, CLONE_NEWNS,
+                                 &IonMemoryPlugin::bindMountCGroup,
+                                 this, sourcePath, targetPath))
+    {
+        AI_LOG_ERROR_EXIT("hook failed to enter mount namespace");
+        return false;
+    }
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Called in the mount namespace of the container
+ *
+ *  The runc tool does mount the ion cgroup in the container, but it's the
+ *  root of the cgroup tree rather than the cgroup created for the container.
+ *
+ *  For example this is the mount layout setup by runc:
+ *
+ *      /sys/fs/cgroup/cpu/<ID>    -> <ROOTFS>/sys/fs/cgroup/cpu
+ *      /sys/fs/cgroup/memory/<ID> -> <ROOTFS>/sys/fs/cgroup/memory
+ *      /sys/fs/cgroup/ion         -> <ROOTFS>/sys/fs/cgroup/ion
+ *      ...
+ *
+ *  We want it to be:
+ *
+ *      /sys/fs/cgroup/ion/<ID>    -> <ROOTFS>/sys/fs/cgroup/ion
+ *      ...
+ *
+ *  So we need to umount the existing ion mount and replace it with the cgroup
+ *  for this container.
+ *
+ *  Nb this is not a security thing, but if we don't do this the app inside
+ *  the container would have to know it's container id so it could monitor
+ *  it's own usage, this is a problem for existing sky apps (like the EPG)
+ *  which expects the cgroup to be mounted for the container only.
+ *
+ *  @param[in]  source      The source path of the cgroup.
+ *  @param[in]  target      The target mount point.
+ *
+ */
+bool IonMemoryPlugin::bindMountCGroup(const std::string &source,
+                                      const std::string &target) const
+{
+    AI_LOG_FN_ENTRY();
+
+    // now try and do the bind mount
+    if (mount(source.c_str(), target.c_str(), nullptr, MS_BIND, nullptr) != 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "failed to bind mount '%s' to '%s'",
+                         source.c_str(), target.c_str());
+    }
+    else
+    {
+        AI_LOG_INFO("bind mounted '%s' to '%s'", source.c_str(),
+                    target.c_str());
+        return false;
+    }
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+// Begin Hook Methods
+
+/**
+ * @brief OCI Hook - Run in host namespace
+ */
+bool IonMemoryPlugin::createRuntime()
+{
+    AI_LOG_FN_ENTRY();
+
+    if (!mValid)
+    {
+        AI_LOG_ERROR_EXIT("Invalid container config");
+        return false;
+    }
+
+    const std::string cgroupDirPath = findIonCGroupMountPoint();
+
+    // sanity check we have an ION cgroup dir
+    if (cgroupDirPath.empty())
+    {
+        AI_LOG_ERROR_EXIT("missing cgroup directory");
+        return false;
+    }
+
+    // get the container pid
+    pid_t containerPid = mUtils->getContainerPid();
+    if (!containerPid)
+    {
+        AI_LOG_ERROR_EXIT("couldn't find container pid");
+        return false;
+    }
+
+    // get the default limit and heap limits
+    const uint64_t defaultLimitValue = mPluginData->default_limit_present ? mPluginData->default_limit : UINT64_MAX;
+    std::map<std::string, uint64_t> heapLimits;
+    for (size_t i = 0; i < mPluginData->heaps_len; i++)
+    {
+        const rt_defs_plugins_ion_memory_data_heaps_element* heap = mPluginData->heaps[i];
+        const char* heapName = heap->name;
+        const uint64_t heapLimit = heap->limit;
+
+        heapLimits[heapName] = heapLimit;
+    }
+
+    // setup the gpu memory limit
+    // setupContainerGpuLimit(cgroupDirPath, containerPid, memLimit);
+
+    // finally apply the limits
+    return setupContainerIonLimits(cgroupDirPath, containerPid, heapLimits, defaultLimitValue);
+
+    AI_LOG_FN_EXIT();
+    return true;
+
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Poststop hook, we use this point to remove the cgroup directory
+ *  created in the pre start phase.
+ *
+ *  The directory will have the same name as the container id.
+ *
+ *  @param[in]  id              The id of the container.
+ *  @param[in]  config          The container config.
+ *  @param[in]  rootfs          The path to the container rootfs.
+ *
+ *  @return true if successful otherwise false.
+ */
+bool IonMemoryPlugin::postStop()
+{
+    AI_LOG_FN_ENTRY();
+
+    const std::string cgroupDirPath = findIonCGroupMountPoint();
+
+    // sanity check we have a cgroup dir
+    if (cgroupDirPath.empty())
+    {
+        AI_LOG_ERROR_EXIT("missing cgroup directory");
+        return false;
+    }
+
+    // remove the container's cgroup directory
+    const std::string cgroupPath = cgroupDirPath + "/" + mUtils->getContainerId();
+    if (rmdir(cgroupPath.c_str()) < 0)
+    {
+        // we could be called at stop time even though the createRuntime hook
+        // wasn't called due to an earlier plugin failing ... so don't report
+        // an error if the directory didn't exist
+        if (errno != ENOENT)
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to delete cgroup dir '%s'",
+                             mUtils->getContainerId().c_str());
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+// End hook methods
+
+// Begin private methods

--- a/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
+++ b/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
@@ -48,7 +48,6 @@ IonMemoryPlugin::IonMemoryPlugin(std::shared_ptr<rt_dobby_schema> &containerConf
         mContainerConfig->rdk_plugins->ionmemory == nullptr ||
         mContainerConfig->rdk_plugins->ionmemory->data == nullptr)
     {
-        AI_LOG_ERROR_EXIT("Invalid container config");
         mValid = false;
     }
     else

--- a/rdkPlugins/IONMemory/source/IonMemoryPlugin.h
+++ b/rdkPlugins/IONMemory/source/IonMemoryPlugin.h
@@ -38,7 +38,7 @@
 class IonMemoryPlugin final : public RdkPluginBase
 {
 public:
-    IonMemoryPlugin(std::shared_ptr<rt_dobby_schema>& containerConfig,
+    IonMemoryPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
                     const std::shared_ptr<DobbyRdkPluginUtils> &utils,
                     const std::string &rootfsPath);
 
@@ -56,8 +56,6 @@ public:
 
 private:
     std::string findIonCGroupMountPoint() const;
-    bool bindMountCGroup(const std::string& source,
-                         const std::string& target) const;
     bool setupContainerIonLimits(const std::string &cGroupDirPath,
                                  pid_t containerPid,
                                  const std::map<std::string, uint64_t> &heapLimits,
@@ -70,7 +68,7 @@ private:
     const std::string mRootfsPath;
 
     bool mValid;
-    const rt_defs_plugins_ion_memory_data* mPluginData;
+    const rt_defs_plugins_ion_memory_data *mPluginData;
 };
 
 #endif // !defined(IONMEMORYPLUGIN_H)

--- a/rdkPlugins/IONMemory/source/IonMemoryPlugin.h
+++ b/rdkPlugins/IONMemory/source/IonMemoryPlugin.h
@@ -1,0 +1,77 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2021 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File: IonMemoryPlugin.h
+ *
+ */
+#ifndef IONMEMORYPLUGIN_H
+#define IONMEMORYPLUGIN_H
+
+#include <RdkPluginBase.h>
+
+/**
+ *  @class IonMemoryPlugin
+ *  @brief Plugin used to setup the ION cgroup controller for the container.
+ *
+ *  ION is the raw memory allocator from Android, it is used on RDK platforms
+ *  by some vendors to allocate memory buffers for the following systems:
+ *    - (wayland) EGL / OpenGL surface buffers
+ *    - gstreamer / OMX Media decode buffers
+ *
+ */
+class IonMemoryPlugin final : public RdkPluginBase
+{
+public:
+    IonMemoryPlugin(std::shared_ptr<rt_dobby_schema>& containerConfig,
+                    const std::shared_ptr<DobbyRdkPluginUtils> &utils,
+                    const std::string &rootfsPath);
+
+public:
+    inline std::string name() const override
+    {
+        return mName;
+    };
+
+    unsigned hookHints() const override;
+
+public:
+    bool createRuntime() override;
+
+    bool postStop() override;
+
+private:
+    std::string findIonCGroupMountPoint() const;
+    bool bindMountCGroup(const std::string& source,
+                         const std::string& target) const;
+    bool setupContainerIonLimits(const std::string &cGroupDirPath,
+                                 pid_t containerPid,
+                                 const std::map<std::string, uint64_t> &heapLimits,
+                                 uint64_t defaultLimit);
+
+private:
+    const std::string mName;
+    std::shared_ptr<rt_dobby_schema> mContainerConfig;
+    const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
+    const std::string mRootfsPath;
+
+    bool mValid;
+    const rt_defs_plugins_ion_memory_data* mPluginData;
+};
+
+#endif // !defined(IONMEMORYPLUGIN_H)

--- a/rdkPlugins/IONMemory/source/IonMemoryPlugin.h
+++ b/rdkPlugins/IONMemory/source/IonMemoryPlugin.h
@@ -52,7 +52,6 @@ public:
 
 public:
     bool createRuntime() override;
-
     bool postStop() override;
 
 private:


### PR DESCRIPTION
### Description
Add ION Memory limiting plugin to allow containers to control ION heap limits.

Also removes the bind mount that was used to fix the cgroup mount point as this is no longer needed in crun (see https://github.com/containers/crun/issues/625)

### Test Procedure
Build with `PLUGIN_IONMEMORY=ON`. IonMemory plugin should be installed. See README.md for more details on config syntax.

When starting container, ION memory limits should be set:
```
0000003010.263200 NFO: < M:IonMemoryPlugin.cpp F:findIonCGroupMountPoint L:221 > found ION cgroup mounted @ '/sys/fs/cgroup/ion'
0000003010.264158 NFO: < M:IonMemoryPlugin.cpp F:setupContainerIonLimits L:331 > setting ion heap 'Media' limit to 0 for container 'ion'
0000003010.264260 NFO: < M:IonMemoryPlugin.cpp F:setupContainerIonLimits L:331 > setting ion heap 'System' limit to 62837 for container 'ion'
0000003010.264325 NFO: < M:IonMemoryPlugin.cpp F:setupContainerIonLimits L:331 > setting ion heap 'Secure' limit to 0 for container 'ion'
0000003010.264392 NFO: < M:IonMemoryPlugin.cpp F:setupContainerIonLimits L:331 > setting ion heap 'Audio' limit to 0 for container 'ion'
```

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)