### PR TITLE
Always add rtScheduling plugin when launching from Dobby spec

### DIFF
--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -606,6 +606,12 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
     {
         dictionary->ShowSection(RTLIMIT_ENABLED);
         dictionary->SetIntValue(RLIMIT_RTPRIO, 6);
+
+        Json::Value rdkPluginData = Json::objectValue;
+        mRdkPluginsJson[RDK_RTSCHEDULING_PLUGIN_NAME]["data"] = rdkPluginData;
+        // The rtScheduling plugin might not be available on all platforms
+        // so don't fail if it doesn't exist
+        mRdkPluginsJson[RDK_RTSCHEDULING_PLUGIN_NAME]["required"] = false;
     }
 
     if (!(flags & JSON_FLAG_CAPABILITIES))


### PR DESCRIPTION
### Description
When launching a container from a Dobby spec, if the spec does not contain an `rtPriority` field, add the rtScheduling plugin regardless with the defaults. This will ensure the process will run in RR scheduling mode. 

This is done to ensure consistency between skyDobby and RDK Dobby, where skyDobby configures the RT scheduling in a syshook

### Test Procedure
Launch a container from a dobby spec.

If the spec is missing the `rtPriority` field, the `rtScheduling` plugin should be added to the config with no data section. The plugin will use its default value(s):
```
        "rtscheduling": {
            "required": false,
            "data": {}
        }
```

The container will run in RR scheduling mode:
```
$ ps -cTeFl | grep sleep
4 S vagrant   3714  3714  3686 RR   46 -  4389 -        676   2 13:07 pts/0    00:00:00 /usr/libexec/DobbyInit sleep 60
0 S vagrant   3842  3842  3714 RR   46 -  1093 -        220   0 13:07 pts/0    00:00:00 sleep 60
```

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)