### PR TITLE
XIONE-4157: Enable SVP for Realtek

### DIFF
--- a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
@@ -82,8 +82,8 @@ static const char* ociJsonTemplate = R"JSON(
         "rlimits": [
             {
                 "type": "RLIMIT_NOFILE",
-                "hard": 1024,
-                "soft": 1024
+                "hard": 4096,
+                "soft": 4096
             },
             {
                 "type": "RLIMIT_NPROC",

--- a/daemon/process/settings/dobby.xi1.json
+++ b/daemon/process/settings/dobby.xi1.json
@@ -29,7 +29,8 @@
       "/dev/snd/*",
       "/dev/uio253",
       "/dev/tee[0-9]",
-      "/dev/vpu"
+      "/dev/vpu",
+      "/dev/buflock"
     ],
     "extraMounts": [
       {


### PR DESCRIPTION
### Description

- Open container for SVP playback on Realtek SoC
- Enabling SVP by adding extra env will be in separate commit
- Permissions to needed /opt/drm access will be part of widget config.

### Test Procedure
See JIRA

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)