### PR TITLE
XIONE-6236 Don't wait for failed forks

### DIFF
--- a/daemon/lib/source/DobbyRunC.cpp
+++ b/daemon/lib/source/DobbyRunC.cpp
@@ -181,6 +181,7 @@ std::pair<pid_t, pid_t> DobbyRunC::create(const ContainerId &id,
     if (pid <= 0)
     {
         AI_LOG_ERROR_EXIT("failed to execute runc tool");
+        return {-1,-1};
     }
 
     // block waiting for the forked process to complete


### PR DESCRIPTION
### Description
We shouldn't do waitpid if fork failed, as if there was another child it will result in infinite wait. Also why do we even use waitpid at all? In forkExecRunC there is implementation based on vfork which is blocking by definition. Which should mean that if we got to this line we already finished the child process. I guess it wouldn't harm (at least as long as we check if it succeed to fork on the first place).

### Test Procedure
We would somehow need to fail the fork, while having other child process. Only disabling fork at all would get "10 - No child processes" result.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)
- [x] No