### PR TITLE
NGDEV-180377: Erasing loopback storage on container start

### DIFF
--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -2112,6 +2112,9 @@ bool DobbySpecConfig::processLoopMount(const Json::Value& value,
     loopMntData["flags"] = flags;
     loopMntData["options"] = rdkMountOpts;
 
+    // disable management of the image to maintain backwards compatibly
+    loopMntData["imgmanagement"] = false;
+
     AI_LOG_FN_EXIT();
     return true;
 }

--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -350,6 +350,9 @@
                                     },
                                     "persistent": {
                                         "type": "boolean"
+                                    },
+                                    "imgmanagement": {
+                                        "type": "boolean"
                                     }
                                 }
                             }

--- a/rdkPlugins/Storage/README.md
+++ b/rdkPlugins/Storage/README.md
@@ -39,7 +39,7 @@ For every mount point Storage plugin should create the should be one item in the
 | `options`           | Mount options, this corresponds to mount "data" field. []                                                                               |
 | `persistent`        | If true image will be persistent between boots, if not image will be deleted after container destruction [true]                         |
 | `imgsize`           | Size of the image file (in bytes), only valid if image wasn't there before [12582912] (12 MB)                                           |
-
+| `imgmanagement`     | If `true` the image will be managed by the plugin, meaning it will check for integrity and try and correct any errors found before mounting. On failure, the image will be deleted and re-created [true] |
 
 #### Example
 ```json

--- a/rdkPlugins/Storage/source/LoopMountDetails.cpp
+++ b/rdkPlugins/Storage/source/LoopMountDetails.cpp
@@ -76,13 +76,24 @@ bool LoopMountDetails::onPreCreate()
     AI_LOG_FN_ENTRY();
     bool success = false;
 
-    // step 1 - Create image file if not yet there
-    if (!StorageHelper::createFileIfNeeded(mMount.fsImagePath,
-                                            mMount.imgSize,
-                                            mUserId,
-                                            mMount.fsImageType))
+    // step 1 - Create image file if not yet there, this also runs checks on
+    // the integrity of the image, those should be enabled if imgManagement
+    // is also enabled (the default is true)
+    if (mMount.imgManagement)
     {
-        // logging already provided by createFileIfNeeded
+        if (!StorageHelper::createFileIfNeeded(mMount.fsImagePath,
+                                               mMount.imgSize,
+                                               mUserId,
+                                               mMount.fsImageType))
+        {
+            // logging already provided by createFileIfNeeded
+            return false;
+        }
+    }
+    else if (access(mMount.fsImagePath.c_str(), F_OK) != 0)
+    {
+        AI_LOG_ERROR("failed to find source image '%s' for storage plugin",
+                     mMount.fsImagePath.c_str());
         return false;
     }
 

--- a/rdkPlugins/Storage/source/LoopMountDetails.h
+++ b/rdkPlugins/Storage/source/LoopMountDetails.h
@@ -60,6 +60,7 @@ public:
         unsigned long mountFlags;
         bool persistent;
         int imgSize;
+        bool imgManagement;
 
     } LoopMount;
 

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -360,6 +360,16 @@ std::vector<LoopMountDetails::LoopMount> Storage::getLoopMounts()
                 mount.mountOptions.push_back(std::string(loopback->options[j]));
             }
 
+            if (loopback->imgmanagement_present)
+            {
+                mount.imgManagement = loopback->imgmanagement;
+            }
+            else
+            {
+                // default imgManagement = true
+                mount.imgManagement = true;
+            }
+
             mounts.push_back(mount);
         }
     }


### PR DESCRIPTION
### Description
Add option to disable image management for loopback file system mounts. 
This is needed on Sky builds where the fs images are managed by appsserviced.

### Test Procedure
Build and run on a sky build, you should no longer see the following error in the log:
```
xattr missing on data file, re-generating a new one
```
And the supplied loopback image file should be used as it.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)