### PR TITLE
RDK-34228: Trusted apps can generate their own tokens

### DIFF
--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -494,6 +494,9 @@
                 "data": {
                     "type": "object",
                     "properties": {
+                        "trusted": {
+                            "type": "boolean"
+                        },
                         "bearerUrl": {
                             "type": "string"
                         },

--- a/rdkPlugins/Thunder/README.md
+++ b/rdkPlugins/Thunder/README.md
@@ -37,6 +37,17 @@ The URL defines which roles the container will have based on the Thunder ACL fil
 }
 ```
 
+### Trusted
+If the app is trusted, then it can generate tokens itself - Dobby will mount in the SecurityAgent socket.
+
+:warning: This must only be enabled on apps that are from a known, trusted source where the source code can be verified by the operator, 3rd party apps should not be allowed to generate their own token. This is because it would be possible for an app to spoof their identity and generate a token for a different application.
+
+```json
+"data": {
+    "trusted": true
+}
+```
+
 ### Connection Limit
 *Note: this feature is currently disabled - change `mEnableConnLimit` in `ThunderPlugin.cpp` to true to enable*
 

--- a/rdkPlugins/Thunder/source/ThunderPlugin.h
+++ b/rdkPlugins/Thunder/source/ThunderPlugin.h
@@ -108,5 +108,8 @@ private:
 private:
     std::mutex mLock;
     const bool mEnableConnLimit;
+    const std::string mSocketDirectory;
+    const std::string mSocketPath;
+    bool mSocketExists;
 };
 #endif // !defined(THUNDERPLUGIN_H)


### PR DESCRIPTION
### Description
Some applications should be allowed to generate their own tokens instead of relying on the pre-generated token from Dobby.

This is required for applications such as web browsers where the single container configuration can be reused for many different applications, each requiring a unique token.

### Test Procedure
Create a container with Thunder plugin and set `trusted: true`.

The container should have a bind-mount for the security agent socket, and should be able to generate it's own token.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)