### PR TITLE
Send plugin log output to journald

### DIFF
--- a/pluginLauncher/tool/CMakeLists.txt
+++ b/pluginLauncher/tool/CMakeLists.txt
@@ -43,9 +43,6 @@ target_link_libraries(${PROJECT_NAME}
     # Export the logging symbols so plugins can use AI_LOG correctly
     -Wl,--dynamic-list=${CMAKE_CURRENT_LIST_DIR}/exported.syms
 
-    # 3rd party libraries
-    JsonCpp::JsonCpp
-
     # Adds dlopen support (if it's a separate library on target)
     ${CMAKE_DL_LIBS}
 
@@ -53,6 +50,13 @@ target_link_libraries(${PROJECT_NAME}
     # from within plugins using IPCService
     Threads::Threads
 )
+
+if(USE_SYSTEMD)
+        target_link_libraries(${PROJECT_NAME}
+                systemd
+        )
+endif(USE_SYSTEMD)
+
 
 install(
     TARGETS ${PROJECT_NAME}

--- a/pluginLauncher/tool/exported.syms
+++ b/pluginLauncher/tool/exported.syms
@@ -1,4 +1,6 @@
 {
     # Export the log level (set with -v flags)
     __ai_debug_log_level;
+    __ai_debug_log_printf;
+    __ai_debug_log_sys_printf;
 };

--- a/pluginLauncher/tool/source/Main.cpp
+++ b/pluginLauncher/tool/source/Main.cpp
@@ -41,6 +41,7 @@
 #include <unordered_map>
 #include <mutex>
 #include <sys/syscall.h>
+#include <sys/uio.h>
 
 #ifdef USE_SYSTEMD
     #define SD_JOURNAL_SUPPRESS_LOCATION


### PR DESCRIPTION
### Description
Send the log output from DobbyPluginLauncher to journald as well as stdout.

On Sky builds, the container stdout is sent to the console.log file, which is not captured as part of the standard log collection. By sending plugin output to journald, it will end up in dobby's logfile inline with the rest of the Dobby and container output (handled by ethanlog)

This will make debugging plugin issues easier

### Test Procedure
* Start container
* Ensure log messages from the createRuntime, createContainer, poststart and poststop should be seen in journald

Example
```
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Running hook poststart for container 'test'
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Loaded plugin 'ipc' from '/usr/lib/plugins/dobby/libIpcPlugin.so.1'
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Loaded plugin 'logging' from '/usr/lib/plugins/dobby/libLoggingPlugin.so.1'
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Loaded plugin 'minidump' from '/usr/lib/plugins/dobby/libMinidumpPlugin.so.1'
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Loaded plugin 'networking' from '/usr/lib/plugins/dobby/libNetworkingPlugin.so.1'
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Loaded plugin 'storage' from '/usr/lib/plugins/dobby/libStoragePlugin.so.1'
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Loaded plugin 'thunder' from '/usr/lib/plugins/dobby/libThunderPlugin.so.1'
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Plugin logging has nothing to do at postStart
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Plugin networking has nothing to do at postStart
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Running storage plugin
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Plugin storage has postStart hook run successfully
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Plugin thunder has nothing to do at postStart
Sep 24 11:15:05 dobby-vagrant-focal test[28789]: Hook poststart completed
Sep 24 11:15:05 dobby-vagrant-focal systemd[4889]: home-vagrant-sleepybundle-rootfs-home-private.temp.mount: Succeeded.
Sep 24 11:15:05 dobby-vagrant-focal systemd[1]: home-vagrant-sleepybundle-rootfs-home-private.temp.mount: Succeeded.
Sep 24 11:15:05 dobby-vagrant-focal DobbyDaemon[24800]: Configuring logging for container 'test' (pid: 28755)
Sep 24 11:15:05 dobby-vagrant-focal DobbyDaemon[24800]: container 'test' started, controller process pid 28755
Sep 24 11:15:05 dobby-vagrant-focal DobbyDaemon[24800]: container 'test'(182) started
```

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)