### PR TITLE
XIONE-3649: Add build region CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,22 @@ else()
     message( FATAL_ERROR "Unknown RDK_PLATFORM '${RDK_PLATFORM}'" )
 endif()
 
+# If no REGION is defined then default to NONE
+set( REGION "NONE" CACHE STRING "Specifies the region the build is targeting, options are \"NONE\", \"UK\", \"DE\" or \"IT\"" )
+string( TOUPPER "${REGION}" REGION )
+# Set the defines / macros for the region
+if( REGION STREQUAL "NONE" )
+    add_definitions( -DREGION_NONE )
+elseif( REGION STREQUAL "UK" )
+    add_definitions( -DREGION_UK )
+elseif( REGION STREQUAL "IT" )
+    add_definitions( -DREGION_IT )
+elseif( REGION STREQUAL "DE" )
+    add_definitions( -DREGION_DE)
+else()
+    message( FATAL_ERROR "REGION '${REGION}' not supported, must be either \"NONE\", \"UK\", \"DE\" or \"IT\"" )
+endif()
+
 set( BUILD_REFERENCE "" CACHE STRING "Commit hash used to build Dobby" )
 
 # Option to enable / disable the Perfetto tracing support

--- a/daemon/process/settings/dobby.xi1.json
+++ b/daemon/process/settings/dobby.xi1.json
@@ -66,7 +66,8 @@
         "source": "/dev/fwsocket",
         "destination": "/dev/fwsocket",
         "type": "bind",
-        "options": [ "bind", "ro", "nosuid", "nodev", "noexec" ]
+        "options": [ "bind", "ro", "nosuid", "nodev", "noexec" ],
+        "excludeRegions": [ "UK" ]
       }
     ]
   },

--- a/settings/include/Settings.h
+++ b/settings/include/Settings.h
@@ -105,6 +105,8 @@ private:
     void dumpHardwareAccess(int aiLogLevel, const std::string& name,
                             const std::shared_ptr<const HardwareAccessSettings>& hwAccess) const;
 
+    std::string getBuildRegion() const;
+
 private:
     std::string mWorkspaceDir;
     std::string mPersistentDir;


### PR DESCRIPTION
### Description
Add a new cmake option: `-DREGION`. Valid options include `NONE` (Default), `UK`, `IT` and `DE`. 

In the dobby settings file, mounts in the `extraMounts` section(s) can be excluded for certain regions. Add exclusion for the `/dev/fwsocket` socket for UK Xi1 builds.

### Test Procedure
See JIRA ticket. `/dev/fwsocket` should not be mounted on UK region builds.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)