### PR TITLE
Upgrade libocispec to latest version

### DIFF
--- a/bundle/runtime-schemas/add_plugin_tables.py
+++ b/bundle/runtime-schemas/add_plugin_tables.py
@@ -65,7 +65,7 @@ def process_c_file(c_file):
     pattern = re.compile("if \(ret->([a-z]+) == NULL && \*err != 0\)")
     pattern2 = re.compile("ret = calloc \(1, sizeof \(\*ret\)\);")
     function_start_pattern = re.compile("make_[a-z_]+_rdk_plugins")
-    function_end_pattern = re.compile("if \(tree->type == yajl_t_object && \(ctx->options & OPT_PARSE_STRICT\)\)")
+    function_end_pattern = re.compile("return move_ptr \(ret\);")
 
     with open(c_file, 'r') as file:
         file_content = file.readlines()
@@ -83,7 +83,7 @@ def process_c_file(c_file):
             for match in re.finditer(pattern, line):
                 # print('Found on line %s: %s' % (i+1, match.group()))
                 # print(match.group(1))
-                add_c_content(match.group(1), file_content, i+5)
+                add_c_content(match.group(1), file_content, i+4)
                 found_plugins_count += 1
                 longest_plugin_name = max(longest_plugin_name, len(match.group(1)))
 

--- a/cmake/Findlibocispec.cmake
+++ b/cmake/Findlibocispec.cmake
@@ -130,8 +130,11 @@ function(GenerateLibocispec)
     # Now run the generator to make our code
     execute_process(
         WORKING_DIRECTORY ${LIBOCISPEC_DIR}
-        COMMAND python3 ./src/generate.py --gen-common --gen-ref --root=./schemas --out=${LIBOCISPEC_GENERATED_DIR} ./schemas/rt
+        COMMAND python3 ./src/generate.py --gen-ref --root=./schemas --out=${LIBOCISPEC_GENERATED_DIR} ./schemas/rt
     )
+
+    file(COPY "${LIBOCISPEC_DIR}/src/json_common.c" DESTINATION ${LIBOCISPEC_GENERATED_DIR}/)
+    file(COPY "${LIBOCISPEC_DIR}/src/json_common.h" DESTINATION ${LIBOCISPEC_GENERATED_DIR}/)
 
     # DobbyConfig needs to be able to see a list of plugins' names and pointers to their structs
     # Add plugin tables to Dobby's schema


### PR DESCRIPTION
### Description
Upgrade libocispec to latest version to bring in bugfixes and support latest OCI runtime spec version

### Test Procedure
Ensure containers work as normal, and no container config options are lost/mangled during container creation - specifically regarding plugins

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)