### PR TITLE
Don't call ip6tables if ipv6 disabled in config

### DIFF
--- a/rdkPlugins/Networking/source/Netfilter.cpp
+++ b/rdkPlugins/Networking/source/Netfilter.cpp
@@ -484,6 +484,8 @@ bool Netfilter::applyRules(const int ipVersion)
 {
     AI_LOG_FN_ENTRY();
 
+    AI_LOG_INFO("Applying iptables rules for IPv%d", ipVersion == AF_INET ? 4 : 6);
+
     // we simply need to pipe the fixed iptables rules into iptables-restore
     // without flushing the existing rules
 

--- a/rdkPlugins/Networking/source/NetworkingPlugin.cpp
+++ b/rdkPlugins/Networking/source/NetworkingPlugin.cpp
@@ -249,9 +249,22 @@ bool NetworkingPlugin::createRuntime()
     }
 
     // apply iptables changes
-    if (!mNetfilter->applyRules(AF_INET) || !mNetfilter->applyRules(AF_INET6))
+    bool iptablesSuccess = true;
+    if (mHelper->ipv4() && !mNetfilter->applyRules(AF_INET))
     {
-        AI_LOG_ERROR_EXIT("failed to apply iptables rules");
+        AI_LOG_ERROR("failed to apply iptables rules");
+        iptablesSuccess = false;
+    }
+
+    if (mHelper->ipv6() && !mNetfilter->applyRules(AF_INET6))
+    {
+        AI_LOG_ERROR("failed to apply iptables IPv6 rules");
+        iptablesSuccess = false;
+    }
+
+    if (!iptablesSuccess)
+    {
+        AI_LOG_FN_EXIT();
         return false;
     }
 


### PR DESCRIPTION
### Description
If IPv6 is disabled in the container config, Dobby should never attempt to call `ip6tables`.

### Test Procedure
Create container config with ipv6 disabled. Launch container. Dobby should never attempt to run `ip6tables-restore`. Dobby should only run `ip6tables-restore` when `ipv6: true` is set in the networking config.

Needed on VAs where ip6tables-restore isn't working (ipv6 support not needed)

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)