### PR TITLE
XIONE-3077: Prevent containers from adjusting their priority

### DIFF
--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -606,12 +606,6 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
     {
         dictionary->ShowSection(RTLIMIT_ENABLED);
         dictionary->SetIntValue(RLIMIT_RTPRIO, 6);
-
-        Json::Value rdkPluginData = Json::objectValue;
-        mRdkPluginsJson[RDK_RTSCHEDULING_PLUGIN_NAME]["data"] = rdkPluginData;
-        // The rtScheduling plugin might not be available on all platforms
-        // so don't fail if it doesn't exist
-        mRdkPluginsJson[RDK_RTSCHEDULING_PLUGIN_NAME]["required"] = false;
     }
 
     if (!(flags & JSON_FLAG_CAPABILITIES))

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -605,7 +605,7 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
     if (!(flags & JSON_FLAG_RTPRIORITY))
     {
         dictionary->ShowSection(RTLIMIT_ENABLED);
-        dictionary->SetIntValue(RLIMIT_RTPRIO, 6);
+        dictionary->SetIntValue(RLIMIT_RTPRIO, 0);
     }
 
     if (!(flags & JSON_FLAG_CAPABILITIES))


### PR DESCRIPTION
### Description
When launched from a dobby spec, containers should not be allowed to adjust their priority, unless the `rtPriority` field is set in the spec (and the `rtScheduling` plugin is therefore added).

This reverts https://github.com/rdkcentral/Dobby/pull/101

### Test Procedure
See XIONE-3077. 

If the dobby spec has no `rtPriority` field, then the container should have a hard & soft limit of 0 for the RTPRIO rlimit.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)