### PR TITLE
RDKTV-12390: Handle long container log lines better with  journald

### DIFF
--- a/daemon/lib/source/DobbyLogger.cpp
+++ b/daemon/lib/source/DobbyLogger.cpp
@@ -179,7 +179,7 @@ void DobbyLogger::connectionMonitorThread(const int socketFd)
 {
     AI_LOG_FN_ENTRY();
 
-    pthread_setname_np(pthread_self(), "DOBBY_LOGGER_CONNECTION_MONITOR");
+    pthread_setname_np(pthread_self(), "DOBBY_LOG_MON");
 
     AI_LOG_INFO("Dobby Logger socket monitoring thread started");
 

--- a/rdkPlugins/Logging/source/LoggingPlugin.h
+++ b/rdkPlugins/Logging/source/LoggingPlugin.h
@@ -28,6 +28,9 @@
 #include <memory>
 #include <mutex>
 
+// Max pty buffer size is 4096
+#define PTY_BUFFER_SIZE 4096
+
 /**
  * @brief Dobby Logging plugin
  */


### PR DESCRIPTION
### Description
Prevent Dobby from locking up and using excessive CPU when printing very long log messages to journald.

This only impacts the journald log sink, logging to files was not affected by this issue

### Test Procedure
Create test container that prints a very long single line (>8000 chars) and configure logging plugin to use journald.

Log message should be printed to journald without error. Note very, very long messages max be broken up into multiple lines based on the journal's LineMax setting

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)