### PR TITLE
Fix invalid dbus service name in Networking Plugin

### DIFF
--- a/rdkPlugins/Networking/source/NetworkingPlugin.cpp
+++ b/rdkPlugins/Networking/source/NetworkingPlugin.cpp
@@ -29,9 +29,6 @@
 
 REGISTER_RDK_PLUGIN(NetworkingPlugin);
 
-static std::string gDBusService(DOBBY_SERVICE ".plugin.networking");
-
-
 NetworkingPlugin::NetworkingPlugin(std::shared_ptr<rt_dobby_schema> &cfg,
                                    const std::shared_ptr<DobbyRdkPluginUtils> &utils,
                                    const std::string &rootfsPath)
@@ -425,13 +422,14 @@ bool NetworkingPlugin::createRemoteService()
 
     // Append the pid onto the end of the service name so we can run multiple
     // clients
+    std::string dbusServiceName(DOBBY_SERVICE ".plugin.networking");
     char strPid[32];
     sprintf(strPid, ".pid%d", getpid());
-    gDBusService += strPid;
+    dbusServiceName += strPid;
 
     try
     {
-        mIpcService = AI_IPC::createIpcService(DBUS_SYSTEM_ADDRESS, gDBusService);
+        mIpcService = AI_IPC::createIpcService(DBUS_SYSTEM_ADDRESS, dbusServiceName);
         if(!mIpcService->start())
         {
             AI_LOG_ERROR_EXIT("failed to create IPC service");


### PR DESCRIPTION
### Description
Prevent the networking plugin generating an invalid dbus service name and failing to connect to dbus with the following error after stopping/starting containers many times:

```
Jun 25 10:32:15 arrisxi6 DobbyDaemon[1896]: failed to register service name 'org.rdk.dobby.plugin.networking.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid1896.pid189
```

### Test Procedure
Using dbus-monitor. ensure the networking plugin name does not repeatedly append the PID to the end when connecting to dbus

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)