### PR TITLE
Bug fixes for localhost masquerade and networking plugin

### DIFF
--- a/rdkPlugins/AppServices/source/AppServicesRdkPlugin.cpp
+++ b/rdkPlugins/AppServices/source/AppServicesRdkPlugin.cpp
@@ -601,12 +601,10 @@ Netfilter::RuleSet AppServicesRdkPlugin::constructMasqueradeRules() const
     for (const auto &port : allPorts)
     {
         const std::string dnatRule = createMasqueradeDnatRule(port);
-        AI_LOG_ERROR(">> DNAT %s", dnatRule.c_str());
         natRules.emplace_back(dnatRule);
     }
 
     std::string snatRule = createMasqueradeSnatRule(networkInfo.ipAddress);
-    AI_LOG_ERROR(">> SNAT %s", snatRule.c_str());
     natRules.emplace_back(snatRule);
 
     ruleSet[Netfilter::TableType::Nat] = std::move(natRules);

--- a/rdkPlugins/Networking/include/TapInterface.h
+++ b/rdkPlugins/Networking/include/TapInterface.h
@@ -36,6 +36,7 @@ class Netlink;
  */
 namespace TapInterface
 {
+    bool platformSupportsTapInterface();
     bool createTapInterface(const std::shared_ptr<Netlink> &netlink);
     bool destroyTapInterface(const std::shared_ptr<Netlink> &netlink);
     bool isValid();

--- a/rdkPlugins/Networking/source/NetworkingPlugin.cpp
+++ b/rdkPlugins/Networking/source/NetworkingPlugin.cpp
@@ -224,17 +224,20 @@ bool NetworkingPlugin::createRuntime()
             return false;
         }
 
-        // Add localhost masquerade (in container network namespace)
-        // Ideally this would be done in the createContainer hook, but that fails
-        // on some platforms with permissions issues (works fine on VM...)
-        if (!mUtils->callInNamespace(mUtils->getContainerPid(), CLONE_NEWNET,
-                                     &PortForwarding::addLocalhostMasquerading,
-                                     mHelper,
-                                     mUtils,
-                                     mPluginData->port_forwarding))
+        // Add localhost masquerade if enabled (run in container network namespace)
+        if (mPluginData->port_forwarding->localhost_masquerade_present && mPluginData->port_forwarding->localhost_masquerade)
         {
-            AI_LOG_ERROR_EXIT("Failed to add AS localhost masquerade iptables rules inside container");
-            return false;
+            // Ideally this would be done in the createContainer hook, but that fails
+            // on some platforms with permissions issues (works fine on VM...)
+            if (!mUtils->callInNamespace(mUtils->getContainerPid(), CLONE_NEWNET,
+                                         &PortForwarding::addLocalhostMasquerading,
+                                         mHelper,
+                                         mUtils,
+                                         mPluginData->port_forwarding))
+            {
+                AI_LOG_ERROR_EXIT("Failed to add AS localhost masquerade iptables rules inside container");
+                return false;
+            }
         }
     }
 

--- a/rdkPlugins/Networking/source/NetworkingPlugin.cpp
+++ b/rdkPlugins/Networking/source/NetworkingPlugin.cpp
@@ -235,7 +235,7 @@ bool NetworkingPlugin::createRuntime()
                                          mUtils,
                                          mPluginData->port_forwarding))
             {
-                AI_LOG_ERROR_EXIT("Failed to add AS localhost masquerade iptables rules inside container");
+                AI_LOG_ERROR_EXIT("Failed to add localhost masquerade iptables rules inside container");
                 return false;
             }
         }

--- a/rdkPlugins/Networking/source/PortForwarding.cpp
+++ b/rdkPlugins/Networking/source/PortForwarding.cpp
@@ -1002,7 +1002,7 @@ std::string createMasqueradeSnatRule(const PortForward &portForward,
     }
     else
     {
-        sourceAddr = "[::1]";
+        sourceAddr = "::1/128";
         destination = std::string() + ipAddress;
         bridgeAddr = std::string() + BRIDGE_ADDRESS_IPV6;
     }

--- a/rdkPlugins/Networking/source/TapInterface.cpp
+++ b/rdkPlugins/Networking/source/TapInterface.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <net/if.h>
 #include <linux/if_tun.h>
 
@@ -39,6 +40,19 @@ ifreq createInterfaceStruct()
     ifr.ifr_flags = IFF_TAP | IFF_NO_PI | IFF_ONE_QUEUE;
     strncpy(ifr.ifr_name, TAP_NAME, IFNAMSIZ);
     return ifr;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Returns true if the platform has the TUN/TAP device driver and therefore
+ *  can create tap devices
+ *
+ *  @return true if supported.
+ */
+bool TapInterface::platformSupportsTapInterface()
+{
+    struct stat buf;
+    return stat(TUNDEV, &buf) == 0;
 }
 
 // -----------------------------------------------------------------------------

--- a/rdkPlugins/Thunder/source/ThunderPlugin.cpp
+++ b/rdkPlugins/Thunder/source/ThunderPlugin.cpp
@@ -97,7 +97,6 @@ bool ThunderPlugin::postInstallation()
     // Set the THUNDER_ACCESS envvar to the Dobby bridge IP address
     bzero(buf, sizeof(buf));
     snprintf(buf, sizeof(buf), "THUNDER_ACCESS=100.64.11.1:%hu", mThunderPort);
-    AI_LOG_INFO(">> %s", buf);
     mUtils->addEnvironmentVar(buf);
 
     return true;


### PR DESCRIPTION
### Description
Few bug fixes for networking plugin & localhost masquerade:

* Ensure localhost masquerade is only enabled when set to `true` in config
* Fix IPv6 support for localhost masquerade
* Remove unnecessary logging
* Reduce unnecessary errors on platforms without tap/tun support

### Test Procedure
Ensure containers launch without errors on all platforms

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)