### PR TITLE
Add localhostmasquerade to Thunder plugin

### DIFF
--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -497,6 +497,9 @@
                         "bearerUrl": {
                             "type": "string"
                         },
+                        "localhostMasquerade": {
+                            "type": "boolean"
+                        },
                         "connLimit": {
                             "type": "integer"
                         }

--- a/rdkPlugins/AppServices/source/AppServicesRdkPlugin.h
+++ b/rdkPlugins/AppServices/source/AppServicesRdkPlugin.h
@@ -25,6 +25,7 @@
 
 #include <Netfilter.h>
 #include <RdkPluginBase.h>
+#include <IpTablesRuleGenerator.h>
 
 #include <sys/types.h>
 #include <netinet/in.h>
@@ -100,9 +101,6 @@ private:
     std::string constructACCEPTRule(const std::string &containerIp,
                                     const std::string &vethName,
                                     in_port_t port) const;
-
-    std::string createMasqueradeDnatRule(const in_port_t &port) const;
-    std::string createMasqueradeSnatRule(const std::string &ipAddress) const;
 
 private:
     const std::string mName;

--- a/rdkPlugins/Common/include/DobbyNetworkingConstants.h
+++ b/rdkPlugins/Common/include/DobbyNetworkingConstants.h
@@ -1,0 +1,73 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2021 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef DOBBYNETWORKINGCONSTANTS_H
+#define DOBBYNETWORKINGCONSTANTS_H
+
+#include <netinet/in.h>
+
+#define BRIDGE_NAME             "dobby0"
+
+// -----------------------------------------------------------------------------
+// IPv4 address macros
+
+// creates an in_addr_t type from ip address
+#define INADDR_CREATE(a, b, c, d) \
+    ( ((((in_addr_t)(a)) << 24) & 0xff000000) | \
+      ((((in_addr_t)(b)) << 16) & 0x00ff0000) | \
+      ((((in_addr_t)(c)) <<  8) & 0x0000ff00) | \
+      ((((in_addr_t)(d)) <<  0) & 0x000000ff) )
+
+// commonly used ip addresses created as in_addr_t type
+#define INADDR_BRIDGE                   INADDR_CREATE( 100,  64,  11,   1 )
+#define INADDR_BRIDGE_NETMASK           INADDR_CREATE( 255, 255, 255,   0 )
+#define INADDR_LO                       INADDR_CREATE( 127,   0,   0,   1 )
+#define INADDR_LO_NETMASK               INADDR_CREATE( 255,   0,   0,   0 )
+
+// commonly used ip address string literals for iptables rules
+// NB: the bridge addresses must work with the above INADDR_* addresses
+#define BRIDGE_ADDRESS_RANGE          "100.64.11.0"
+#define BRIDGE_ADDRESS                "100.64.11.1"
+#define LOCALHOST                     "127.0.0.1"
+
+
+// -----------------------------------------------------------------------------
+// IPv6 address helpers
+
+// 2080:d0bb:1e::
+static const struct in6_addr IN6ADDR_BASE = {{
+    0x20, 0x80, 0xd0, 0xbb,
+    0x00, 0x1e, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+}};
+
+// 0000:0000:0000:0000:0000:0000:0000:0000
+static const struct in6_addr IN6ADDR_ANY = {{
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+}};
+
+#define BRIDGE_ADDRESS_RANGE_IPV6     "2080:d0bb:1e::6440:b00"
+#define BRIDGE_ADDRESS_IPV6           "2080:d0bb:1e::6440:b01"
+#define LOCALHOST_IPV6                "::1"
+
+#endif

--- a/rdkPlugins/Common/include/IpTablesRuleGenerator.h
+++ b/rdkPlugins/Common/include/IpTablesRuleGenerator.h
@@ -1,0 +1,140 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2021 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#ifndef IPTABLESRULEGENERATOR_H
+#define IPTABLESRULEGENERATOR_H
+
+#include "DobbyRdkPluginUtils.h"
+#include "DobbyNetworkingConstants.h"
+#include <Logging.h>
+
+#include <string>
+#include <memory>
+#include <netinet/in.h>
+#include <inttypes.h>
+
+class IpTablesRuleGenerator
+{
+public:
+    // Localhost masquerade rules
+    inline static std::string createMasqueradeDnatRule(const std::string &pluginName,
+                                                       const std::string &containerId,
+                                                       const in_port_t &port,
+                                                       const std::string &protocol,
+                                                       const int ipVersion)
+
+    {
+        AI_LOG_FN_ENTRY();
+
+#if defined(DEV_VM)
+        const std::string comment(pluginName + ":" + containerId);
+#else
+        const std::string comment("\"" + pluginName + ":" + containerId + "\"");
+#endif
+
+        std::string baseRule("OUTPUT "
+                             "-o lo "
+                             "-p %s "       // protocol
+                             "-m %s "       // protocol
+                             "--dport %hu " // port number
+                             "-j DNAT "
+                             "-m comment --comment %s " // Container id
+                             "--to-destination %s"      // Bridge address:port
+        );
+
+        // create addresses based on IP version
+        char destination[128];
+        if (ipVersion == AF_INET)
+        {
+            snprintf(destination, sizeof(destination), "%s:%" PRIu16, BRIDGE_ADDRESS, port);
+        }
+        else
+        {
+            snprintf(destination, sizeof(destination), "%s:%" PRIu16, BRIDGE_ADDRESS_IPV6, port);
+        }
+
+        // populate fields in base rule
+        char buf[256];
+        snprintf(buf, sizeof(buf), baseRule.c_str(),
+                 protocol.c_str(),
+                 protocol.c_str(),
+                 port,
+                 comment.c_str(),
+                 destination);
+
+        AI_LOG_DEBUG("Constructed rule: %s", buf);
+        AI_LOG_FN_EXIT();
+        return std::string(buf);
+    }
+
+    inline static std::string createMasqueradeSnatRule(const std::string &pluginName,
+                                                       const std::string &containerId,
+                                                       const std::string &ipAddress,
+                                                       const std::string &protocol,
+                                                       const int ipVersion)
+    {
+        AI_LOG_FN_ENTRY();
+
+#if defined(DEV_VM)
+        const std::string comment(pluginName + ":" + containerId);
+#else
+        const std::string comment("\"" + pluginName + ":" + containerId + "\"");
+#endif
+
+        std::string bridgeAddr;
+        std::string sourceAddr;
+        std::string destination;
+
+        std::string baseRule("POSTROUTING "
+                             "-p %s " // protocol
+                             "-s %s " // container localhost
+                             "-d %s " // bridge address
+                             "-j SNAT "
+                             "-m comment --comment %s " // container id
+                             "--to %s");
+
+        // create addresses based on IP version
+        if (ipVersion == AF_INET)
+        {
+            sourceAddr = "127.0.0.1";
+            destination = std::string() + ipAddress;
+            bridgeAddr = std::string() + BRIDGE_ADDRESS;
+        }
+        else
+        {
+            sourceAddr = "::1/128";
+            destination = std::string() + ipAddress;
+            bridgeAddr = std::string() + BRIDGE_ADDRESS_IPV6;
+        }
+
+        // populate '%s' fields in base rule
+        char buf[256];
+        snprintf(buf, sizeof(buf), baseRule.c_str(),
+                 protocol.c_str(),
+                 sourceAddr.c_str(),
+                 bridgeAddr.c_str(),
+                 comment.c_str(),
+                 destination.c_str());
+
+        AI_LOG_DEBUG("Constructed rule: %s", buf);
+        AI_LOG_FN_EXIT();
+        return std::string(buf);
+    }
+};
+
+#endif

--- a/rdkPlugins/Networking/include/NetworkingHelper.h
+++ b/rdkPlugins/Networking/include/NetworkingHelper.h
@@ -20,13 +20,12 @@
 #ifndef NETWORKINGHELPER_H
 #define NETWORKINGHELPER_H
 
+#include <DobbyNetworkingConstants.h>
+
 #include <netinet/in.h>
 #include <string>
 
-#define BRIDGE_NAME             "dobby0"
-
 enum class NetworkType { None, Nat, Open };
-
 class NetworkingHelper
 {
 public:
@@ -60,51 +59,5 @@ private:
 
     std::string mVethName;
 };
-
-// -----------------------------------------------------------------------------
-// IPv4 address macros
-
-// creates an in_addr_t type from ip address
-#define INADDR_CREATE(a, b, c, d) \
-    ( ((((in_addr_t)(a)) << 24) & 0xff000000) | \
-      ((((in_addr_t)(b)) << 16) & 0x00ff0000) | \
-      ((((in_addr_t)(c)) <<  8) & 0x0000ff00) | \
-      ((((in_addr_t)(d)) <<  0) & 0x000000ff) )
-
-// commonly used ip addresses created as in_addr_t type
-#define INADDR_BRIDGE                   INADDR_CREATE( 100,  64,  11,   1 )
-#define INADDR_BRIDGE_NETMASK           INADDR_CREATE( 255, 255, 255,   0 )
-#define INADDR_LO                       INADDR_CREATE( 127,   0,   0,   1 )
-#define INADDR_LO_NETMASK               INADDR_CREATE( 255,   0,   0,   0 )
-
-// commonly used ip address string literals for iptables rules
-// NB: the bridge addresses must work with the above INADDR_* addresses
-#define BRIDGE_ADDRESS_RANGE          "100.64.11.0"
-#define BRIDGE_ADDRESS                "100.64.11.1"
-#define LOCALHOST                     "127.0.0.1"
-
-
-// -----------------------------------------------------------------------------
-// IPv6 address helpers
-
-// 2080:d0bb:1e::
-static const struct in6_addr IN6ADDR_BASE = {{
-    0x20, 0x80, 0xd0, 0xbb,
-    0x00, 0x1e, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-}};
-
-// 0000:0000:0000:0000:0000:0000:0000:0000
-static const struct in6_addr IN6ADDR_ANY = {{
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-}};
-
-#define BRIDGE_ADDRESS_RANGE_IPV6     "2080:d0bb:1e::6440:b00"
-#define BRIDGE_ADDRESS_IPV6           "2080:d0bb:1e::6440:b01"
-#define LOCALHOST_IPV6                "::1"
 
 #endif // !defined(NETWORKINGHELPER_H)

--- a/rdkPlugins/Networking/include/PortForwarding.h
+++ b/rdkPlugins/Networking/include/PortForwarding.h
@@ -130,14 +130,4 @@ std::string createAcceptRule(const PortForward &portForward,
                              const std::string &vethName,
                              const int ipVersion);
 
-std::string createMasqueradeDnatRule(const PortForward &portForward,
-                                     const std::string &id,
-                                     const std::string &ipAddress,
-                                     const int ipVersion);
-
-std::string createMasqueradeSnatRule(const PortForward &portForward,
-                                    const std::string &id,
-                                    const std::string &ipAddress,
-                                    const int ipVersion);
-
 #endif // !defined(PORTFORWARDING_H)

--- a/rdkPlugins/Thunder/README.md
+++ b/rdkPlugins/Thunder/README.md
@@ -9,7 +9,9 @@ Add the following section to your OCI runtime configuration `config.json` file t
         "thunder": {
             "required": true,
             "dependsOn": ["networking"],
-            "data": {}
+            "data": {
+                "bearerUrl": "http://localhost"
+            }
         }
     }
 }
@@ -36,6 +38,13 @@ The URL defines which roles the container will have based on the Thunder ACL fil
     "bearerUrl": "http://localhost"
 }
 ```
+
+### Localhost Masquerade
+If `localhostmasquerade` is set to `true`, Thunder will be made available inside the container on `127.0.0.1:9998` and `THUNDER_ACCESS` will be set to `127.0.0.1:9998` to match.
+
+This is set to `false` by default.
+
+When enabled, Thunder will still also be accessible on `100.64.11.1:9998`.
 
 ### Connection Limit
 *Note: this feature is currently disabled - change `mEnableConnLimit` in `ThunderPlugin.cpp` to true to enable*

--- a/rdkPlugins/Thunder/README.md
+++ b/rdkPlugins/Thunder/README.md
@@ -40,7 +40,7 @@ The URL defines which roles the container will have based on the Thunder ACL fil
 ```
 
 ### Localhost Masquerade
-If `localhostmasquerade` is set to `true`, Thunder will be made available inside the container on `127.0.0.1:9998` and `THUNDER_ACCESS` will be set to `127.0.0.1:9998` to match.
+If `localhostMasquerade` is set to `true`, Thunder will be made available inside the container on `127.0.0.1:9998` and `THUNDER_ACCESS` will be set to `127.0.0.1:9998` to match.
 
 This is set to `false` by default.
 

--- a/rdkPlugins/Thunder/source/ThunderPlugin.h
+++ b/rdkPlugins/Thunder/source/ThunderPlugin.h
@@ -78,6 +78,8 @@ public:
 private:
     Netfilter::RuleSet constructRules() const;
 
+    bool setupLocalhostMasquerade(Netfilter::RuleSet& ruleSet) const;
+
     std::string constructDNATRule(const std::string &containerIp,
                                   in_port_t port) const;
 
@@ -89,6 +91,9 @@ private:
     std::string constructACCEPTRule(const std::string &containerIp,
                                     const std::string &vethName,
                                     in_port_t port) const;
+
+    std::string createMasqueradeDnatRule(const in_port_t &port) const;
+    std::string createMasqueradeSnatRule(const std::string &ipAddress) const;
 
 private:
     const std::string mName;


### PR DESCRIPTION
### Description
Add `localhostMasquerade` functionality to Thunder plugin.

When enabled, Thunder will be available at `127.0.0.1:9998` inside the container in addition to `100.64.11.1:9998`. This is useful for applications that don't correctly respect the THUNDER_ACCESS env var. 

Refactor some iptables rule generation code for re-use, as localhost masquerade feature is used across Network, AS and Thunder plugins.

### Test Procedure
When the Thunder plugin is configured with `localhostMasquerade` set:

```json
"rdkPlugins": {
        "thunder": {
            "required": true,
            "dependsOn": ["networking"],
            "data": {
                "bearerUrl": "http://localhost",
                "localhostMasquerade": true
            }
        }
    }
```
Thunder should be accessible over `127.0.0.1:9998` inside the container.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)