### PR TITLE
XIONE-6236 Create timeout for RuncCreate

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -313,7 +313,7 @@ void DobbyManager::cleanupContainers()
             case DobbyRunC::ContainerStatus::Pausing:
             case DobbyRunC::ContainerStatus::Running:
                 AI_LOG_INFO("attempting to kill old container '%s'", id.c_str());
-                mRunc->kill(id, SIGKILL, true);
+                mRunc->killCont(id, SIGKILL, true);
                 // fall through
 
             case DobbyRunC::ContainerStatus::Created:
@@ -550,7 +550,7 @@ bool DobbyManager::createAndStartContainer(const ContainerId &id,
 
         // Something went wrong during container start, clean up everything
         // kill the container created
-        if (!mRunc->kill(id, SIGKILL))
+        if (!mRunc->killCont(id, SIGKILL))
         {
             AI_LOG_ERROR("failed to kill (non-running) container for '%s'",
                         id.c_str());
@@ -1122,7 +1122,7 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
     // we are consistent with the tools
     else if (container->state == DobbyContainer::State::Running)
     {
-        if (!mRunc->kill(id, withPrejudice ? SIGKILL : SIGTERM))
+        if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM))
         {
             AI_LOG_WARN("failed to send signal to '%s'", id.c_str());
             AI_LOG_FN_EXIT();
@@ -1155,7 +1155,7 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
             }
 
             // Container has been resumed, so kill it now
-            if (!mRunc->kill(id, withPrejudice ? SIGKILL : SIGTERM))
+            if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM))
             {
                 AI_LOG_WARN("failed to send signal to '%s'", id.c_str());
                 AI_LOG_FN_EXIT();

--- a/daemon/lib/source/DobbyRunC.cpp
+++ b/daemon/lib/source/DobbyRunC.cpp
@@ -173,20 +173,131 @@ std::pair<pid_t, pid_t> DobbyRunC::create(const ContainerId &id,
 
     runtimeArgs.push_back(id.c_str());
 
+    // additional security in case worker stucks
+    int status;
+    pid_t exited_pid;
+    pid_t worker_pid;
+    pid_t timeout_pid;
+
     // run the following command "runc create --bundle <dir> <id>"
-    pid_t pid = forkExecRunC(runtimeArgs,
-                             { },
-                             files,
-                             console, console);
-    if (pid <= 0)
+    worker_pid = forkExecRunC(runtimeArgs,
+                            { },
+                            files,
+                            console, console);
+    if (worker_pid <= 0)
     {
         AI_LOG_ERROR_EXIT("failed to execute runc tool");
         return {-1,-1};
     }
 
-    // block waiting for the forked process to complete
-    int status;
-    if (TEMP_FAILURE_RETRY(waitpid(pid, &status, 0)) < 0)
+    timeout_pid = fork();
+    if (timeout_pid == 0) {
+        // Wait 0.5 second
+        struct timespec timeout_val, remaining;
+        timeout_val.tv_nsec = 500000000L;
+        timeout_val.tv_sec = 0;
+
+        // In case signal comes during wait
+        while(nanosleep(&timeout_val, &remaining) && errno==EINTR){
+            timeout_val=remaining;
+        }
+
+        _exit(0);
+    }
+
+    // Wait for either worker or timeout to finish
+    do
+    {
+        exited_pid = TEMP_FAILURE_RETRY(wait(&status));
+        if (exited_pid >= 0 && 
+            exited_pid != timeout_pid &&
+            exited_pid != worker_pid)
+        {
+            AI_LOG_DEBUG("Found non-waited process with pid %d", exited_pid);
+        }
+    } while (exited_pid >= 0 && 
+            exited_pid != timeout_pid &&
+            exited_pid != worker_pid);
+
+    if (exited_pid == timeout_pid)
+    {
+        // Timeout occured
+        // Check if we can kill worker_pid (if it ended already
+        // then we will be unable to kill)
+        if (kill(worker_pid, 0) == -1)
+        {
+            // Cannot kill process, probably already dead
+            // treat it as if it would return proper waitpid
+            AI_LOG_DEBUG("Cannot kill after timeout");
+            exited_pid = waitpid(worker_pid, &status, WNOHANG);
+        }
+        else
+        {
+            // Worker is stuck, we need to kill it
+            AI_LOG_DEBUG("Can kill after timeout");
+            kill(worker_pid, SIGKILL);
+            // Collect the worker process
+            waitpid(worker_pid, &status, 0);
+            // Collect child of worker if any
+            wait(nullptr); 
+        }
+
+    }
+    else if (exited_pid == worker_pid)
+    {
+        // Worker finished
+        kill(timeout_pid, SIGKILL);
+        // Collect the timeout process
+        wait(nullptr); 
+    }
+
+
+    // Now as we had finished both forks we can safely exit if necessary
+    if (exited_pid == timeout_pid)
+    {
+        AI_LOG_WARN("Timeout occured - container creation has hung. Cleaning up");
+
+        // We need to clean up after failed container creation, as we
+        // don't know when in creation process it failed do full step
+        // by step procedure
+
+        // First kill container so it is in stopped state
+        if (!killCont(id, SIGKILL))
+        {
+            // Even though the container couldn't be killed it can still
+            // exists so we still need to destroy it so no return here
+            AI_LOG_WARN("failed to kill (non-running) container for '%s'",
+                        id.c_str());
+        }
+        else
+        {
+            // We are not sure if process started, so check if we can get
+            // container pid, read the file
+            pid_t containerPid = readPidFile(pidFilePath);
+            if (containerPid > 0)
+            {
+                // wait for the half-started container to terminate
+                if (waitpid(containerPid, nullptr, 0) < 0)
+                {
+                    AI_LOG_SYS_ERROR(errno, "error waiting for (non-running) container '%s' to terminate",
+                                    id.c_str());
+                }
+            }
+        }
+
+        // Don't bother capturing hook logs here
+        std::shared_ptr<DobbyDevNullStream> nullstream = std::make_shared<DobbyDevNullStream>();
+        AI_LOG_INFO("attempting to destroy (non-running) container '%s'", id.c_str());
+        // Force delete by default as we have no idea what condition the container is in
+        // and it may not respond to a normal delete
+        if (!destroy(id, nullstream, true))
+        {
+            AI_LOG_ERROR("failed to destroy '%s'", id.c_str());
+        }
+
+        return {-1,-1};
+    }
+    else if (exited_pid < 0)
     {
         AI_LOG_SYS_ERROR_EXIT(errno, "waitpid failed");
         return {-1,-1};
@@ -204,24 +315,15 @@ std::pair<pid_t, pid_t> DobbyRunC::create(const ContainerId &id,
 
     // now need to read the pid file it created so we know were to find the
     // container
-    const size_t maxLength = 64;
-    std::string pidFileContents = mUtilities->readTextFile(pidFilePath, maxLength);
-    if (pidFileContents.empty())
+    pid_t containerPid = readPidFile(pidFilePath);
+    if (containerPid < 0)
     {
-        AI_LOG_ERROR_EXIT("failed to read pid file contents");
-        return {-1,-1};
-    }
-
-    char *endptr;
-    pid_t containerPid = static_cast<pid_t>(strtol(pidFileContents.c_str(), &endptr, 0));
-    if (endptr == pidFileContents.c_str())
-    {
-        AI_LOG_ERROR_EXIT("failed to to convert '%s' to a pid", pidFileContents.c_str());
+        AI_LOG_ERROR_EXIT("Wrong container pid, read from file failed");
         return {-1,-1};
     }
 
     AI_LOG_FN_EXIT();
-    return std::make_pair(pid, containerPid);
+    return std::make_pair(worker_pid, containerPid);
 }
 
 // -----------------------------------------------------------------------------
@@ -289,7 +391,7 @@ bool DobbyRunC::start(const ContainerId& id, const std::shared_ptr<const IDobbyS
  *
  *  @return true or false based on the return code of the runc tool.
  */
-bool DobbyRunC::kill(const ContainerId& id, int signal, bool all) const
+bool DobbyRunC::killCont(const ContainerId& id, int signal, bool all) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -378,7 +480,7 @@ bool DobbyRunC::kill(const ContainerId& id, int signal, bool all) const
             AI_LOG_DEBUG("SIGTERM kill wasn't kill container (probably masked), "
                         "retrying kill with SIGKILL");
             // retry kill with SIGKILL now, its result will be proper result now
-            returnValue = DobbyRunC::kill(id, SIGKILL, all);
+            returnValue = DobbyRunC::killCont(id, SIGKILL, all);
         }
     }
 
@@ -1177,4 +1279,32 @@ pid_t DobbyRunC::forkExecRunC(const std::vector<const char*>& args,
     return pid;
 }
 
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Reads file with pid of the container and converts it into pid_t
+ *  type variable.
+ *
+ *  @return container pid, -1 if failed
+ *
+ */
+pid_t DobbyRunC::readPidFile(const std::string pidFilePath) const
+{
+    const size_t maxLength = 64;
+    std::string pidFileContents = mUtilities->readTextFile(pidFilePath, maxLength);
+    if (pidFileContents.empty())
+    {
+        AI_LOG_INFO("failed to read pid file contents");
+        return -1;
+    }
+
+    char *endptr;
+    pid_t containerPid = static_cast<pid_t>(strtol(pidFileContents.c_str(), &endptr, 0));
+    if (endptr == pidFileContents.c_str())
+    {
+        AI_LOG_INFO("failed to to convert '%s' to a pid", pidFileContents.c_str());
+        return -1;
+    }
+
+    return containerPid;
+}
 

--- a/daemon/lib/source/DobbyRunC.cpp
+++ b/daemon/lib/source/DobbyRunC.cpp
@@ -192,10 +192,10 @@ std::pair<pid_t, pid_t> DobbyRunC::create(const ContainerId &id,
 
     timeout_pid = fork();
     if (timeout_pid == 0) {
-        // Wait 0.5 second
+        // Wait 5.5 second
         struct timespec timeout_val, remaining;
         timeout_val.tv_nsec = 500000000L;
-        timeout_val.tv_sec = 0;
+        timeout_val.tv_sec = 5;
 
         // In case signal comes during wait
         while(nanosleep(&timeout_val, &remaining) && errno==EINTR){

--- a/daemon/lib/source/DobbyRunC.h
+++ b/daemon/lib/source/DobbyRunC.h
@@ -72,7 +72,7 @@ public:
 
     bool destroy(const ContainerId &id, const std::shared_ptr<const IDobbyStream> &console, bool force = false) const;
     bool start(const ContainerId &id, const std::shared_ptr<const IDobbyStream> &console) const;
-    bool kill(const ContainerId &id, int signal, bool all = false) const;
+    bool killCont(const ContainerId &id, int signal, bool all = false) const;
     bool pause(const ContainerId &id) const;
     bool resume(const ContainerId &id) const;
     std::pair<pid_t, pid_t> exec(const ContainerId &id,
@@ -97,6 +97,8 @@ private:
                        const std::list<int> &files = std::list<int>(),
                        const std::shared_ptr<const IDobbyStream> &stdoutStream = nullptr,
                        const std::shared_ptr<const IDobbyStream> &stderrStream = nullptr) const;
+
+    pid_t readPidFile(const std::string pidFilePath) const;
 
     ContainerStatus getContainerStatusFromJson(const Json::Value &state) const;
 


### PR DESCRIPTION
### Description
We need to make sure RuncCreate doesn't stuck. We need to add timeout in case this process take too long and kill it if needed.
This is continuation of https://github.com/rdkcentral/Dobby/pull/150 as on some platforms previous timeout was insufficient.

### Test Procedure
Change timeout to 80000 ms (so it will sometime destroy creation in the middle) and check if next run will be successful (assuming no timeout occurred).

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)
- [x] No 