### PR TITLE
LLAMA-3997 XIONE-6340 Added better codition variable into DobbyWorkQueue

### DIFF
--- a/daemon/lib/source/DobbyWorkQueue.cpp
+++ b/daemon/lib/source/DobbyWorkQueue.cpp
@@ -59,7 +59,7 @@ void DobbyWorkQueue::exit()
     else
     {
         // take the lock and set the terminate flag
-        std::unique_lock<std::mutex> locker(mWorkQueueLock);
+        std::unique_lock<AICommon::Mutex> locker(mWorkQueueLock);
 
         // set the exit request flag and drop the lock
         mExitRequested = true;
@@ -118,7 +118,7 @@ bool DobbyWorkQueue::runUntil(const std::chrono::steady_clock::time_point &deadl
     };
 
     // run the event loop by processing all lambdas posted to the work queue
-    std::unique_lock<std::mutex> locker(mWorkQueueLock);
+    std::unique_lock<AICommon::Mutex> locker(mWorkQueueLock);
 
     // store the id of the thread running the loop
     mRunningThreadId = std::this_thread::get_id();
@@ -203,7 +203,7 @@ bool DobbyWorkQueue::doWork(WorkFunc &&work)
     }
 
     // otherwise add to the queue and return
-    std::unique_lock<std::mutex> queueLocker(mWorkQueueLock);
+    std::unique_lock<AICommon::Mutex> queueLocker(mWorkQueueLock);
 
     // add to the queue
     const uint64_t tag = ++mWorkCounter;
@@ -216,7 +216,7 @@ bool DobbyWorkQueue::doWork(WorkFunc &&work)
 
 
     // then wait for the function to be executed
-    std::unique_lock<std::mutex> completeLocker(mWorkCompleteLock);
+    std::unique_lock<AICommon::Mutex> completeLocker(mWorkCompleteLock);
     while (mWorkCompleteCounter < tag)
     {
         // wait with a timeout for debugging, we log an error if been waiting
@@ -256,7 +256,7 @@ bool DobbyWorkQueue::postWork(WorkFunc &&work)
     else
     {
         // otherwise add to the queue and wait till processed
-        std::lock_guard<std::mutex> locker(mWorkQueueLock);
+        std::lock_guard<AICommon::Mutex> locker(mWorkQueueLock);
 
         // add to the queue
         const uint64_t tag = ++mWorkCounter;

--- a/daemon/lib/source/DobbyWorkQueue.h
+++ b/daemon/lib/source/DobbyWorkQueue.h
@@ -30,7 +30,7 @@
 #include <atomic>
 #include <thread>
 #include <mutex>
-#include <condition_variable>
+#include "ConditionVariable.h"
 #include <functional>
 
 class DobbyWorkQueue
@@ -67,12 +67,12 @@ private:
     bool mExitRequested;
     std::atomic<std::thread::id> mRunningThreadId;
 
-    std::mutex mWorkQueueLock;
-    std::condition_variable mWorkQueueCond;
+    AICommon::Mutex mWorkQueueLock;
+    AICommon::ConditionVariable mWorkQueueCond;
     std::queue< WorkItem > mWorkQueue;
 
-    std::mutex mWorkCompleteLock;
-    std::condition_variable mWorkCompleteCond;
+    AICommon::Mutex mWorkCompleteLock;
+    AICommon::ConditionVariable mWorkCompleteCond;
     uint64_t mWorkCompleteCounter;
 };
 


### PR DESCRIPTION
### Description
Standard C++ std::condition_variable waits don't use
monotonic clock, even if used with std::chrono::steady_clock.
AICommon::ConditionVariable correctly uses monotonic clock
so it is better suited for this purpose.

### Test Procedure
1. On your PC create custom NTP i.e. by using running:
`sudo ntpd -d`
(make sure `listen on` in config is set correctly)
2. then in box run:
`systemctl stop systemd-timesyncd`
`vi /etc/systemd/timesyncd.conf 
---here add your PC ip as provider of NTP---`
`env SYSTEMD_LOG_LEVEL=debug /lib/systemd/systemd-timesyncd`

3. On your PC change time
4. Wait two minutes
5. On the box run:
`cat /opt/logs/sky-messages.log | grep ABRT`
result should be empty
6. You can repeat steps 3-5 x5 times just to make sure

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [x] No
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)