### PR TITLE
XIONE-7154 Plugin launcher hook execution timeout

### DIFF
--- a/pluginLauncher/lib/include/DobbyRdkPluginManager.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginManager.h
@@ -66,6 +66,10 @@ private:
     bool preprocessPlugins();
     bool executeHook(const std::string &pluginName,
                      const IDobbyRdkPlugin::HintFlags hook) const;
+    bool executeHookTimeout(const std::string &pluginName,
+                            const IDobbyRdkPlugin::HintFlags hook,
+                            const uint timeoutMs) const;
+    std::string HookPointToString(const IDobbyRdkPlugin::HintFlags &hookPoint) const;
 
     bool implementsHook(const std::string &pluginName,
                         const IDobbyRdkPlugin::HintFlags hook) const;

--- a/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
@@ -34,6 +34,9 @@
 #include <dlfcn.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
+#include <sys/mman.h>
+#include <signal.h>
 
 #include <functional>
 #include <list>
@@ -659,25 +662,131 @@ bool DobbyRdkPluginManager::executeHook(const std::string &pluginName,
 
 // -----------------------------------------------------------------------------
 /**
- * @brief Run the plugins specified in the container config at the given hook point.
- * Returns true if all required plugins execute successfully. If non-required plugins
- * fail or are not loaded, then it logs an error but continues running other plugins
+ * Runs the specified hook for a given plugin, controls if execution takes
+ * less than timeoutMs value.
  *
- * @param[in]   hookPoint   Which hook point to execute
+ * @param[in]   pluginName      Name of the plugin to run
+ * @param[in]   hook            Which hook to execute
+ * @param[in]   timeoutMs       Timeout value in miliseconds
  *
- * @return True if all required plugins ran successfully
- *
+ * @return True if the hook executed successfully
  */
-bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint) const
+bool DobbyRdkPluginManager::executeHookTimeout(const std::string &pluginName,
+                                                const IDobbyRdkPlugin::HintFlags hook,
+                                                const uint timeoutMs) const
 {
-    AI_LOG_FN_ENTRY();
+    int status;
+    pid_t exitedPid;
+    pid_t workerPid;
+    pid_t timeoutPid;
+    const size_t sharedMemorySize = 1;
 
-    if (!mValid)
+    // Create shared memory to get result from hook execution
+    void* sharedMemory = mmap(NULL, sharedMemorySize, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+
+    // Set result as fail in case we need to kill worker
+    *(char *)sharedMemory = 0;
+
+    workerPid = fork();
+    if (workerPid == 0)
     {
-        AI_LOG_ERROR_EXIT("Container config invalid. Plugins will not be run");
+        // Create a new SID for the child process
+        if (setsid() < 0)
+            _exit(EXIT_FAILURE);
+
+        char result = (char) executeHook(pluginName, hook);
+
+        // Set result in shared memory
+        *(char *)sharedMemory = result;
+
+        _exit(0);
+    }
+    else if (workerPid < 0)
+    {
+        AI_LOG_ERROR_EXIT("Failed to create for for executeHookTimeout");
         return false;
     }
 
+    timeoutPid = fork();
+    if (timeoutPid == 0) {
+        struct timespec timeout_val, remaining;
+        timeout_val.tv_nsec = (long)(timeoutMs % 1000) * 1000000;
+        timeout_val.tv_sec = timeoutMs/1000;
+
+        // In case signal comes during wait
+        while(nanosleep(&timeout_val, &remaining) && errno==EINTR){
+            timeout_val=remaining;
+        }
+
+        _exit(0);
+    }
+
+    // Wait for either worker or timeout to finish
+    do
+    {
+        exitedPid = TEMP_FAILURE_RETRY(wait(&status));
+        if (exitedPid >= 0 &&
+            exitedPid != timeoutPid &&
+            exitedPid != workerPid)
+        {
+            AI_LOG_DEBUG("Found non-waited process with pid %d", exitedPid);
+        }
+    } while (exitedPid >= 0 &&
+            exitedPid != timeoutPid &&
+            exitedPid != workerPid);
+
+    if (exitedPid == timeoutPid)
+    {
+        // Timeout occurred
+        AI_LOG_ERROR("Timeout executing plugin %s hookpoint %s",
+                    pluginName.c_str(), HookPointToString(hook).c_str());
+
+        // Check if we can kill workerPid (if it ended already
+        // then we will be unable to kill)
+        if (kill(workerPid, 0) == -1)
+        {
+            // Cannot kill process, probably already dead
+            // treat it as if it would return proper waitpid
+            AI_LOG_DEBUG("Cannot kill after timeout");
+            exitedPid = waitpid(workerPid, &status, WNOHANG);
+        }
+        else
+        {
+            // Worker is stuck, we need to kill whole group
+            // in case any child process was stuck too
+            AI_LOG_DEBUG("Can kill after timeout");
+            killpg(workerPid, SIGKILL);
+            // Collect the worker process
+            waitpid(workerPid, &status, 0);
+            // Collect child of worker if any
+            wait(nullptr);
+        }
+
+    }
+    else if (exitedPid == workerPid)
+    {
+        // Worker finished
+        kill(timeoutPid, SIGKILL);
+        // Collect the timeout process
+        wait(nullptr);
+    }
+
+    // get result and free shared memory
+    bool result = (bool) *(char *)sharedMemory;
+    munmap(sharedMemory, sharedMemorySize);
+    return result;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ * Converts hook point into human readable string
+ *
+ * @param[in]   hook            Which hook to translate
+ *
+ * @return std::string with representation, empty if not found.
+ */
+std::string DobbyRdkPluginManager::HookPointToString(const IDobbyRdkPlugin::HintFlags &hookPoint) const
+{
     // Get the hook name as string, mostly just for logging purposes
     std::string hookName;
     switch (hookPoint)
@@ -710,6 +819,35 @@ bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoi
         break;
     default:
         AI_LOG_ERROR_EXIT("Unknown Hook Point");
+    }
+    return hookName;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Run the plugins specified in the container config at the given hook point.
+ * Returns true if all required plugins execute successfully. If non-required plugins
+ * fail or are not loaded, then it logs an error but continues running other plugins
+ *
+ * @param[in]   hookPoint   Which hook point to execute
+ *
+ * @return True if all required plugins ran successfully
+ *
+ */
+bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint) const
+{
+    AI_LOG_FN_ENTRY();
+
+    if (!mValid)
+    {
+        AI_LOG_ERROR_EXIT("Container config invalid. Plugins will not be run");
+        return false;
+    }
+
+    // Get the hook name as string, mostly just for logging purposes
+    std::string hookName = HookPointToString(hookPoint);
+    if(hookName.empty())
+    {
         return false;
     }
 
@@ -754,7 +892,7 @@ bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoi
 
         // Everything looks good, run the plugin
         AI_LOG_INFO("Running %s plugin", pluginName.c_str());
-        const bool success = executeHook(pluginName, hookPoint);
+        const bool success = executeHookTimeout(pluginName, hookPoint, 4000);
 
         // If the plugin has failed and is required, don't bother running any
         // other plugins. If it's not required, just log it


### PR DESCRIPTION
### Description
Added timeout for hook execution in plugin launcher because it looks like some plugins freezes. With additional log provided by this commit we should be able to pinpoint the offender.

### Test Procedure
Modify any plugin to have some long (more than 4 seconds) wait in it. This should make timeout happen and if plugin is required then container will fail to start.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)