### PR TITLE
Fix segfault when no rdkplugins section in config

### DIFF
--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -649,7 +649,7 @@ bool DobbyConfig::updateBundleConfig(const ContainerId& id, std::shared_ptr<rt_d
     cfg->hostname = strdup(id.c_str());
 
     // if there are any rdk plugins, set up DobbyPluginLauncher in config
-    if (cfg->rdk_plugins->plugins_count)
+    if (cfg->rdk_plugins && cfg->rdk_plugins->plugins_count)
     {
 #ifdef USE_STARTCONTAINER_HOOK
         // bindmount DobbyPluginLauncher to container


### PR DESCRIPTION
### Description
Fix a segfault that occurs when launching an OCI config with type `1.0.2-dobby` and no rdkplugins section, 

### Test Procedure
Create config.json with schema type `1.0.2-dobby` and no rdkplugins section. No segfault should occur.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)