### PR TITLE
XIONE-2953: Add /dev/fwsocket node for Xi1

### DIFF
--- a/daemon/process/settings/dobby.xi1.json
+++ b/daemon/process/settings/dobby.xi1.json
@@ -61,6 +61,12 @@
         "destination": "/opt/property.ini",
         "type": "bind",
         "options": [ "bind", "nosuid", "nodev", "noexec" ]
+      },
+      {
+        "source": "/dev/fwsocket",
+        "destination": "/dev/fwsocket",
+        "type": "bind",
+        "options": [ "bind", "ro", "nosuid", "nodev", "noexec" ]
       }
     ]
   },


### PR DESCRIPTION
### Description
Add /dev/fwsocket node to dobby settings file for Xi1 for MS12 support

### Test Procedure
See JIRA:

- https://ccp.sys.comcast.net/browse/XIONE-3649
- https://ccp.sys.comcast.net/browse/XIONE-2953
- https://ccp.sys.comcast.net/browse/REALTEK-379

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)