### PR TITLE
Increase default log level in debug builds

### DIFF
--- a/daemon/process/source/Main.cpp
+++ b/daemon/process/source/Main.cpp
@@ -68,7 +68,11 @@ static bool gDaemonise = true;
 static bool gNoConsole = false;
 
 //
+#if (AI_BUILD_TYPE == AI_DEBUG)
+static int gLogLevel = AI_DEBUG_LEVEL_INFO;
+#else
 static int gLogLevel = AI_DEBUG_LEVEL_MILESTONE;
+#endif
 
 //
 static bool gUseSyslog = false;


### PR DESCRIPTION
### Description
Increase the default log level of Debug builds from Milestone to Info.

### Test Procedure
Debug builds should print `NFO` log messages by default

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)