### PR TITLE
XIONE-6749 Created high priority watchdog wagger

### DIFF
--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -2053,6 +2053,54 @@ void Dobby::onContainerStopped(int32_t cd, const ContainerId& id, int status)
 }
 
 #if defined(RDK) && defined(USE_SYSTEMD)
+#define WATCHDOG_TIMEOUT_SEC 10L
+#define WATCHDOG_UPDATE_SEC  (WATCHDOG_TIMEOUT_SEC/2)
+#define HIGH_USAGE_TIME_SEC  120L
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief This function should be run as thread fro wagging watchdog
+ *
+ *  As on some platforms we expirienced heavy load from unidentified source
+ *  Dobby got shut down by the watchdog. It is hard to pinpoint which process
+ *  is taking those resources, but it looks like this happens during bootup.
+ *  This function if run as separate thread will work around the problem by
+ *  creating high priority watchdog wagger for the time period where the
+ *  issue exists. During this time there will be 2 concurent wagging procedures,
+ *  but this doesn't harm.
+ *  We should delete this code when we find out the real offender.
+ *
+ */
+void wag_watchdog_heavy_load()
+{
+    struct timespec wag_period, remaining;
+    int ping_count;
+
+    // set the lowest priority of real time policy
+    struct sched_param sp;
+    sp.sched_priority = sched_get_priority_min(SCHED_RR);
+    int ret;
+
+    ret = sched_setscheduler(0, SCHED_RR, &sp);
+    if (ret == -1) {
+        AI_LOG_ERROR("Couldn't schedule real time priority for wag_watchdog_heavy_load");
+    }
+
+    for (ping_count = HIGH_USAGE_TIME_SEC/WATCHDOG_UPDATE_SEC; ping_count > 0; ping_count--)
+    {
+        wag_period.tv_sec = WATCHDOG_UPDATE_SEC;
+        wag_period.tv_nsec = 0L;
+
+        // wait for desired time
+        while(nanosleep(&wag_period, &remaining) && errno==EINTR){
+            wag_period=remaining;
+        }
+
+        // We probably shouldn't log fails inside here, as logger could be blocked.
+        sd_notify(0, "WATCHDOG=1");
+    }
+}
+
 // -----------------------------------------------------------------------------
 /**
  *  @brief Starts a timer to ping ourselves over dbus to send a watchdog
@@ -2090,6 +2138,10 @@ void Dobby::initWatchdog()
         mUtilities->startTimer(std::chrono::microseconds(usecTimeout),
                                 false,
                                 std::bind(&Dobby::onWatchdogTimer, this));
+
+    // Run heavy load wagger thread
+    std::thread wagger(wag_watchdog_heavy_load);
+    wagger.detach();
 
     AI_LOG_FN_EXIT();
 }


### PR DESCRIPTION
### Description
Created high priority wagging thread for Dobby, which will work even if CPU resources are scarce. It has a downside of not reflecting true Dobby state, but this is required during boot-up as sometimes Dobby gets killed by watchdog due to other processes taking to much CPU. This solution is a workaround and should be disabled when real offenders are found.

### Test Procedure
Force box to be out of CPU for more than 10 seconds (watchdog timeout) and running `systemctl status Dobby` should show if Dobby restarted. Without this fix there is 24% chance to dobby to be restarted. With this fix during the first 120 seconds (defined by `HIGH_USAGE_TIME_SEC`) there should be not restart due to high CPU usage. For testing one can set this define to something very big (I used 3600 just so I can make a lot of tests).

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)