### PR TITLE
XIONE-2953: Update Xi1 config file

### DIFF
--- a/daemon/process/settings/dobby.xi1.json
+++ b/daemon/process/settings/dobby.xi1.json
@@ -31,9 +31,6 @@
       "/dev/tee[0-9]",
       "/dev/vpu"
     ],
-    "extraEnvVariables": [
-      "ENABLE_MEDIAINFO=0"
-    ],
     "extraMounts": [
       {
         "source": "/etc/xdg/gstomx.conf",


### PR DESCRIPTION
### Description
Remove `ENABLE_MEDIAINFO=0` from XiOne containers launched from dobby specs

### Test Procedure
Ensure `get_avstatus.sh` returns valid data when run inside a container

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)