### PR TITLE
Change crun logfile path to /opt/logs

### DIFF
--- a/daemon/lib/source/DobbyRunC.cpp
+++ b/daemon/lib/source/DobbyRunC.cpp
@@ -50,7 +50,7 @@ DobbyRunC::DobbyRunC(const std::shared_ptr<IDobbyUtils>& utils,
     , mRuncPath("/usr/sbin/runc")
 #endif
     , mWorkingDir("/var/run/rdk/crun")
-    , mLogDir("/var/log")
+    , mLogDir("/opt/logs")
     , mLogFilePath(mLogDir + "/crun.log")
     , mConsoleSocket(settings->consoleSocketPath())
 {


### PR DESCRIPTION
### Description
Change the crun logfile location to `/opt/logs` to ensure it's stored with the rest of the RDK logfiles.

### Test Procedure
Ensure `/opt/logs/crun.log` is created when starting containers.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)