### PR TITLE
LLAMA-3127: Prevent segfault at shutdown

### DIFF
--- a/bundle/lib/source/DobbyRootfs.cpp
+++ b/bundle/lib/source/DobbyRootfs.cpp
@@ -217,6 +217,8 @@ void DobbyRootfs::unmountAllAt(const std::string& pathPrefix)
 
     // process each line of the file, we are looking for any mount point that
     // is prefixed with the above path
+    char mntRoot[256 + 1] = {0};
+    char mntPoint[256 + 1] = {0};
     while ((rd = getline(&line, &len, fp)) >= 0)
     {
         if ((line == nullptr) || (rd < 8))
@@ -228,9 +230,6 @@ void DobbyRootfs::unmountAllAt(const std::string& pathPrefix)
         // process the individual mount line
         int mntId, parentMntId;
         unsigned devMajor, devMinor;
-        char mntRoot[256 + 1];
-        char mntPoint[256 + 1];
-
         if (sscanf(line, "%i %i %u:%u %256s %256s", &mntId, &parentMntId,
                                                     &devMajor, &devMinor,
                                                     mntRoot, mntPoint) != 6)

--- a/daemon/lib/include/Dobby.h
+++ b/daemon/lib/include/Dobby.h
@@ -139,7 +139,6 @@ private:
     std::shared_ptr<DobbyIPCUtils> mIPCUtilities;
     std::shared_ptr<DobbyManager> mManager;
 
-    std::shared_ptr<DobbyLogger> mContainerLogger;
     std::unique_ptr<DobbyWorkQueue> mWorkQueue;
     std::unique_ptr<DobbyWorkQueue> mPluginWorkQueue;
 

--- a/daemon/lib/include/DobbyLogger.h
+++ b/daemon/lib/include/DobbyLogger.h
@@ -54,6 +54,7 @@ public:
                     const bool createNewLog);
 
     void WaitForLoggingToFinish(pid_t containerPid);
+    void ShutdownLoggers();
 
 private:
     int createUnixSocket(const std::string path);
@@ -67,6 +68,8 @@ private:
 
     std::map<pid_t, IDobbyRdkLoggingPlugin::ContainerInfo> mTempConnections;
     std::map<pid_t, std::future<void>> mFutures;
+
+    std::atomic_bool mCancellationToken;
 };
 
 #endif // !defined(DOBBYLOGGER_H)

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -86,7 +86,6 @@ Dobby::Dobby(const std::string& dbusAddress,
     : mEnvironment(std::make_shared<DobbyEnv>(settings))
     , mUtilities(std::make_shared<DobbyUtils>())
     , mIPCUtilities(std::make_shared<DobbyIPCUtils>(dbusAddress, ipcService))
-    , mContainerLogger(std::make_shared<DobbyLogger>(settings))
     , mWorkQueue(new DobbyWorkQueue)
     , mPluginWorkQueue(new DobbyWorkQueue)
     , mIpcService(ipcService)
@@ -115,7 +114,7 @@ Dobby::Dobby(const std::string& dbusAddress,
 
     // create the container manager which does all the heavy lifting
     mManager = std::make_shared<DobbyManager>(mEnvironment, mUtilities,
-                            mIPCUtilities, mContainerLogger, settings, startedCb, stoppedCb);
+                            mIPCUtilities, settings, startedCb, stoppedCb);
     if (!mManager)
     {
         AI_LOG_FATAL("failed to create manager");

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -65,6 +65,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
+#include <sys/syscall.h>
 #include <inttypes.h>
 
 volatile sig_atomic_t Dobby::mSigTerm = 0;
@@ -270,7 +271,7 @@ void Dobby::logConsolePrinter(int level, const char *file, const char *func,
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
 
-    struct iovec iov[5];
+    struct iovec iov[6];
     char tbuf[32];
 
     iov[0].iov_base = tbuf;
@@ -278,55 +279,61 @@ void Dobby::logConsolePrinter(int level, const char *file, const char *func,
                               ts.tv_sec, ts.tv_nsec / 1000);
     iov[0].iov_len = std::min<size_t>(iov[0].iov_len, sizeof(tbuf));
 
+
+    char threadbuf[32];
+    iov[1].iov_base = threadbuf;
+    iov[1].iov_len = snprintf(threadbuf, sizeof(threadbuf), "<T-%lu> ", syscall(SYS_gettid));
+    iov[1].iov_len = std::min<size_t>(iov[1].iov_len, sizeof(threadbuf));
+
     switch (level)
     {
         case AI_DEBUG_LEVEL_FATAL:
-            iov[1].iov_base = (void*)"FTL: ";
-            iov[1].iov_len = 5;
+            iov[2].iov_base = (void*)"FTL: ";
+            iov[2].iov_len = 5;
             break;
         case AI_DEBUG_LEVEL_ERROR:
-            iov[1].iov_base = (void*)"ERR: ";
-            iov[1].iov_len = 5;
+            iov[2].iov_base = (void*)"ERR: ";
+            iov[2].iov_len = 5;
             break;
         case AI_DEBUG_LEVEL_WARNING:
-            iov[1].iov_base = (void*)"WRN: ";
-            iov[1].iov_len = 5;
+            iov[2].iov_base = (void*)"WRN: ";
+            iov[2].iov_len = 5;
             break;
         case AI_DEBUG_LEVEL_MILESTONE:
-            iov[1].iov_base = (void*)"MIL: ";
-            iov[1].iov_len = 5;
+            iov[2].iov_base = (void*)"MIL: ";
+            iov[2].iov_len = 5;
             break;
         case AI_DEBUG_LEVEL_INFO:
-            iov[1].iov_base = (void*)"NFO: ";
-            iov[1].iov_len = 5;
+            iov[2].iov_base = (void*)"NFO: ";
+            iov[2].iov_len = 5;
             break;
         case AI_DEBUG_LEVEL_DEBUG:
-            iov[1].iov_base = (void*)"DBG: ";
-            iov[1].iov_len = 5;
+            iov[2].iov_base = (void*)"DBG: ";
+            iov[2].iov_len = 5;
             break;
         default:
-            iov[1].iov_base = (void*)": ";
-            iov[1].iov_len = 2;
+            iov[2].iov_base = (void*)": ";
+            iov[2].iov_len = 2;
             break;
     }
 
     char fbuf[160];
-    iov[2].iov_base = (void*)fbuf;
+    iov[3].iov_base = (void*)fbuf;
     if (!file || !func || (line <= 0))
-        iov[2].iov_len = snprintf(fbuf, sizeof(fbuf), "< M:? F:? L:? > ");
+        iov[3].iov_len = snprintf(fbuf, sizeof(fbuf), "< M:? F:? L:? > ");
     else
-        iov[2].iov_len = snprintf(fbuf, sizeof(fbuf), "< M:%.*s F:%.*s L:%d > ",
+        iov[3].iov_len = snprintf(fbuf, sizeof(fbuf), "< M:%.*s F:%.*s L:%d > ",
                                   64, file, 64, func, line);
-    iov[2].iov_len = std::min<size_t>(iov[2].iov_len, sizeof(fbuf));
+    iov[3].iov_len = std::min<size_t>(iov[3].iov_len, sizeof(fbuf));
 
-    iov[3].iov_base = const_cast<char*>(message);
-    iov[3].iov_len = strlen(message);
+    iov[4].iov_base = const_cast<char*>(message);
+    iov[4].iov_len = strlen(message);
 
-    iov[4].iov_base = (void*)"\n";
-    iov[4].iov_len = 1;
+    iov[5].iov_base = (void*)"\n";
+    iov[5].iov_len = 1;
 
 
-    writev(fileno((level < AI_DEBUG_LEVEL_INFO) ? stderr : stdout), iov, 5);
+    writev(fileno((level < AI_DEBUG_LEVEL_INFO) ? stderr : stdout), iov, 6);
 }
 
 #if defined(RDK) && defined(USE_SYSTEMD)

--- a/daemon/lib/source/DobbyManager.h
+++ b/daemon/lib/source/DobbyManager.h
@@ -83,7 +83,6 @@ public:
     DobbyManager(const std::shared_ptr<IDobbyEnv>& env,
                  const std::shared_ptr<IDobbyUtils>& utils,
                  const std::shared_ptr<IDobbyIPCUtils>& ipcUtils,
-                 const std::shared_ptr<DobbyLogger> logger,
                  const std::shared_ptr<const IDobbySettings>& settings,
                  const ContainerStartedFunc& containerStartedCb,
                  const ContainerStoppedFunc& containerStoppedCb);
@@ -211,9 +210,9 @@ private:
     const std::shared_ptr<IDobbyUtils> mUtilities;
     const std::shared_ptr<IDobbyIPCUtils> mIPCUtilities;
     const std::shared_ptr<const IDobbySettings> mSettings;
-    const std::shared_ptr<DobbyLogger> mLogger;
 
 private:
+    std::unique_ptr<DobbyLogger> mLogger;
     std::unique_ptr<DobbyRunC> mRunc;
     std::shared_ptr<DobbyState> mState;
 

--- a/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
+++ b/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
@@ -60,7 +60,8 @@ public:
 
     virtual void LoggingLoop(ContainerInfo containerInfo,
                              const bool isBuffer,
-                             const bool createNew) = 0;
+                             const bool createNew,
+                             const std::atomic_bool& cancellationToken) = 0;
 };
 
 // -----------------------------------------------------------------------------

--- a/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
@@ -146,18 +146,21 @@ bool DobbyRdkPluginManager::loadPlugins()
             if (fstatat(dirfd(dir), namelist[i]->d_name, &buf, AT_NO_AUTOMOUNT) != 0)
             {
                 AI_LOG_SYS_ERROR(errno, "failed to stat '%s'", namelist[i]->d_name);
+                free(namelist[i]);
                 continue;
             }
 
             if (!S_ISREG(buf.st_mode))
             {
                 // symlink doesn't point to a regular file so skip it
+                free(namelist[i]);
                 continue;
             }
         }
         else if (namelist[i]->d_type != DT_REG)
         {
             // the entry is not a regular file so skip it
+            free(namelist[i]);
             continue;
         }
 
@@ -189,6 +192,7 @@ bool DobbyRdkPluginManager::loadPlugins()
         {
             dlclose(libHandle);
             AI_LOG_DEBUG("%s does not contain create/destroy functions, skipping...\n", namelist[i]->d_name);
+            free(namelist[i]);
             continue;
         }
 
@@ -237,6 +241,7 @@ bool DobbyRdkPluginManager::loadPlugins()
         {
             AI_LOG_WARN("plugin for library '%s' failed to register", libPath);
             dlclose(libHandle);
+            free(namelist[i]);
             continue;
         }
 
@@ -246,6 +251,7 @@ bool DobbyRdkPluginManager::loadPlugins()
             AI_LOG_WARN("plugin for library '%s' returned an invalid name", libPath);
             plugin.reset();
             dlclose(libHandle);
+            free(namelist[i]);
             continue;
         }
 

--- a/rdkPlugins/Logging/source/LoggingPlugin.h
+++ b/rdkPlugins/Logging/source/LoggingPlugin.h
@@ -56,7 +56,8 @@ public:
     // Logging Specific Methods
     void LoggingLoop(IDobbyRdkLoggingPlugin::ContainerInfo containerInfo,
                      const bool isBuffer,
-                     const bool createNew) override;
+                     const bool createNew,
+                     const std::atomic_bool& cancellationToken) override;
 
 private:
     // Locations the plugin can send the logs
@@ -69,10 +70,10 @@ private:
 
 private:
     LoggingSink GetContainerSink();
-    void FileSink(const ContainerInfo &containerInfo, bool exitEof, bool createNew);
-    void DevNullSink(const ContainerInfo &containerInfo, bool exitEof);
+    void FileSink(const ContainerInfo &containerInfo, bool exitEof, bool createNew, const std::atomic_bool &cancellationToken);
+    void DevNullSink(const ContainerInfo &containerInfo, bool exitEof, const std::atomic_bool &cancellationToken);
 #if defined(USE_SYSTEMD)
-    void JournaldSink(const ContainerInfo &containerInfo, bool exitEof);
+    void JournaldSink(const ContainerInfo &containerInfo, bool exitEof, const std::atomic_bool &cancellationToken);
 #endif
 
 private:

--- a/rdkPlugins/Networking/source/StdStreamPipe.cpp
+++ b/rdkPlugins/Networking/source/StdStreamPipe.cpp
@@ -76,7 +76,7 @@ int StdStreamPipe::writeFd() const
 std::string StdStreamPipe::getPipeContents() const
 {
     std::string contents;
-    char buf[256];
+    char buf[256] = {0};
 
     while (true)
     {


### PR DESCRIPTION
### Description
In some scenarios, DobbyDaemon can segfault during daemon shutdown (whether shutdown is triggered by systemd or the admin.shutdown command over dbus).

Segfault occurs when a container is writing large amounts of log data whilst the container is shutting down. Due to a race condition Dobby can attempt to unload the logging plugin whilst the deamon is still writing logs, causing segfault.

PR makes the following improvements:
* Send cancellation request to logging threads during daemon shutdown to ensure logging finishes cleanly
* Prevent unloading plugin `.so` if a reference is still held (this ideally should never happen but until the root cause of the race condition can be identified this prevents the daemon from crashing entirely)
* Fix warnings and memory leaks reported by Valgrind
* Add thread ID to logs for debugging

### Test Procedure
DobbyDaemon should not segfault at shutdown. Create container config that prints to stdout as fast as possible (e.g. loop echo).

Repeat the following test:
```
DobbyTool start test <path/to/container> && DobbyTool shutdown
```

Dobby should never crash during shutdown

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)