### PR TITLE
Check if network interfaces are actually available

### DIFF
--- a/rdkPlugins/Networking/source/NetworkingPlugin.cpp
+++ b/rdkPlugins/Networking/source/NetworkingPlugin.cpp
@@ -173,7 +173,7 @@ bool NetworkingPlugin::createRuntime()
     const std::vector<std::string> extIfaces = mDobbyProxy->getExternalInterfaces();
     if (extIfaces.empty())
     {
-        AI_LOG_ERROR_EXIT("no external network interfaces defined in settings");
+        AI_LOG_ERROR_EXIT("No network interfaces available");
         return false;
     }
 


### PR DESCRIPTION
### Description
When returning the list of network interfaces to the networking plugin, only return interfaces that are actually available. Log warnings/errors if network interfaces we expect are missing

### Test Procedure
Edit the dobby.json file to add a non-existent interface:
```
    "network": {
      "externalInterfaces": [ "enp0s8", "enp0s3", "fakeiface" ],
      "addressRange": "100.64.11.0"
    }
```

When starting a container in NAT network mode, a warning will be logged but the container will still start:
```
0000010356.230847 NFO: < M:Dobby.cpp F:getExtIfaces L:1866 > GetExternalInterfaces()
0000010356.230953 WRN: < M:DobbyManager.cpp F:getExtIfaces L:1705 > Interface 'fakeiface' from settings file not available
```

If none of the interfaces in the settings file are present, an error will be logged and the container will fail to start:
```
0000010470.999618 ERR: < M:DobbyManager.cpp F:getExtIfaces L:1717 > None of the external interfaces defined in the settings file are available
```


### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)