### PR TITLE
Use createRuntime hook for localhost masquerade

### DIFF
--- a/rdkPlugins/AppServices/source/AppServicesRdkPlugin.h
+++ b/rdkPlugins/AppServices/source/AppServicesRdkPlugin.h
@@ -61,7 +61,6 @@ public:
 public:
     bool postInstallation() override;
     bool createRuntime() override;
-    bool createContainer() override;
     bool postHalt() override;
 
 public:
@@ -86,6 +85,8 @@ private:
     Netfilter::RuleSet constructRules() const;
     Netfilter::RuleSet constructMasqueradeRules() const;
 
+    bool setupLocalhostMasquerade(Netfilter::RuleSet& ruleSet);
+
     void addRulesForPort(const std::string &containerIp, const std::string &vethName,
                          in_port_t port,
                          std::list<std::string>& acceptRules, std::list<std::string>& natRules) const;
@@ -101,8 +102,7 @@ private:
                                     in_port_t port) const;
 
     std::string createMasqueradeDnatRule(const in_port_t &port) const;
-    std::string createMasqueradeSnatRule(const in_port_t &port,
-                                         const std::string &ipAddress) const;
+    std::string createMasqueradeSnatRule(const std::string &ipAddress) const;
 
 private:
     const std::string mName;

--- a/rdkPlugins/Networking/include/NetworkingPlugin.h
+++ b/rdkPlugins/Networking/include/NetworkingPlugin.h
@@ -55,7 +55,6 @@ public:
 public:
     bool postInstallation() override;
     bool createRuntime() override;
-    bool createContainer() override;
     bool postHalt() override;
 
 public:

--- a/rdkPlugins/Networking/include/PortForwarding.h
+++ b/rdkPlugins/Networking/include/PortForwarding.h
@@ -21,6 +21,7 @@
 
 #include "Netfilter.h"
 #include "NetworkingHelper.h"
+#include "DobbyRdkPluginUtils.h"
 #include <rt_defs_plugins.h>
 
 #include <sys/types.h>
@@ -64,9 +65,8 @@ bool removePortForwards(const std::shared_ptr<Netfilter> &netfilter,
                         const std::string &containerId,
                         rt_defs_plugins_networking_data_port_forwarding *portsConfig);
 
-bool addLocalhostMasquerading(const std::shared_ptr<Netfilter> &netfilter,
-                              const std::shared_ptr<NetworkingHelper> &helper,
-                              const std::string &containerId,
+bool addLocalhostMasquerading(const std::shared_ptr<NetworkingHelper> &helper,
+                              const std::shared_ptr<DobbyRdkPluginUtils> &utils,
                               rt_defs_plugins_networking_data_port_forwarding *portsConfig);
 };
 


### PR DESCRIPTION
### Description
For both the Networking and AS plugins, move the localhost masquerade code to the createRuntime hook.

The localhost masquerade code should run in the container namespace. However, whilst using the createContainer hook for this worked fine on the VM, on some STBs it fails with permissions issues:

```
0000000181.918440 NFO: < M:DobbyRdkPluginManager.cpp F:runPlugins L:714 > Running appservicesrdk plugin
0000000181.928768 ERR: < M:Netfilter.cpp F:forkExec L:281 > /usr/sbin/iptables-restore failed with exit code 2
0000000181.928830 ERR: < M:Netfilter.cpp F:dumpPipeContents L:137 > iptables-restore v1.6.0: iptables-restore: unable to initialize table 'nat'
Error occurred at line: 1
Try `iptables-restore -h' or 'iptables-restore --help' for more information.
0000000181.928939 ERR: < M:AppServicesRdkPlugin.cpp F:createContainer L:213 > Failed to apply AS iptables rules for 'com.bskyb.epgui'
0000000181.928966 WRN: < M:DobbyRdkPluginManager.cpp F:runPlugins L:729 > Non-required plugin appservicesrdk createContainer hook has failed. Continuing running other plugins.
```

Switch to use the createRuntime hook and use the `callInNamespace()` function to manually call the code in the network namespace. This works around the issue as iptables is still run as the root user.

### Test Procedure
Ensure localhost masquerade works on the STB for both the Networking plugin and AS plugin.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)