### PR TITLE
Add more process information to container info

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1464,7 +1464,7 @@ std::string DobbyManager::statsOfContainer(int32_t cd) const
     else
     {
         // create a stats object for the container
-        DobbyStats stats(it->first, mEnvironment);
+        DobbyStats stats(it->first, mEnvironment, mUtilities);
 
         // get the raw stats and add the "id" and "state" fields
         Json::Value jsonStats = stats.stats();
@@ -1486,8 +1486,9 @@ std::string DobbyManager::statsOfContainer(int32_t cd) const
         }
 
         // convert the json stats to a string and return
-        Json::FastWriter writer;
-        return writer.write(jsonStats);
+        Json::StreamWriterBuilder builder;
+        builder["indentation"] = " ";
+        return Json::writeString(builder, jsonStats);
     }
 
     return std::string();


### PR DESCRIPTION
### Description
Return more info about the running processes inside a container.

Will return an array containing all the processes running inside the container, in additional to the existing PID array:

```json
 "processes" : 
 [
  {
   "cmdline" : "/usr/libexec/DobbyInit /echo_test.sh ",
   "executable" : "/usr/local/libexec/DobbyInit",
   "nsPid" : 1,
   "pid" : 17263
  },
  {
   "cmdline" : "/bin/bash /echo_test.sh ",
   "executable" : "/bin/bash",
   "nsPid" : 5,
   "pid" : 17326
  },
  {
   "cmdline" : "sleep 1 ",
   "executable" : "/bin/sleep",
   "nsPid" : 6,
   "pid" : 17327
  }
 ]
```

Also remove deprecated `FastWriter` jsoncpp call.

### Test Procedure
Start container. Run `DobbyTool info <id>`. Check output of processes array matches `ps auxf` output.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)