### PR TITLE
XIONE-6236 Kill CrunCreate group instead of only process

### DIFF
--- a/daemon/lib/source/DobbyRunC.cpp
+++ b/daemon/lib/source/DobbyRunC.cpp
@@ -233,9 +233,10 @@ std::pair<pid_t, pid_t> DobbyRunC::create(const ContainerId &id,
         }
         else
         {
-            // Worker is stuck, we need to kill it
+            // Worker is stuck, we need to kill whole group
+            // in case any child process was stuck too
             AI_LOG_DEBUG("Can kill after timeout");
-            kill(worker_pid, SIGKILL);
+            killpg(worker_pid, SIGKILL);
             // Collect the worker process
             waitpid(worker_pid, &status, 0);
             // Collect child of worker if any
@@ -1249,8 +1250,8 @@ pid_t DobbyRunC::forkExecRunC(const std::vector<const char*>& args,
             _exit(EXIT_FAILURE);
 
         // Create a new SID for the child process
-        //if (setsid() < 0)
-        //    _exit(EXIT_FAILURE);
+        if (setsid() < 0)
+            _exit(EXIT_FAILURE);
 
         // Change the current working directory
         if ((chdir("/")) < 0)


### PR DESCRIPTION
### Description
If timeout occur we should kill whole group, not only parent process. Sadly it will not help if other sessions are created, but it is better than previous solution.

### Test Procedure
Change timeout to 80000 ms (so it will sometime destroy creation in the middle) and check if timeout occurred process group was killed properly.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)