### PR TITLE
Allow to loop mount xfs file system.

### DIFF
--- a/rdkPlugins/Storage/source/ImageManager.h
+++ b/rdkPlugins/Storage/source/ImageManager.h
@@ -30,11 +30,13 @@ class ImageManager
 public:
     static bool checkFSImage(const std::string & filepath,
                              uid_t userId,
+                             const std::string & fs,
                              bool fix = true);
 
     static bool checkFSImageAt(int dirFd,
                                const std::string & filepath,
                                uid_t userId,
+                               const std::string & fs,
                                bool fix = true);
 
     static bool createFSImage(const std::string & filepath,

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -351,8 +351,16 @@ std::vector<LoopMountDetails::LoopMount> Storage::getLoopMounts()
             }
             else
             {
-                // default image size = 12 MB
-                mount.imgSize = 12 * 1024 * 1024;
+                if (mount.fsImageType.compare("xfs") == 0)
+                {
+                    // default image size = 16 MB
+                    mount.imgSize = 16 * 1024 * 1024;
+                }
+                else
+                {
+                    // default image size = 12 MB
+                    mount.imgSize = 12 * 1024 * 1024;
+                }
             }
 
             for (size_t j = 0; j < loopback->options_len; j++)

--- a/rdkPlugins/Storage/source/StorageHelper.cpp
+++ b/rdkPlugins/Storage/source/StorageHelper.cpp
@@ -282,7 +282,7 @@ bool StorageHelper::createFileIfNeeded(const std::string& filePath,
     {
         // the package requires storage so check we have a valid data image
         // and if not try and create it
-        if (!ImageManager::checkFSImage(filePath, userId, true))
+        if (!ImageManager::checkFSImage(filePath, userId, fileSystem, true))
         {
             // File doesn't exist yet, need to create it
             AI_LOG_DEBUG("File not exists, need to create '%s'", filePath.c_str());


### PR DESCRIPTION
### Description
Adds possibility to loop mount xfs filesystem (in storage plugin).

### Test Procedure
Define storage plugin entry in config.json file with xfs loop mount:

_"storage": {
            "required": true,
            "data": {
                "loopback": [
                    {
                        "destination": "/home/private",
                        "flags": 14,
                        "fstype": "xfs",
                        "source": "/tmp/data.img"
                    }
                ]
            }
        }_


### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)