### PR TITLE
XIONE-6161: Increase watchdog timeout

### DIFF
--- a/daemon/process/dobby.service.in
+++ b/daemon/process/dobby.service.in
@@ -38,7 +38,7 @@ Description=RDK Dobby (Container) daemon
 Type=dbus
 BusName=@DOBBY_SERVICE@
 ExecStart=/usr/sbin/DobbyDaemon --nofork --noconsole --journald
-WatchdogSec=5
+WatchdogSec=10
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
### Description
Increase Dobby watchdog timeout to 10 seconds

### Test Procedure


### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)