### PR TITLE
XIONE-6749 Mutex was not unlocked before notify

### DIFF
--- a/daemon/lib/source/DobbyWorkQueue.cpp
+++ b/daemon/lib/source/DobbyWorkQueue.cpp
@@ -256,11 +256,13 @@ bool DobbyWorkQueue::postWork(WorkFunc &&work)
     else
     {
         // otherwise add to the queue and wait till processed
-        std::lock_guard<AICommon::Mutex> locker(mWorkQueueLock);
+        std::unique_lock<AICommon::Mutex> locker(mWorkQueueLock);
 
         // add to the queue
         const uint64_t tag = ++mWorkCounter;
         mWorkQueue.emplace(tag, std::move(work));
+
+        locker.unlock();
 
         // wake the event loop
         mWorkQueueCond.notify_one();


### PR DESCRIPTION
### Description
We should unlock mutex before notifying condition variable.

### Test Procedure
- Un-testable (very slim chance to get problems with original issue)

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)
- [x] No