### PR TITLE
Add write access to OCDM directory so svp-sockets could be created

### DIFF
--- a/plugins/OpenCDM/source/OpenCDMPlugin.cpp
+++ b/plugins/OpenCDM/source/OpenCDMPlugin.cpp
@@ -183,14 +183,13 @@ bool OpenCDMPlugin::enableTmpOCDMDir(const std::shared_ptr<IDobbyStartState>& st
 
     // on newer builds the OCDM files have moved to a dedicate a /tmp/OCDM
     // directory
-    if ((mkdir(dirPath.c_str(), 0750) != 0) && (errno != EEXIST))
+    if ((mkdir(dirPath.c_str(), 0770) != 0) && (errno != EEXIST))
     {
         AI_LOG_SYS_ERROR(errno, "failed to create dir @ '%s'", dirPath.c_str());
         return false;
     }
 
-    // make sure the directory is accessible by apps but not writable
-    if (chmod(dirPath.c_str(), 0750) != 0)
+    if (chmod(dirPath.c_str(), 0770) != 0)
     {
         AI_LOG_SYS_ERROR(errno, "failed to change access on '%s''", dirPath.c_str());
         return false;


### PR DESCRIPTION
Description
XIONE-4157
Open container for SVP playback on Realtek SoC
Enabling SVP by adding extra env will be in separate commit
For SVP playback sockets are created from app context therefore OCDM directory need group write permission so it can be written and use by any member of Apps group.

Test Procedure
See JIRA

Type of Change
 Bug fix (non-breaking change which fixes an issue)
[] New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 Other (doesn't fit into the above categories - e.g. documentation updates)
Requires Bitbake Recipe changes?
 The base Bitbake recipe (meta-rdk-ext/recipes-containers/dobby/dobby.bb) must be modified to support the changes in this PR (beyond updating SRC_REV)