### PR TITLE
Add localhost masquerade feature to Networking plugin

### DIFF
--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -246,6 +246,9 @@
                         "portForwarding": {
                             "type": "object",
                             "properties": {
+                                "localhostMasquerade": {
+                                    "type": "boolean"
+                                },
                                 "hostToContainer": {
                                     "type": "array",
                                     "items": {

--- a/rdkPlugins/AppServices/source/AppServicesRdkPlugin.h
+++ b/rdkPlugins/AppServices/source/AppServicesRdkPlugin.h
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #include <string>
 #include <memory>
+#include <set>
 
 /**
  *  @class AppServicesRdkPlugin
@@ -60,6 +61,7 @@ public:
 public:
     bool postInstallation() override;
     bool createRuntime() override;
+    bool createContainer() override;
     bool postHalt() override;
 
 public:
@@ -79,11 +81,15 @@ private:
     };
 
     LocalServicesPort getAsPort() const;
+    std::set<in_port_t> getAllPorts() const;
 
     Netfilter::RuleSet constructRules() const;
+    Netfilter::RuleSet constructMasqueradeRules() const;
+
     void addRulesForPort(const std::string &containerIp, const std::string &vethName,
                          in_port_t port,
                          std::list<std::string>& acceptRules, std::list<std::string>& natRules) const;
+
     std::string constructDNATRule(const std::string &containerIp,
                                   in_port_t port) const;
     std::string constructCONNLIMITRule(const std::string &containerIp,
@@ -93,6 +99,10 @@ private:
     std::string constructACCEPTRule(const std::string &containerIp,
                                     const std::string &vethName,
                                     in_port_t port) const;
+
+    std::string createMasqueradeDnatRule(const in_port_t &port) const;
+    std::string createMasqueradeSnatRule(const in_port_t &port,
+                                         const std::string &ipAddress) const;
 
 private:
     const std::string mName;

--- a/rdkPlugins/Networking/README.md
+++ b/rdkPlugins/Networking/README.md
@@ -34,7 +34,8 @@ Add the following section to your OCI runtime configuration `config.json` file t
                             "port": 5678,
                             "protocol": "udp"
                         }
-                    ]
+                    ],
+                    "localhostMasquerade": true
                 },
                 "multicastForwarding": [
                     {
@@ -176,6 +177,14 @@ Container to host port forwarding can be used to allow containers access to the 
     }
 }
 ```
+
+##### Localhost Masquerade
+
+If enabled, redirect packets sent to localhost in the container to the host's localhost (via the dobby bridge device) for the forwarded ports.
+
+This allows containers to access services on the host without needing to change existing code to point to the bridge IP address.
+
+This can obviously only work for ports specified in the `containerToHost` section.
 
 ### Multicast Forwarding
 

--- a/rdkPlugins/Networking/include/NetworkingPlugin.h
+++ b/rdkPlugins/Networking/include/NetworkingPlugin.h
@@ -55,6 +55,7 @@ public:
 public:
     bool postInstallation() override;
     bool createRuntime() override;
+    bool createContainer() override;
     bool postHalt() override;
 
 public:

--- a/rdkPlugins/Networking/include/PortForwarding.h
+++ b/rdkPlugins/Networking/include/PortForwarding.h
@@ -63,6 +63,11 @@ bool removePortForwards(const std::shared_ptr<Netfilter> &netfilter,
                         const std::shared_ptr<NetworkingHelper> &helper,
                         const std::string &containerId,
                         rt_defs_plugins_networking_data_port_forwarding *portsConfig);
+
+bool addLocalhostMasquerading(const std::shared_ptr<Netfilter> &netfilter,
+                              const std::shared_ptr<NetworkingHelper> &helper,
+                              const std::string &containerId,
+                              rt_defs_plugins_networking_data_port_forwarding *portsConfig);
 };
 
 typedef struct PortForward
@@ -81,10 +86,15 @@ typedef struct PortForwards
 std::string parseProtocol(const std::string &protocol);
 PortForwards parsePortsConfig(rt_defs_plugins_networking_data_port_forwarding *portsConfig);
 
-std::vector<Netfilter::RuleSet> constructRules(const std::shared_ptr<NetworkingHelper> &helper,
+std::vector<Netfilter::RuleSet> constructPortForwardingRules(const std::shared_ptr<NetworkingHelper> &helper,
                                                const std::string &containerId,
                                                const PortForwards &portForwards,
                                                const int ipVersion);
+
+std::vector<Netfilter::RuleSet> constructMasqueradeRules(const std::shared_ptr<NetworkingHelper> &helper,
+                                                         const std::string &containerId,
+                                                         const PortForwards &portForwards,
+                                                         const int ipVersion);
 
 bool constructHostToContainerRules(std::vector<Netfilter::RuleSet> &ruleSets,
                                    const std::string &containerId,
@@ -119,5 +129,15 @@ std::string createAcceptRule(const PortForward &portForward,
                              const std::string &ipAddress,
                              const std::string &vethName,
                              const int ipVersion);
+
+std::string createMasqueradeDnatRule(const PortForward &portForward,
+                                     const std::string &id,
+                                     const std::string &ipAddress,
+                                     const int ipVersion);
+
+std::string createMasqueradeSnatRule(const PortForward &portForward,
+                                    const std::string &id,
+                                    const std::string &ipAddress,
+                                    const int ipVersion);
 
 #endif // !defined(PORTFORWARDING_H)


### PR DESCRIPTION
### Description
Adds a new option `localhostMasquerade` to the Networking plugin.

If enabled, redirect packets sent to localhost in the container to the host's localhost (via the dobby bridge device) for the forwarded ports.

This allows containers to access services on the host without needing to change existing code to point to the bridge IP address.

This can obviously only work for ports specified in the `containerToHost` section.

### Test Procedure
Start a server on the host machine running on port 8080. Configure the container to forward the port the server is running on into the container and enable `localhostMasquerade`:

```json
"portForwarding": {
    "localhostMasquerade": true,
    "containerToHost": [
        {
            "port": 8080,
            "protocol": "tcp"
        }
    ]
}
```

Requests made to `localhost:8080` inside the container will be sent to the server running on the host:

![masquerade](https://user-images.githubusercontent.com/7406950/118303217-1a7b6a80-b4dd-11eb-9947-6f13e49c8ba6.gif)

Requests to the bridge device will also be forwarded to the host as normal - this is unchanged regardless of the value of `localhostMasquerade`

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)