### PR TITLE
LLAMA-3448: Additional sanity check in trimDuplicates

### DIFF
--- a/rdkPlugins/Networking/source/Netfilter.cpp
+++ b/rdkPlugins/Networking/source/Netfilter.cpp
@@ -379,10 +379,17 @@ void Netfilter::trimDuplicates(RuleSet &existing, RuleSet &newRuleSet, Operation
     for (std::pair<const TableType, std::list<std::string>> &newRules : newRuleSet)
     {
         const TableType &table = newRules.first;
+        AI_LOG_DEBUG("Trimming duplicates for rule type %d", int(table));
         std::list<std::string> &tableRules = newRules.second;
 
         // get the existing table
-        const std::list<std::string> &existingRules = (*(existing.find(table))).second;
+        auto existingIt = existing.find(table);
+        if (existingIt == existing.end())
+        {
+            AI_LOG_WARN("Could not find any existing rules for table type %d", int(table));
+            continue;
+        }
+        const std::list<std::string> &existingRules = (*(existingIt)).second;
 
         // iterate through all rules in the table to check for duplicates
         auto it = tableRules.begin();


### PR DESCRIPTION
### Description
Prevent segfault when checking for duplicate iptables rules

### Test Procedure
See ticket

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)