### PR TITLE
Fix build error in DobbyInit due to Ethanlog

### DIFF
--- a/daemon/init/CMakeLists.txt
+++ b/daemon/init/CMakeLists.txt
@@ -43,11 +43,13 @@ if (LEGACY_COMPONENTS)
                 )
 endif()
 
-target_include_directories(
-        DobbyInit
-        PRIVATE
-        $<TARGET_PROPERTY:ethanlog,INTERFACE_INCLUDE_DIRECTORIES>
-        )
+if (LEGACY_COMPONENTS)
+        target_include_directories(
+                DobbyInit
+                PRIVATE
+                $<TARGET_PROPERTY:ethanlog,INTERFACE_INCLUDE_DIRECTORIES>
+                )
+endif()
 
 
 


### PR DESCRIPTION
### Description
Fix CMake issue preventing DobbyInit from building when LEGACY_COMPONENTS=OFF due to incorrect ethanlog dependency

### Test Procedure
Build Dobby with LEGACY_COMPONENTS=OFF

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)