### PR TITLE
Fix null termination in localtime

### DIFF
--- a/rdkPlugins/LocalTime/source/LocalTimePlugin.cpp
+++ b/rdkPlugins/LocalTime/source/LocalTimePlugin.cpp
@@ -65,7 +65,7 @@ bool LocalTimePlugin::postInstallation()
         return false;
     }
 
-    const std::string localtimeInHost = pathBuf;
+    const std::string localtimeInHost(pathBuf, len);
     const std::string localtimeInContainer = mRootfsPath + "/etc/localtime";
 
     if (localtimeInHost.empty())


### PR DESCRIPTION
### Description
Localtime plugin should correctly null-terminate the filename, preventing the following issue:

```
ls -lah /proc/12345/root/etc/
drwxr-xr-x    3 root     root         220 Jul 28 12:33 .
drwxr-xr-x   15 root     root         300 Jul 28 12:33 ..
lrwxrwxrwx    1 root     root          36 Jul 28 12:33 localtime -> /usr/share/zoneinfo/Europe/London???
```

### Test Procedure
Ensure localtime plugin correctly creates a valid symlink.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)