### PR TITLE
RDKTV-12717/RDKTV-13079: Support relaying syslog/journald messages

### DIFF
--- a/AppInfrastructure/Common/include/IPollLoop.h
+++ b/AppInfrastructure/Common/include/IPollLoop.h
@@ -42,7 +42,7 @@ public:
     virtual ~IPollSource() { }
 
 public:
-    virtual void process(const std::shared_ptr<IPollLoop>& pollLoop, uint32_t events) = 0;
+    virtual void process(const std::shared_ptr<IPollLoop>& pollLoop, epoll_event event) = 0;
 };
 
 class IPollLoop
@@ -59,7 +59,7 @@ public:
 
     virtual bool addSource(const std::shared_ptr<IPollSource>& source, int fd, uint32_t events) = 0;
     virtual bool modSource(const std::shared_ptr<IPollSource>& source, uint32_t events) = 0;
-    virtual void delSource(const std::shared_ptr<IPollSource>& source) = 0;
+    virtual void delSource(const std::shared_ptr<IPollSource>& source, int fd = -1) = 0;
     virtual void delAllSources() = 0;
 };
 

--- a/AppInfrastructure/Common/include/IPollLoop.h
+++ b/AppInfrastructure/Common/include/IPollLoop.h
@@ -60,6 +60,7 @@ public:
     virtual bool addSource(const std::shared_ptr<IPollSource>& source, int fd, uint32_t events) = 0;
     virtual bool modSource(const std::shared_ptr<IPollSource>& source, uint32_t events) = 0;
     virtual void delSource(const std::shared_ptr<IPollSource>& source) = 0;
+    virtual void delAllSources() = 0;
 };
 
 } // namespace AICommon

--- a/AppInfrastructure/Common/include/PollLoop.h
+++ b/AppInfrastructure/Common/include/PollLoop.h
@@ -70,6 +70,7 @@ public:
     virtual bool addSource(const std::shared_ptr<IPollSource>& source, int fd, uint32_t events) override;
     virtual bool modSource(const std::shared_ptr<IPollSource>& source, uint32_t events) override;
     virtual void delSource(const std::shared_ptr<IPollSource>& source) override;
+    void delAllSources();
 
     virtual std::thread::id threadId() const override;
     virtual pid_t gettid() const override;

--- a/AppInfrastructure/Common/include/PollLoop.h
+++ b/AppInfrastructure/Common/include/PollLoop.h
@@ -69,7 +69,7 @@ public:
 
     virtual bool addSource(const std::shared_ptr<IPollSource>& source, int fd, uint32_t events) override;
     virtual bool modSource(const std::shared_ptr<IPollSource>& source, uint32_t events) override;
-    virtual void delSource(const std::shared_ptr<IPollSource>& source) override;
+    virtual void delSource(const std::shared_ptr<IPollSource>& source, int fd = -1) override;
     virtual void delAllSources() override;
 
     virtual std::thread::id threadId() const override;

--- a/AppInfrastructure/Common/include/PollLoop.h
+++ b/AppInfrastructure/Common/include/PollLoop.h
@@ -70,7 +70,7 @@ public:
     virtual bool addSource(const std::shared_ptr<IPollSource>& source, int fd, uint32_t events) override;
     virtual bool modSource(const std::shared_ptr<IPollSource>& source, uint32_t events) override;
     virtual void delSource(const std::shared_ptr<IPollSource>& source) override;
-    void delAllSources();
+    virtual void delAllSources() override;
 
     virtual std::thread::id threadId() const override;
     virtual pid_t gettid() const override;

--- a/AppInfrastructure/Common/source/PollLoop.cpp
+++ b/AppInfrastructure/Common/source/PollLoop.cpp
@@ -374,6 +374,16 @@ void PollLoop::delSource(const std::shared_ptr<IPollSource>& source)
     return;
 }
 
+// -----------------------------------------------------------------------------
+/**
+ * @brief Removes all sources
+ *
+ * It's important to note that even after sources has been removed and this
+ * function returns, it's possible for the source's process() method to be called.
+ * This is because the poll loop thread locks the shared_ptrs while processing
+ * the events.
+ *
+ */
 void PollLoop::delAllSources()
 {
     AI_LOG_FN_ENTRY();

--- a/AppInfrastructure/Common/source/PollLoop.cpp
+++ b/AppInfrastructure/Common/source/PollLoop.cpp
@@ -736,7 +736,7 @@ void PollLoop::run(const std::string& name, int priority)
                             {
                                 // Failed to get the shared_ptr, should we remove
                                 // it from the list of sources ?
-                               AI_LOG_ERROR("failed to get source shared_ptr");
+                                AI_LOG_ERROR("failed to get source shared_ptr");
                             }
                         }
                     }

--- a/AppInfrastructure/Common/source/PollLoop.cpp
+++ b/AppInfrastructure/Common/source/PollLoop.cpp
@@ -328,9 +328,11 @@ bool PollLoop::modSource(const std::shared_ptr<IPollSource>& source, uint32_t ev
  * the events.
  *
  * @param[in]  source   The source object to remove from the poll loop.
+ * @param[in]  fd       (Optional) If the same source has been registered for multiple
+ *                      fds, only remove the source for this specific fd
  *
  */
-void PollLoop::delSource(const std::shared_ptr<IPollSource>& source)
+void PollLoop::delSource(const std::shared_ptr<IPollSource>& source, int fd /*= -1*/)
 {
     AI_LOG_FN_ENTRY();
 
@@ -341,7 +343,7 @@ void PollLoop::delSource(const std::shared_ptr<IPollSource>& source)
     std::list<PollSourceWrapper>::iterator it = mSources.begin();
     for (; it != mSources.end(); ++it)
     {
-        if (it->source.lock() == source)
+        if (it->source.lock() == source && (it->fd == fd || fd < 0))
         {
             // decrement the list of deferred sources if set
             if (it->events & EPOLLDEFERRED)
@@ -657,8 +659,8 @@ void PollLoop::run(const std::string& name, int priority)
 
 
     // Map of all the sources that we're triggered in one epoll cycle
-    std::map<std::shared_ptr<IPollSource>, uint32_t> triggered;
-    std::map<std::shared_ptr<IPollSource>, uint32_t>::iterator trigItor;
+    std::map<std::shared_ptr<IPollSource>, epoll_event> triggered;
+    std::map<std::shared_ptr<IPollSource>, epoll_event>::iterator trigItor;
 
     std::list<PollSourceWrapper>::const_iterator srcItor;
 
@@ -715,7 +717,10 @@ void PollLoop::run(const std::string& name, int priority)
                         std::shared_ptr<IPollSource> source = srcItor->source.lock();
                         if (source)
                         {
-                            triggered[source] |= EPOLLDEFERRED;
+                            triggered[source] = {
+                                .events = EPOLLDEFERRED,
+                                .data = event->data
+                            };
                         }
                     }
                 }
@@ -740,7 +745,10 @@ void PollLoop::run(const std::string& name, int priority)
                             std::shared_ptr<IPollSource> source = srcItor->source.lock();
                             if (source)
                             {
-                                triggered[source] |= event->events;
+                                triggered[source] = {
+                                    .events = event->events,
+                                    .data = event->data
+                                };
                             }
                             else
                             {

--- a/AppInfrastructure/ReadLine/source/ReadLine.cpp
+++ b/AppInfrastructure/ReadLine/source/ReadLine.cpp
@@ -451,9 +451,9 @@ void ReadLine::commandExecute(const std::string& cmdStr,
  *
  *
  */
-void ReadLine::process(const std::shared_ptr<AICommon::IPollLoop>& pollLoop, uint32_t events)
+void ReadLine::process(const std::shared_ptr<AICommon::IPollLoop>& pollLoop, epoll_event event)
 {
-    if (events & EPOLLIN)
+    if (event.events & EPOLLIN)
     {
         _rl_callback_read_char();
     }

--- a/AppInfrastructure/ReadLine/source/ReadLine.h
+++ b/AppInfrastructure/ReadLine/source/ReadLine.h
@@ -75,7 +75,7 @@ public:
     void runCommand(int argc, char* const *argv) override;
 
 public:
-    void process(const std::shared_ptr<AICommon::IPollLoop>& pollLoop, uint32_t events) override;
+    void process(const std::shared_ptr<AICommon::IPollLoop>& pollLoop, epoll_event event) override;
 
 public:
     std::shared_ptr<const IReadLineContext> getContext() const override;

--- a/daemon/lib/CMakeLists.txt
+++ b/daemon/lib/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library( DobbyDaemonLib
         source/DobbyAsync.cpp
         source/DobbyWorkQueue.cpp
         source/DobbyLogger.cpp
+        source/DobbyLogRelay.cpp
 
         ${ADDITIONAL_SOURCES}
         )

--- a/daemon/lib/source/DobbyLogRelay.cpp
+++ b/daemon/lib/source/DobbyLogRelay.cpp
@@ -9,21 +9,65 @@
 
 #include <Logging.h>
 
-DobbyLogRelay::DobbyLogRelay(const int sourceSocketFd, const std::string &destinationSocketPath)
-      : mSourceSocketFd(sourceSocketFd),
+DobbyLogRelay::DobbyLogRelay(const std::string &sourceSocketPath,
+                             const std::string &destinationSocketPath)
+    : mSourceSocketPath(sourceSocketPath),
       mDestinationSocketPath(destinationSocketPath)
 {
     AI_LOG_FN_ENTRY();
 
-    // Set up the socket we will relay messages to
-    mDestinationSocketAddress = {};
-    mDestinationSocketFd = socket(AF_UNIX, SOCK_DGRAM, 0);
-    mDestinationSocketAddress.sun_family = AF_UNIX;
-    strcpy(mDestinationSocketAddress.sun_path, mDestinationSocketPath.c_str());
+    mSourceSocketFd = createDgramSocket(mSourceSocketPath);
+    if (mSourceSocketFd < 0)
+    {
+        AI_LOG_ERROR("Failed to create socket at %s", sourceSocketPath.c_str());
+    }
 
-    AI_LOG_INFO("Created log relay from fd %d to %d", sourceSocketFd, mDestinationSocketFd);
+    if (access(mDestinationSocketPath.c_str(), F_OK) < 0)
+    {
+        AI_LOG_ERROR("Socket %s does not exist, cannot create relay", mDestinationSocketPath.c_str());
+    }
+    else
+    {
+        // Connect to the socket we will relay messages to
+        mDestinationSocketFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+
+        mDestinationSocketAddress = {};
+        mDestinationSocketAddress.sun_family = AF_UNIX;
+        strcpy(mDestinationSocketAddress.sun_path, mDestinationSocketPath.c_str());
+
+        AI_LOG_INFO("Created log relay from %s to %s", mSourceSocketPath.c_str(), mDestinationSocketPath.c_str());
+    }
 
     AI_LOG_FN_EXIT();
+}
+
+DobbyLogRelay::~DobbyLogRelay()
+{
+    AI_LOG_FN_ENTRY();
+
+    // Close and remove the source socket we created
+    if (close(mSourceSocketFd) < 0)
+    {
+        AI_LOG_SYS_WARN(errno, "Failed to close socket %s", mSourceSocketPath.c_str());
+    }
+
+    if (unlink(mSourceSocketPath.c_str()))
+    {
+        AI_LOG_SYS_ERROR(errno, "Failed to remove socket at '%s'", mSourceSocketPath.c_str());
+    }
+
+    // Close the destination socket (but don't remove it)
+    if (close(mDestinationSocketFd) < 0)
+    {
+        AI_LOG_SYS_WARN(errno, "Failed to close socket %s", mDestinationSocketPath.c_str());
+    }
+
+    AI_LOG_FN_EXIT();
+}
+
+int DobbyLogRelay::getSourceFd()
+{
+    return mSourceSocketFd;
 }
 
 void DobbyLogRelay::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events)
@@ -47,4 +91,31 @@ void DobbyLogRelay::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop
     }
 
     return;
+}
+
+int DobbyLogRelay::createDgramSocket(const std::string &path)
+{
+    AI_LOG_FN_ENTRY();
+
+    // Remove the socket if it exists already...
+    unlink(path.c_str());
+
+    // Create a socket
+    int sockFd;
+    sockFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+
+    struct sockaddr_un address = {};
+    address.sun_family = AF_UNIX;
+    strcpy(address.sun_path, path.c_str());
+
+    if (bind(sockFd, (const struct sockaddr *)&address, sizeof(address)) < 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "Failed to bind socket @ '%s'", address.sun_path);
+        return -1;
+    }
+
+    chmod(path.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
+
+    AI_LOG_FN_EXIT();
+    return sockFd;
 }

--- a/daemon/lib/source/DobbyLogRelay.cpp
+++ b/daemon/lib/source/DobbyLogRelay.cpp
@@ -1,0 +1,50 @@
+#include "DobbyLogRelay.h"
+
+#include <unistd.h>
+#include <strings.h>
+#include <fcntl.h>
+#include <map>
+#include <sys/stat.h>
+#include <sys/un.h>
+
+#include <Logging.h>
+
+DobbyLogRelay::DobbyLogRelay(const int sourceSocketFd, const std::string &destinationSocketPath)
+      : mSourceSocketFd(sourceSocketFd),
+      mDestinationSocketPath(destinationSocketPath)
+{
+    AI_LOG_FN_ENTRY();
+
+    // Set up the socket we will relay messages to
+    mDestinationSocketAddress = {};
+    mDestinationSocketFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+    mDestinationSocketAddress.sun_family = AF_UNIX;
+    strcpy(mDestinationSocketAddress.sun_path, mDestinationSocketPath.c_str());
+
+    AI_LOG_INFO("Created log relay from fd %d to %d", sourceSocketFd, mDestinationSocketFd);
+
+    AI_LOG_FN_EXIT();
+}
+
+void DobbyLogRelay::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events)
+{
+    if (events & EPOLLIN)
+    {
+        char buf[BUFFER_SIZE] = {};
+        ssize_t ret;
+
+        ret = TEMP_FAILURE_RETRY(read(mSourceSocketFd, buf, sizeof(buf)));
+
+        if (ret < 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "Errror during read");
+        }
+
+        if (sendto(mDestinationSocketFd, buf, sizeof(buf), 0, (struct sockaddr *)&mDestinationSocketAddress, sizeof(mDestinationSocketAddress)) < 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "sento failed");
+        }
+    }
+
+    return;
+}

--- a/daemon/lib/source/DobbyLogRelay.cpp
+++ b/daemon/lib/source/DobbyLogRelay.cpp
@@ -113,10 +113,10 @@ void DobbyLogRelay::addToPollLoop(const std::shared_ptr<AICommon::IPollLoop> &po
  * @param[in]   pollLoop    The pollLoop instance that the process method was called from
  * @param[in]   events      The epoll event that occured
  */
-void DobbyLogRelay::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events)
+void DobbyLogRelay::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, epoll_event event)
 {
     // Got some data
-    if (events & EPOLLIN)
+    if (event.events & EPOLLIN)
     {
         ssize_t ret;
         memset(mBuf, 0, sizeof(mBuf));
@@ -173,7 +173,10 @@ int DobbyLogRelay::createDgramSocket(const std::string &path)
     AI_LOG_FN_ENTRY();
 
     // Remove the socket if it exists already...
-    unlink(path.c_str());
+    if (unlink(path.c_str()) > 0)
+    {
+        AI_LOG_DEBUG("Removed existing socket @ '%s'", path.c_str());
+    }
 
     // Create a socket
     int sockFd;

--- a/daemon/lib/source/DobbyLogRelay.h
+++ b/daemon/lib/source/DobbyLogRelay.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "IPollLoop.h"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#define BUFFER_SIZE (16 * 1024)
+
+class DobbyLogRelay : public AICommon::IPollSource,
+                      public std::enable_shared_from_this<DobbyLogRelay>
+{
+public:
+    DobbyLogRelay(const int sourceSocketFd,
+                  const std::string &destinationSocketPath);
+
+public:
+    void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
+
+private:
+    const int mSourceSocketFd;
+    const std::string mDestinationSocketPath;
+
+    int mDestinationSocketFd;
+
+    sockaddr_un mDestinationSocketAddress;
+};

--- a/daemon/lib/source/DobbyLogRelay.h
+++ b/daemon/lib/source/DobbyLogRelay.h
@@ -1,9 +1,29 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #pragma once
 
 #include "IPollLoop.h"
 
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <mutex>
 
 #define BUFFER_SIZE (16 * 1024)
 
@@ -30,4 +50,7 @@ private:
     int mDestinationSocketFd;
 
     sockaddr_un mDestinationSocketAddress;
+
+    char mBuf[BUFFER_SIZE];
+    std::mutex mLock;
 };

--- a/daemon/lib/source/DobbyLogRelay.h
+++ b/daemon/lib/source/DobbyLogRelay.h
@@ -11,16 +11,22 @@ class DobbyLogRelay : public AICommon::IPollSource,
                       public std::enable_shared_from_this<DobbyLogRelay>
 {
 public:
-    DobbyLogRelay(const int sourceSocketFd,
+    DobbyLogRelay(const std::string &sourceSocketPath,
                   const std::string &destinationSocketPath);
+    ~DobbyLogRelay();
 
 public:
     void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
+    int getSourceFd();
 
 private:
-    const int mSourceSocketFd;
+    int createDgramSocket(const std::string& path);
+
+private:
+    const std::string mSourceSocketPath;
     const std::string mDestinationSocketPath;
 
+    int mSourceSocketFd;
     int mDestinationSocketFd;
 
     sockaddr_un mDestinationSocketAddress;

--- a/daemon/lib/source/DobbyLogRelay.h
+++ b/daemon/lib/source/DobbyLogRelay.h
@@ -37,7 +37,7 @@ public:
     ~DobbyLogRelay();
 
 public:
-    void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
+    void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, epoll_event event) override;
     void addToPollLoop(const std::shared_ptr<AICommon::IPollLoop> &pollLoop);
 
 private:

--- a/daemon/lib/source/DobbyLogRelay.h
+++ b/daemon/lib/source/DobbyLogRelay.h
@@ -25,7 +25,8 @@
 #include <sys/un.h>
 #include <mutex>
 
-#define BUFFER_SIZE (16 * 1024)
+// Need a large buffer to store the entire datagram
+#define BUFFER_SIZE (32 * 1024)
 
 class DobbyLogRelay : public AICommon::IPollSource,
                       public std::enable_shared_from_this<DobbyLogRelay>
@@ -37,7 +38,7 @@ public:
 
 public:
     void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
-    int getSourceFd();
+    void addToPollLoop(const std::shared_ptr<AICommon::IPollLoop> &pollLoop);
 
 private:
     int createDgramSocket(const std::string& path);

--- a/daemon/lib/source/DobbyLogger.cpp
+++ b/daemon/lib/source/DobbyLogger.cpp
@@ -79,8 +79,8 @@ DobbyLogger::DobbyLogger(const std::shared_ptr<const IDobbySettings> &settings)
     mPollLoop->start();
 
     // Monitor that socket for new connections
-    mConnectionMonitor = std::thread(&DobbyLogger::connectionMonitorThread, this, mSocketFd);
-    mConnectionMonitor.detach();
+    std::thread socketConnectionMonitor(&DobbyLogger::connectionMonitorThread, this, mSocketFd);
+    socketConnectionMonitor.detach();
 
     AI_LOG_FN_EXIT();
 }

--- a/daemon/lib/source/DobbyLogger.cpp
+++ b/daemon/lib/source/DobbyLogger.cpp
@@ -206,6 +206,11 @@ int DobbyLogger::receiveFdFromSocket(const int connectionFd)
     // Get the fd sent by crun
     int stdioFd;
     memcpy(&stdioFd, CMSG_DATA(cmsg), sizeof(stdioFd));
+
+    // Put the fd into non-blocking mode
+    int flags = fcntl(stdioFd, F_GETFL, 0);
+    fcntl(stdioFd, F_SETFL, flags | O_NONBLOCK);
+
     return stdioFd;
 }
 

--- a/daemon/lib/source/DobbyLogger.h
+++ b/daemon/lib/source/DobbyLogger.h
@@ -69,7 +69,8 @@ private:
     const std::string mSyslogSocketPath;
     const std::string mJournaldSocketPath;
 
-    std::map<pid_t, IDobbyRdkLoggingPlugin::LoggingOptions> mTempConnections;
+    // Map of container PID -> tty file descriptor
+    std::map<pid_t, int> mTempFds;
 
     std::shared_ptr<AICommon::PollLoop> mPollLoop;
 

--- a/daemon/lib/source/DobbyLogger.h
+++ b/daemon/lib/source/DobbyLogger.h
@@ -47,13 +47,11 @@ public:
     bool StartContainerLogging(std::string containerId,
                                pid_t runtimePid,
                                pid_t containerPid,
-                               std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin,
-                               const bool createNewLog);
+                               std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin);
 
     bool DumpBuffer(int bufferMemFd,
                     pid_t containerPid,
-                    std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin,
-                    const bool createNewLog);
+                    std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin);
 
 private:
     int createDgramSocket(const std::string &path);
@@ -61,25 +59,24 @@ private:
     int receiveFdFromSocket(const int connectionFd);
     void connectionMonitorThread(const int socketFd);
 
+    void closeAndDeleteSocket(const int fd, const std::string& path);
+
 private:
     std::mutex mLock;
+
     int mSocketFd;
     const std::string mSocketPath;
     const std::string mSyslogSocketPath;
     const std::string mJournaldSocketPath;
 
-    int mSyslogFd;
-    int mJournaldFd;
-
     std::map<pid_t, IDobbyRdkLoggingPlugin::LoggingOptions> mTempConnections;
-    std::map<pid_t, std::future<void>> mFutures;
-
-    bool mShutdown;
 
     std::shared_ptr<AICommon::PollLoop> mPollLoop;
 
     std::shared_ptr<DobbyLogRelay> mSyslogRelay;
     std::shared_ptr<DobbyLogRelay> mJournaldRelay;
+
+    std::thread mConnectionMonitor;
 };
 
 #endif // !defined(DOBBYLOGGER_H)

--- a/daemon/lib/source/DobbyLogger.h
+++ b/daemon/lib/source/DobbyLogger.h
@@ -75,8 +75,6 @@ private:
 
     std::shared_ptr<DobbyLogRelay> mSyslogRelay;
     std::shared_ptr<DobbyLogRelay> mJournaldRelay;
-
-    std::thread mConnectionMonitor;
 };
 
 #endif // !defined(DOBBYLOGGER_H)

--- a/daemon/lib/source/DobbyLogger.h
+++ b/daemon/lib/source/DobbyLogger.h
@@ -71,7 +71,7 @@ private:
     int mSyslogFd;
     int mJournaldFd;
 
-    std::map<pid_t, IDobbyRdkLoggingPlugin::ContainerInfo> mTempConnections;
+    std::map<pid_t, IDobbyRdkLoggingPlugin::LoggingOptions> mTempConnections;
     std::map<pid_t, std::future<void>> mFutures;
 
     bool mShutdown;

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -382,7 +382,7 @@ bool DobbyManager::createAndStart(const ContainerId &id,
         // Dump the runtime output to a new file even if the container failed to start
         if (loggingPlugin)
         {
-            mLogger->DumpBuffer(createBuffer->getMemFd(), -1, loggingPlugin, true);
+            mLogger->DumpBuffer(createBuffer->getMemFd(), -1, loggingPlugin);
         }
 
         container->containerPid = -1;
@@ -417,12 +417,12 @@ bool DobbyManager::createAndStart(const ContainerId &id,
     if (loggingPlugin)
     {
         // Dump the contents of the buffers even if the container didn't start
-        mLogger->DumpBuffer(createBuffer->getMemFd(), container->containerPid, loggingPlugin, true);
-        mLogger->DumpBuffer(startBuffer->getMemFd(), container->containerPid, loggingPlugin, false);
+        mLogger->DumpBuffer(createBuffer->getMemFd(), container->containerPid, loggingPlugin);
+        mLogger->DumpBuffer(startBuffer->getMemFd(), container->containerPid, loggingPlugin);
 
         if (started)
         {
-            mLogger->StartContainerLogging(id.str(), pids.first, pids.second, loggingPlugin, false);
+            mLogger->StartContainerLogging(id.str(), pids.first, pids.second, loggingPlugin);
         }
     }
 
@@ -578,7 +578,7 @@ bool DobbyManager::createAndStartContainer(const ContainerId &id,
         auto loggingPlugin = GetContainerLogger(container);
         if (loggingPlugin)
         {
-            mLogger->DumpBuffer(destroyBuffer->getMemFd(), container->containerPid, loggingPlugin, false);
+            mLogger->DumpBuffer(destroyBuffer->getMemFd(), container->containerPid, loggingPlugin);
         }
 
         // clear the pid now it's been killed
@@ -1048,8 +1048,7 @@ bool DobbyManager::restartContainer(const ContainerId &id,
                 // If main container logging thread is still running,
                 // wait for it to finish before we dump the hook output
                 // to the log
-                //mLogger->WaitForLoggingToFinish(container->containerPid);
-                mLogger->DumpBuffer(bufferStream->getMemFd(), container->containerPid, loggingPlugin, false);
+                mLogger->DumpBuffer(bufferStream->getMemFd(), container->containerPid, loggingPlugin);
             }
         }
     }
@@ -1355,7 +1354,7 @@ bool DobbyManager::execInContainer(int32_t cd, const std::string &options, const
                 else
                 {
                     // Spin up thread to capture output from the exec command (could be long running)
-                    mLogger->StartContainerLogging(id.str(), pids.first, container->containerPid, loggingPlugin, false);
+                    mLogger->StartContainerLogging(id.str(), pids.first, container->containerPid, loggingPlugin);
                 }
             }
 
@@ -2121,8 +2120,7 @@ void DobbyManager::onChildExit()
                         // If main container logging thread is still running,
                         // wait for it to finish before we dump the hook output
                         // to the log
-                        //mLogger->WaitForLoggingToFinish(container->containerPid);
-                        mLogger->DumpBuffer(bufferStream->getMemFd(), container->containerPid, loggingPlugin, false);
+                        mLogger->DumpBuffer(bufferStream->getMemFd(), container->containerPid, loggingPlugin);
                     }
                 }
 

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -109,12 +109,6 @@ DobbyManager::~DobbyManager()
     // TODO: clean-up all containers
 
     stopRuncMonitorThread();
-
-    // We must wait for all logging threads to finish before we start
-    // destructing DobbyManager, otherwise there's a chance we'll unload
-    // the logging plugin whilst the thread is logging data, which leads
-    // to undefined behaviour
-    mLogger->ShutdownLoggers();
 }
 
 // -----------------------------------------------------------------------------
@@ -1054,7 +1048,7 @@ bool DobbyManager::restartContainer(const ContainerId &id,
                 // If main container logging thread is still running,
                 // wait for it to finish before we dump the hook output
                 // to the log
-                mLogger->WaitForLoggingToFinish(container->containerPid);
+                //mLogger->WaitForLoggingToFinish(container->containerPid);
                 mLogger->DumpBuffer(bufferStream->getMemFd(), container->containerPid, loggingPlugin, false);
             }
         }
@@ -2127,7 +2121,7 @@ void DobbyManager::onChildExit()
                         // If main container logging thread is still running,
                         // wait for it to finish before we dump the hook output
                         // to the log
-                        mLogger->WaitForLoggingToFinish(container->containerPid);
+                        //mLogger->WaitForLoggingToFinish(container->containerPid);
                         mLogger->DumpBuffer(bufferStream->getMemFd(), container->containerPid, loggingPlugin, false);
                     }
                 }

--- a/daemon/process/settings/dobby.dev_vm.json
+++ b/daemon/process/settings/dobby.dev_vm.json
@@ -16,8 +16,18 @@
     "network": {
       "externalInterfaces": [ "enp0s8", "enp0s3" ],
       "addressRange": "100.64.11.0"
-    }
+    },
 
+    "logRelay": {
+      "syslog": {
+        "enable": true,
+        "socketPath": "/tmp/dobby-syslog"
+      },
+      "journald": {
+        "enable": true,
+        "socketPath": "/tmp/dobby-journald"
+      }
+    }
   }
 
 

--- a/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
+++ b/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
@@ -50,7 +50,7 @@ public:
     virtual ~IDobbyRdkLoggingPlugin() = default;
 
 public:
-    struct ContainerInfo
+    struct LoggingOptions
     {
         // Actual pid of the running container
         pid_t containerPid;
@@ -58,13 +58,14 @@ public:
         int connectionFd;
         // fd of the container pseudo-terminal master fd
         int pttyFd;
+        // If possible, start a new log (i.e. if logging to file, create an empty file)
+        bool createNewLog;
     };
 
-    virtual void RegisterPollSources(ContainerInfo& containerInfo,
-                                    bool createNewFile,
+    virtual void RegisterPollSources(LoggingOptions& loggingOptions,
                                     std::shared_ptr<AICommon::IPollLoop> pollLoop) = 0;
 
-    virtual void DumpToLog(ContainerInfo& containerInfo) = 0;
+    virtual void DumpToLog(const int bufferFd, const bool startNewLog) = 0;
 };
 
 // -----------------------------------------------------------------------------

--- a/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
+++ b/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
@@ -50,18 +50,7 @@ public:
     virtual ~IDobbyRdkLoggingPlugin() = default;
 
 public:
-    struct LoggingOptions
-    {
-        // Actual pid of the running container
-        pid_t containerPid;
-        // fd of the open connection so we can close it when the container exits
-        int connectionFd;
-        // fd of the container pseudo-terminal master fd
-        int pttyFd;
-    };
-
-    virtual void RegisterPollSources(LoggingOptions& loggingOptions,
-                                    std::shared_ptr<AICommon::IPollLoop> pollLoop) = 0;
+    virtual void RegisterPollSources(int fd, std::shared_ptr<AICommon::IPollLoop> pollLoop) = 0;
 
     virtual void DumpToLog(const int bufferFd) = 0;
 };

--- a/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
+++ b/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
@@ -58,14 +58,12 @@ public:
         int connectionFd;
         // fd of the container pseudo-terminal master fd
         int pttyFd;
-        // If possible, start a new log (i.e. if logging to file, create an empty file)
-        bool createNewLog;
     };
 
     virtual void RegisterPollSources(LoggingOptions& loggingOptions,
                                     std::shared_ptr<AICommon::IPollLoop> pollLoop) = 0;
 
-    virtual void DumpToLog(const int bufferFd, const bool startNewLog) = 0;
+    virtual void DumpToLog(const int bufferFd) = 0;
 };
 
 // -----------------------------------------------------------------------------

--- a/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
+++ b/pluginLauncher/lib/include/IDobbyRdkLoggingPlugin.h
@@ -26,6 +26,8 @@
 #include "IDobbyRdkPlugin.h"
 #include "DobbyRdkPluginUtils.h"
 
+#include "IPollLoop.h"
+
 #include "rt_dobby_schema.h"
 
 #include <Logging.h>
@@ -58,10 +60,11 @@ public:
         int pttyFd;
     };
 
-    virtual void LoggingLoop(ContainerInfo containerInfo,
-                             const bool isBuffer,
-                             const bool createNew,
-                             const std::atomic_bool& cancellationToken) = 0;
+    virtual void RegisterPollSources(ContainerInfo& containerInfo,
+                                    bool createNewFile,
+                                    std::shared_ptr<AICommon::IPollLoop> pollLoop) = 0;
+
+    virtual void DumpToLog(ContainerInfo& containerInfo) = 0;
 };
 
 // -----------------------------------------------------------------------------

--- a/rdkPlugins/Logging/CMakeLists.txt
+++ b/rdkPlugins/Logging/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library( ${PROJECT_NAME}
         SHARED
         source/LoggingPlugin.cpp
         source/JournaldSink.cpp
+        source/FileSink.cpp
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/rdkPlugins/Logging/CMakeLists.txt
+++ b/rdkPlugins/Logging/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library( ${PROJECT_NAME}
         source/LoggingPlugin.cpp
         source/JournaldSink.cpp
         source/FileSink.cpp
+        source/NullSink.cpp
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/rdkPlugins/Logging/CMakeLists.txt
+++ b/rdkPlugins/Logging/CMakeLists.txt
@@ -19,12 +19,21 @@
 # CMake will prefix this with "lib"
 project(LoggingPlugin)
 
-add_library( ${PROJECT_NAME}
-        SHARED
+set(LOGGING_PLUGIN_SRC
         source/LoggingPlugin.cpp
-        source/JournaldSink.cpp
         source/FileSink.cpp
         source/NullSink.cpp
+)
+
+if (USE_SYSTEMD)
+        list(APPEND LOGGING_PLUGIN_SRC
+                source/JournaldSink.cpp
+        )
+endif()
+
+add_library( ${PROJECT_NAME}
+        SHARED
+        ${LOGGING_PLUGIN_SRC}
         )
 
 target_include_directories(${PROJECT_NAME}
@@ -42,5 +51,11 @@ install(
 target_link_libraries(${PROJECT_NAME}
         DobbyRdkPluginCommonLib
 )
+
+if (USE_SYSTEMD)
+        target_link_libraries(${PROJECT_NAME}
+                systemd
+        )
+endif()
 
 set_target_properties( ${PROJECT_NAME} PROPERTIES SOVERSION 1 )

--- a/rdkPlugins/Logging/CMakeLists.txt
+++ b/rdkPlugins/Logging/CMakeLists.txt
@@ -22,10 +22,12 @@ project(LoggingPlugin)
 add_library( ${PROJECT_NAME}
         SHARED
         source/LoggingPlugin.cpp
+        source/JournaldSink.cpp
         )
 
 target_include_directories(${PROJECT_NAME}
         PRIVATE
+        include
         $<TARGET_PROPERTY:DobbyDaemonLib,INTERFACE_INCLUDE_DIRECTORIES>
 )
 

--- a/rdkPlugins/Logging/LogRelay.md
+++ b/rdkPlugins/Logging/LogRelay.md
@@ -1,0 +1,53 @@
+# Log Relay Support
+Dobby has a feature called Log Relay, which is designed to forward messages sent to syslog or journald from inside the container to the appropriate sockets on the host
+
+## The need for a Log Relay
+If an application calls `sd_journal_print()` to directly log a message to journald, that message is sent down the `/run/systemd/journal/socket` socket to the journald daemon. Whilst it is possible to mount that socket directly into the container, there is an issue with filtering the logs.
+
+When `/run/systemd/journal/socket` is directly mounted into the container, the log message arrives to journald, but it is not tagged with a `_SYSTEMD_UNIT` label.
+
+This means when filtering logs with `journalctl -fu dobby`, the log messages do not appear as they are not part of the dobby unit. Messages captured by the Logging plugin (or EthanLog on Sky builds) are tagged with the Dobby unit, and the DumpLogs script on RDK makes use of the unit to filter and sort log files.
+
+## Solution
+To enable the Dobby log relay, add the following to the settings file at /etc/dobby.json
+
+```json
+    "logRelay": {
+      "syslog": {
+        "enable": true,
+        "socketPath": "/tmp/dobby-syslog"
+      },
+      "journald": {
+        "enable": true,
+        "socketPath": "/tmp/dobby-journald"
+      }
+    }
+```
+
+Then add bind mounts for the dobby sockets into the container. E.G
+```json
+        {
+            "source": "/tmp/dobby-syslog",
+            "destination": "/dev/log",
+            "options": [
+                "rbind",
+                "rprivate",
+                "nosuid",
+                "nodev"
+            ],
+            "type": "bind"
+        },
+        {
+            "source": "/tmp/dobby-journald",
+            "destination": "/run/systemd/journal/socket",
+            "options": [
+                "rbind",
+                "rprivate",
+                "nosuid",
+                "nodev"
+            ],
+            "type": "bind"
+        }
+```
+
+Log messages will now appear when doing `journalctl -fu dobby`

--- a/rdkPlugins/Logging/include/ILoggingSink.h
+++ b/rdkPlugins/Logging/include/ILoggingSink.h
@@ -3,12 +3,14 @@
 #include "IPollLoop.h"
 #include "IDobbyRdkLoggingPlugin.h"
 
+#define PTY_BUFFER_SIZE 4096
+
 class ILoggingSink : public AICommon::IPollSource,
                      public std::enable_shared_from_this<ILoggingSink>
 {
 
 public:
-    virtual void DumpLog(const int bufferFd, const bool startNewLog) = 0;
+    virtual void DumpLog(const int bufferFd) = 0;
 
     virtual void SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions& options) = 0;
 };

--- a/rdkPlugins/Logging/include/ILoggingSink.h
+++ b/rdkPlugins/Logging/include/ILoggingSink.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "IPollLoop.h"
+#include "IDobbyRdkLoggingPlugin.h"
+
+class ILoggingSink : public AICommon::IPollSource,
+                     public std::enable_shared_from_this<ILoggingSink>
+{
+
+public:
+    virtual void DumpLog(const IDobbyRdkLoggingPlugin::ContainerInfo &containerInfo) = 0;
+
+    virtual void SetContainerInfo(IDobbyRdkLoggingPlugin::ContainerInfo &containerInfo) = 0;
+};

--- a/rdkPlugins/Logging/include/ILoggingSink.h
+++ b/rdkPlugins/Logging/include/ILoggingSink.h
@@ -8,7 +8,7 @@ class ILoggingSink : public AICommon::IPollSource,
 {
 
 public:
-    virtual void DumpLog(const IDobbyRdkLoggingPlugin::ContainerInfo &containerInfo) = 0;
+    virtual void DumpLog(const int bufferFd, const bool startNewLog) = 0;
 
-    virtual void SetContainerInfo(IDobbyRdkLoggingPlugin::ContainerInfo &containerInfo) = 0;
+    virtual void SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions& options) = 0;
 };

--- a/rdkPlugins/Logging/include/ILoggingSink.h
+++ b/rdkPlugins/Logging/include/ILoggingSink.h
@@ -30,6 +30,4 @@ class ILoggingSink : public AICommon::IPollSource,
 
 public:
     virtual void DumpLog(const int bufferFd) = 0;
-
-    virtual void SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions& options) = 0;
 };

--- a/rdkPlugins/Logging/include/ILoggingSink.h
+++ b/rdkPlugins/Logging/include/ILoggingSink.h
@@ -1,3 +1,22 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #pragma once
 
 #include "IPollLoop.h"

--- a/rdkPlugins/Logging/source/FileSink.cpp
+++ b/rdkPlugins/Logging/source/FileSink.cpp
@@ -1,3 +1,22 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #include "FileSink.h"
 
 #include <Logging.h>

--- a/rdkPlugins/Logging/source/FileSink.cpp
+++ b/rdkPlugins/Logging/source/FileSink.cpp
@@ -1,0 +1,187 @@
+#include "FileSink.h"
+
+#include <unistd.h>
+#include <strings.h>
+#include <fcntl.h>
+#include <map>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <limits.h>
+
+
+#include <Logging.h>
+
+FileSink::FileSink(const std::string &containerId, std::shared_ptr<rt_dobby_schema> &containerConfig)
+    : mContainerConfig(containerConfig),
+      mContainerId(containerId),
+      mLoggingOptions({}),
+      mOutputFileFd(openFile())
+{
+    AI_LOG_FN_ENTRY();
+
+    mDevNullFd = open("/dev/null", O_CLOEXEC | O_WRONLY);
+    if (mDevNullFd < 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "Failed to open /dev/null");
+    }
+
+    AI_LOG_FN_EXIT();
+}
+
+FileSink::~FileSink()
+{
+    close(mDevNullFd);
+
+    if (mOutputFileFd > 0)
+    {
+        close(mOutputFileFd);
+    }
+
+    closeFile();
+}
+
+void FileSink::SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions& options)
+{
+    mLoggingOptions = options;
+    AI_LOG_INFO("ptty fd - %d", mLoggingOptions.pttyFd);
+}
+
+void FileSink::DumpLog(const int bufferFd, const bool startNewLog)
+{
+    // // Starting a new log file? Close the existing file and open a new one so we truncate
+    // if (startNewLog)
+    // {
+    //     AI_LOG_INFO("STARTING NEW FILE!");
+    //     if (mOutputFileFd > 0)
+    //     {
+    //         closeFile();
+    //         mOutputFileFd = openFile();
+    //     }
+    // }
+    char buf[PTY_BUFFER_SIZE];
+    memset(buf, 0, sizeof(buf));
+
+    ssize_t ret;
+    ssize_t offset = 0;
+
+    bool limitHit = false;
+    while (true)
+    {
+        ret = read(bufferFd, buf, sizeof(buf));
+        if (ret <= 0)
+        {
+            break;
+        }
+
+        offset += ret;
+
+        if (offset <= mFileSizeLimit)
+        {
+            // Write to the output file
+            if (write(mOutputFileFd, buf, ret) < 0)
+            {
+                AI_LOG_SYS_ERROR(errno, "Write failed");
+            }
+        }
+        else
+        {
+            // Hit the limit, send the data into the void
+            if (!limitHit)
+            {
+                AI_LOG_WARN("Logger for container %s has hit maximum size of %zu",
+                            mContainerId.c_str(), mFileSizeLimit);
+            }
+            limitHit = true;
+            write(mDevNullFd, buf, ret);
+        }
+    }
+}
+
+void FileSink::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events)
+{
+    if (events & EPOLLHUP)
+    {
+        AI_LOG_INFO("EPOLLHUP! Removing ourself from the event loop!");
+
+        // Remove ourselves from the event loop
+        pollLoop->delSource(shared_from_this());
+
+        // Clean up
+        if (close(mLoggingOptions.pttyFd) != 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "Failed to close container ptty fd %d", mLoggingOptions.pttyFd);
+        }
+
+        if (close(mLoggingOptions.connectionFd) != 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "Failed to close container connection %d", mLoggingOptions.connectionFd);
+        }
+
+        return;
+    }
+}
+
+void FileSink::closeFile()
+{
+    AI_LOG_INFO("Closing output fd");
+    close(mOutputFileFd);
+}
+
+int FileSink::openFile()
+{
+    const mode_t mode = 0644;
+
+    int flags;
+    // // Do we want to append to the file or create a new empty file?
+    // if (append)
+    // {
+    //     flags = O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC;
+    // }
+    // else
+    // {
+    //     flags = O_CREAT | O_APPEND | O_WRONLY | O_CLOEXEC;
+    // }
+
+    flags = O_CREAT | O_TRUNC | O_APPEND | O_WRONLY | O_CLOEXEC;
+
+    // Read the options from the config if possible
+    std::string pathName;
+    if (mContainerConfig->rdk_plugins->logging->data->file_options)
+    {
+        pathName = mContainerConfig->rdk_plugins->logging->data->file_options->path;
+        if (mContainerConfig->rdk_plugins->logging->data->file_options->limit_present)
+        {
+            mFileSizeLimit = mContainerConfig->rdk_plugins->logging->data->file_options->limit;
+        }
+    }
+
+    // if limit is -1 it means unlimited, but to make life easier just set it
+    // to the max value
+    if (mFileSizeLimit < 0)
+        mFileSizeLimit = SSIZE_MAX;
+
+    int openedFd = -1;
+
+    // Open both our file and /dev/null (so we can send to null if we hit the limit)
+    int devNullFd = open("/dev/null", O_CLOEXEC | O_WRONLY);
+
+    if (pathName.empty())
+    {
+        AI_LOG_ERROR("Log settings set to log to file but no path provided. Sending to /dev/null");
+        openedFd = devNullFd;
+    }
+    else
+    {
+        AI_LOG_INFO(">>> About to open %s", pathName.c_str());
+        openedFd = open(pathName.c_str(), flags, mode);
+        if (openedFd < 0)
+        {
+            // throw away everything we receive
+            AI_LOG_SYS_ERROR(errno, "failed to open/create '%s'", pathName.c_str());
+            openedFd = devNullFd;
+        }
+    }
+
+    return openedFd;
+}

--- a/rdkPlugins/Logging/source/FileSink.cpp
+++ b/rdkPlugins/Logging/source/FileSink.cpp
@@ -161,6 +161,13 @@ void FileSink::DumpLog(const int bufferFd)
             write(mDevNullFd, mBuf, ret);
         }
     }
+
+#if (AI_BUILD_TYPE == AI_DEBUG)
+    // Separate sections of log file for reabability
+    // (useful if we're writing lots of buffer dumps)
+    std::string marker = "---------------------------------------------\n";
+    write(mOutputFileFd, marker.c_str(), marker.length());
+#endif
 }
 
 /**

--- a/rdkPlugins/Logging/source/FileSink.h
+++ b/rdkPlugins/Logging/source/FileSink.h
@@ -31,9 +31,7 @@ public:
 public:
     void DumpLog(const int bufferFd) override;
 
-    void SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions &options) override;
-
-    void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
+    void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, epoll_event event) override;
 
 private:
     int openFile(const std::string& pathName);
@@ -41,7 +39,6 @@ private:
 private:
     const std::shared_ptr<rt_dobby_schema> mContainerConfig;
     const std::string mContainerId;
-    IDobbyRdkLoggingPlugin::LoggingOptions mLoggingOptions;
 
     ssize_t mFileSizeLimit;
     std::string mOutputFilePath;

--- a/rdkPlugins/Logging/source/FileSink.h
+++ b/rdkPlugins/Logging/source/FileSink.h
@@ -2,8 +2,6 @@
 
 #include "ILoggingSink.h"
 
-#define PTY_BUFFER_SIZE 4096
-
 class FileSink : public ILoggingSink
 {
 public:
@@ -12,7 +10,7 @@ public:
     ~FileSink();
 
 public:
-    void DumpLog(const int bufferFd, const bool startNewLog) override;
+    void DumpLog(const int bufferFd) override;
 
     void SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions &options) override;
 
@@ -20,7 +18,6 @@ public:
 
 private:
     int openFile();
-    void closeFile();
 
 private:
     const std::shared_ptr<rt_dobby_schema> mContainerConfig;
@@ -30,4 +27,9 @@ private:
     ssize_t mFileSizeLimit;
     int mOutputFileFd;
     int mDevNullFd;
+
+    bool mLimitHit;
+    char mBuf[PTY_BUFFER_SIZE];
+
+    std::mutex mLock;
 };

--- a/rdkPlugins/Logging/source/FileSink.h
+++ b/rdkPlugins/Logging/source/FileSink.h
@@ -36,7 +36,7 @@ public:
     void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
 
 private:
-    int openFile();
+    int openFile(const std::string& pathName);
 
 private:
     const std::shared_ptr<rt_dobby_schema> mContainerConfig;
@@ -44,6 +44,7 @@ private:
     IDobbyRdkLoggingPlugin::LoggingOptions mLoggingOptions;
 
     ssize_t mFileSizeLimit;
+    std::string mOutputFilePath;
     int mOutputFileFd;
     int mDevNullFd;
 

--- a/rdkPlugins/Logging/source/FileSink.h
+++ b/rdkPlugins/Logging/source/FileSink.h
@@ -4,21 +4,30 @@
 
 #define PTY_BUFFER_SIZE 4096
 
-class JournaldSink : public ILoggingSink
+class FileSink : public ILoggingSink
 {
 public:
-    JournaldSink(const std::string &containerId, std::shared_ptr<rt_dobby_schema> &containerConfig);
+    FileSink(const std::string &containerId, std::shared_ptr<rt_dobby_schema> &containerConfig);
+
+    ~FileSink();
 
 public:
     void DumpLog(const int bufferFd, const bool startNewLog) override;
 
-    void SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions& options) override;
+    void SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions &options) override;
 
     void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
 
 private:
-    int mJournaldSteamFd;
+    int openFile();
+    void closeFile();
+
+private:
     const std::shared_ptr<rt_dobby_schema> mContainerConfig;
     const std::string mContainerId;
     IDobbyRdkLoggingPlugin::LoggingOptions mLoggingOptions;
+
+    ssize_t mFileSizeLimit;
+    int mOutputFileFd;
+    int mDevNullFd;
 };

--- a/rdkPlugins/Logging/source/FileSink.h
+++ b/rdkPlugins/Logging/source/FileSink.h
@@ -1,3 +1,22 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #pragma once
 
 #include "ILoggingSink.h"

--- a/rdkPlugins/Logging/source/JournaldSink.cpp
+++ b/rdkPlugins/Logging/source/JournaldSink.cpp
@@ -94,6 +94,7 @@ JournaldSink::~JournaldSink()
 
 void JournaldSink::SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions& options)
 {
+    std::lock_guard<std::mutex> locker(mLock);
     mLoggingOptions = options;
 }
 
@@ -138,7 +139,7 @@ void JournaldSink::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop,
                 }
 
                 // Something went wrong whilst reading
-                AI_LOG_SYS_ERROR(errno, "Read from container tty failed");
+                AI_LOG_SYS_ERROR(errno, "Read from container %s tty failed", mContainerId.c_str());
                 return;
             }
 

--- a/rdkPlugins/Logging/source/JournaldSink.cpp
+++ b/rdkPlugins/Logging/source/JournaldSink.cpp
@@ -1,3 +1,22 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #include "JournaldSink.h"
 
 #include <unistd.h>

--- a/rdkPlugins/Logging/source/JournaldSink.cpp
+++ b/rdkPlugins/Logging/source/JournaldSink.cpp
@@ -1,0 +1,132 @@
+#include "JournaldSink.h"
+
+#include <unistd.h>
+#include <strings.h>
+#include <fcntl.h>
+#include <map>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#if defined(USE_SYSTEMD)
+#include <systemd/sd-journal.h>
+#endif
+
+#include <Logging.h>
+
+JournaldSink::JournaldSink(const std::string &containerId, std::shared_ptr<rt_dobby_schema> &containerConfig)
+    : mContainerConfig(containerConfig),
+      mContainerId(containerId)
+{
+    // Create a file descriptor we can write to
+    // journald will handle line breaks etc automatically
+    AI_LOG_FN_ENTRY();
+
+    int logPriority = LOG_INFO;
+    if (mContainerConfig->rdk_plugins->logging->data->journald_options)
+    {
+        std::string priority = mContainerConfig->rdk_plugins->logging->data->journald_options->priority;
+        if (!priority.empty())
+        {
+            const std::map<std::string, int> options =
+                {
+                    {"LOG_EMERG", 0},
+                    {"LOG_ALERT", 1},
+                    {"LOG_CRIT", 2},
+                    {"LOG_ERR", 3},
+                    {"LOG_WARNING", 4},
+                    {"LOG_NOTICE", 5},
+                    {"LOG_INFO", 6},
+                    {"LOG_DEBUG", 7}};
+
+            auto it = options.find(priority);
+            if (it != options.end())
+            {
+                logPriority = it->second;
+            }
+            else
+            {
+                AI_LOG_WARN("Could not parse journald priority - using LOG_INFO");
+            }
+        }
+    }
+
+    mJournaldSteamFd = sd_journal_stream_fd(mContainerId.c_str(), logPriority, 1);
+
+    if (mJournaldSteamFd < 0)
+    {
+        AI_LOG_SYS_ERROR(-mJournaldSteamFd, "Failed to create journald stream fd");
+
+        // Just use /dev/null instead
+        mJournaldSteamFd = open("/dev/null", O_CLOEXEC | O_WRONLY);
+    }
+
+    AI_LOG_FN_EXIT();
+}
+
+void JournaldSink::DumpLog(const IDobbyRdkLoggingPlugin::ContainerInfo &containerInfo)
+{
+    char buf[PTY_BUFFER_SIZE];
+    memset(buf, 0, sizeof(buf));
+
+    ssize_t ret;
+    while (true)
+    {
+        //AI_LOG_INFO("About to read from %d", containerInfo.pttyFd);
+        ret = read(containerInfo.pttyFd, buf, sizeof(buf));
+        // AI_LOG_INFO("Read %lu bytes", ret);
+        if (ret <= 0)
+        {
+            break;
+        }
+
+        write(mJournaldSteamFd, buf, ret);
+    }
+}
+
+void JournaldSink::SetContainerInfo(IDobbyRdkLoggingPlugin::ContainerInfo &containerInfo)
+{
+    // TODO:: this is crap
+    mContainerInfo = containerInfo;
+}
+
+void JournaldSink::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events)
+{
+    // Got some data, yay
+    if (events & EPOLLIN)
+    {
+        ssize_t ret;
+        char buf[PTY_BUFFER_SIZE];
+        bzero(&buf, sizeof(buf));
+
+        ret = TEMP_FAILURE_RETRY(read(mContainerInfo.pttyFd, buf, sizeof(buf)));
+
+        write(mJournaldSteamFd, buf, ret);
+
+        return;
+    }
+
+    // Container shutdown
+    if (events & EPOLLHUP)
+    {
+        AI_LOG_INFO("EPOLLHUP! Removing ourselves from the event loop!");
+        // Remove ourselves from the event loop
+        pollLoop->delSource(shared_from_this());
+
+        // Clean up
+        if (close(mContainerInfo.pttyFd) != 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "Failed to close container ptty fd");
+        }
+
+        if (close(mContainerInfo.connectionFd) != 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "Failed to close container connection");
+        }
+
+        return;
+    }
+
+    // Don't handle any other events
+    return;
+}

--- a/rdkPlugins/Logging/source/JournaldSink.h
+++ b/rdkPlugins/Logging/source/JournaldSink.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ILoggingSink.h"
+
+#define PTY_BUFFER_SIZE 4096
+
+class JournaldSink : public ILoggingSink
+{
+public:
+    JournaldSink(const std::string &containerId, std::shared_ptr<rt_dobby_schema> &containerConfig);
+
+public:
+    void DumpLog(const IDobbyRdkLoggingPlugin::ContainerInfo &containerInfo);
+
+    void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
+
+    void SetContainerInfo(IDobbyRdkLoggingPlugin::ContainerInfo &containerInfo);
+
+private:
+    int mJournaldSteamFd;
+    const std::shared_ptr<rt_dobby_schema> mContainerConfig;
+    const std::string mContainerId;
+    IDobbyRdkLoggingPlugin::ContainerInfo mContainerInfo;
+};

--- a/rdkPlugins/Logging/source/JournaldSink.h
+++ b/rdkPlugins/Logging/source/JournaldSink.h
@@ -30,15 +30,12 @@ public:
 public:
     void DumpLog(const int bufferFd) override;
 
-    void SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions& options) override;
-
-    void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
+    void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, epoll_event event) override;
 
 private:
     int mJournaldSteamFd;
     const std::shared_ptr<rt_dobby_schema> mContainerConfig;
     const std::string mContainerId;
-    IDobbyRdkLoggingPlugin::LoggingOptions mLoggingOptions;
 
     char mBuf[PTY_BUFFER_SIZE];
 

--- a/rdkPlugins/Logging/source/JournaldSink.h
+++ b/rdkPlugins/Logging/source/JournaldSink.h
@@ -1,3 +1,22 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #pragma once
 
 #include "ILoggingSink.h"

--- a/rdkPlugins/Logging/source/LoggingPlugin.cpp
+++ b/rdkPlugins/Logging/source/LoggingPlugin.cpp
@@ -182,7 +182,12 @@ std::shared_ptr<ILoggingSink> LoggingPlugin::CreateSink(LoggingPlugin::LoggingSi
     switch (sinkType)
     {
     case LoggingSink::Journald:
+#ifdef USE_SYSTEMD
         return std::make_shared<JournaldSink>(mUtils->getContainerId(), mContainerConfig);
+#else
+        AI_LOG_ERROR("Cannot create journald sink - Dobby built without systemd support");
+        return std::make_shared<NullSink>(mUtils->getContainerId(), mContainerConfig);
+#endif
     case LoggingSink::File:
         return std::make_shared<FileSink>(mUtils->getContainerId(), mContainerConfig);
     case LoggingSink::DevNull:

--- a/rdkPlugins/Logging/source/LoggingPlugin.cpp
+++ b/rdkPlugins/Logging/source/LoggingPlugin.cpp
@@ -153,7 +153,7 @@ void LoggingPlugin::RegisterPollSources(LoggingOptions &loggingOptions,
     // Register the poll source
     if (!mPollLoop->addSource(mSink, loggingOptions.pttyFd, EPOLLIN))
     {
-        AI_LOG_ERROR("Failed to add logging poll source for container %s", mUtils->getContainerId());
+        AI_LOG_ERROR("Failed to add logging poll source for container %s", mUtils->getContainerId().c_str());
     }
 
     AI_LOG_FN_EXIT();
@@ -188,7 +188,8 @@ std::shared_ptr<ILoggingSink> LoggingPlugin::CreateSink(LoggingPlugin::LoggingSi
     case LoggingSink::DevNull:
         return std::make_shared<NullSink>(mUtils->getContainerId(), mContainerConfig);
     default:
-        break;
+        AI_LOG_ERROR("Could not create sink - unknown sink type");
+        return nullptr;
     }
 }
 

--- a/rdkPlugins/Logging/source/LoggingPlugin.cpp
+++ b/rdkPlugins/Logging/source/LoggingPlugin.cpp
@@ -125,6 +125,13 @@ std::vector<std::string> LoggingPlugin::getDependencies() const
     return dependencies;
 }
 
+/**
+ * @brief Adds the necessary poll source(s) to the provided pollLoop instance
+ * based on the logging sink specified in the container config
+ *
+ * @param[in]   loggingOptions  Info about the container such as the fd to read from
+ * @param[in]   pollLoop        The poll loop the sources should be added to
+ */
 void LoggingPlugin::RegisterPollSources(LoggingOptions &loggingOptions,
                                         std::shared_ptr<AICommon::IPollLoop> pollLoop)
 {
@@ -159,6 +166,14 @@ void LoggingPlugin::RegisterPollSources(LoggingOptions &loggingOptions,
     AI_LOG_FN_EXIT();
 }
 
+/**
+ * @brief Dump the contents of a file descriptor to the log sink
+ *
+ * Will block until the contents of the fd has been written to the
+ * log
+ *
+ * @param[in]   bufferFd    The file descriptor to read from
+ */
 void LoggingPlugin::DumpToLog(const int bufferFd)
 {
     AI_LOG_FN_ENTRY();
@@ -177,6 +192,14 @@ void LoggingPlugin::DumpToLog(const int bufferFd)
 
 // Begin private methods
 
+/**
+ * @brief Constructs an instance of the requested sink
+ *
+ * @param[in]  sinkType    The type of sink to be constructed
+ *
+ * @return shared_ptr pointing to the instance of the logging sink. Nullptr if no sink
+ * of the requested type is available
+ */
 std::shared_ptr<ILoggingSink> LoggingPlugin::CreateSink(LoggingPlugin::LoggingSink sinkType)
 {
     switch (sinkType)

--- a/rdkPlugins/Logging/source/LoggingPlugin.cpp
+++ b/rdkPlugins/Logging/source/LoggingPlugin.cpp
@@ -129,11 +129,10 @@ std::vector<std::string> LoggingPlugin::getDependencies() const
  * @brief Adds the necessary poll source(s) to the provided pollLoop instance
  * based on the logging sink specified in the container config
  *
- * @param[in]   loggingOptions  Info about the container such as the fd to read from
+ * @param[in]   fd              The file descriptor we need to read from (i.e. the container tty)
  * @param[in]   pollLoop        The poll loop the sources should be added to
  */
-void LoggingPlugin::RegisterPollSources(LoggingOptions &loggingOptions,
-                                        std::shared_ptr<AICommon::IPollLoop> pollLoop)
+void LoggingPlugin::RegisterPollSources(int fd, std::shared_ptr<AICommon::IPollLoop> pollLoop)
 {
     AI_LOG_FN_ENTRY();
 
@@ -149,16 +148,13 @@ void LoggingPlugin::RegisterPollSources(LoggingOptions &loggingOptions,
         }
     }
 
-    // Configure the sink to read from the container ptty
-    mSink->SetLogOptions(loggingOptions);
-
     if (!mPollLoop)
     {
         mPollLoop = pollLoop;
     }
 
     // Register the poll source
-    if (!mPollLoop->addSource(mSink, loggingOptions.pttyFd, EPOLLIN))
+    if (!mPollLoop->addSource(mSink, fd, EPOLLIN))
     {
         AI_LOG_ERROR("Failed to add logging poll source for container %s", mUtils->getContainerId().c_str());
     }

--- a/rdkPlugins/Logging/source/LoggingPlugin.h
+++ b/rdkPlugins/Logging/source/LoggingPlugin.h
@@ -63,7 +63,7 @@ public:
     void RegisterPollSources(LoggingOptions &loggingOptions,
                              std::shared_ptr<AICommon::IPollLoop> pollLoop) override;
 
-    void DumpToLog(const int bufferFd, const bool startNewLog) override;
+    void DumpToLog(const int bufferFd) override;
 
 private:
     // Locations the plugin can send the logs

--- a/rdkPlugins/Logging/source/LoggingPlugin.h
+++ b/rdkPlugins/Logging/source/LoggingPlugin.h
@@ -60,11 +60,10 @@ public:
     std::vector<std::string> getDependencies() const override;
 
 public:
-    void RegisterPollSources(ContainerInfo &containerInfo,
-                             bool createNewFile,
+    void RegisterPollSources(LoggingOptions &loggingOptions,
                              std::shared_ptr<AICommon::IPollLoop> pollLoop) override;
 
-    void DumpToLog(ContainerInfo& containerInfo) override;
+    void DumpToLog(const int bufferFd, const bool startNewLog) override;
 
 private:
     // Locations the plugin can send the logs
@@ -76,9 +75,10 @@ private:
     };
 
 private:
-    std::shared_ptr<ILoggingSink> GetContainerSink();
-    void FileSink(const ContainerInfo &containerInfo, bool exitEof, bool createNew, const std::atomic_bool &cancellationToken);
-    void DevNullSink(const ContainerInfo &containerInfo, bool exitEof, const std::atomic_bool &cancellationToken);
+    std::shared_ptr<ILoggingSink> CreateSink(LoggingSink sinkType);
+    LoggingSink GetContainerSink();
+    //void FileSink(const LoggingOptions &containerInfo, bool exitEof, bool createNew, const std::atomic_bool &cancellationToken);
+    void DevNullSink(const LoggingOptions &containerInfo, bool exitEof, const std::atomic_bool &cancellationToken);
 
 private:
     const std::string mName;

--- a/rdkPlugins/Logging/source/LoggingPlugin.h
+++ b/rdkPlugins/Logging/source/LoggingPlugin.h
@@ -21,6 +21,10 @@
 
 #include <DobbyLoggerBase.h>
 
+#include "IPollLoop.h"
+#include "PollLoop.h"
+#include "ILoggingSink.h"
+
 #include <sys/types.h>
 
 #include <unistd.h>
@@ -56,11 +60,11 @@ public:
     std::vector<std::string> getDependencies() const override;
 
 public:
-    // Logging Specific Methods
-    void LoggingLoop(IDobbyRdkLoggingPlugin::ContainerInfo containerInfo,
-                     const bool isBuffer,
-                     const bool createNew,
-                     const std::atomic_bool& cancellationToken) override;
+    void RegisterPollSources(ContainerInfo &containerInfo,
+                             bool createNewFile,
+                             std::shared_ptr<AICommon::IPollLoop> pollLoop) override;
+
+    void DumpToLog(ContainerInfo& containerInfo) override;
 
 private:
     // Locations the plugin can send the logs
@@ -72,17 +76,19 @@ private:
     };
 
 private:
-    LoggingSink GetContainerSink();
+    std::shared_ptr<ILoggingSink> GetContainerSink();
     void FileSink(const ContainerInfo &containerInfo, bool exitEof, bool createNew, const std::atomic_bool &cancellationToken);
     void DevNullSink(const ContainerInfo &containerInfo, bool exitEof, const std::atomic_bool &cancellationToken);
-#if defined(USE_SYSTEMD)
-    void JournaldSink(const ContainerInfo &containerInfo, bool exitEof, const std::atomic_bool &cancellationToken);
-#endif
 
 private:
     const std::string mName;
     std::shared_ptr<rt_dobby_schema> mContainerConfig;
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
+
+    std::shared_ptr<ILoggingSink> mSink;
+
+    // TODO:: crap
+    std::shared_ptr<AICommon::IPollLoop> mPollLoop;
 };
 
 #endif // !defined(LOGGINGPLUGIN_H)

--- a/rdkPlugins/Logging/source/LoggingPlugin.h
+++ b/rdkPlugins/Logging/source/LoggingPlugin.h
@@ -77,8 +77,6 @@ private:
 private:
     std::shared_ptr<ILoggingSink> CreateSink(LoggingSink sinkType);
     LoggingSink GetContainerSink();
-    //void FileSink(const LoggingOptions &containerInfo, bool exitEof, bool createNew, const std::atomic_bool &cancellationToken);
-    void DevNullSink(const LoggingOptions &containerInfo, bool exitEof, const std::atomic_bool &cancellationToken);
 
 private:
     const std::string mName;
@@ -86,8 +84,6 @@ private:
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
 
     std::shared_ptr<ILoggingSink> mSink;
-
-    // TODO:: crap
     std::shared_ptr<AICommon::IPollLoop> mPollLoop;
 };
 

--- a/rdkPlugins/Logging/source/LoggingPlugin.h
+++ b/rdkPlugins/Logging/source/LoggingPlugin.h
@@ -60,8 +60,7 @@ public:
     std::vector<std::string> getDependencies() const override;
 
 public:
-    void RegisterPollSources(LoggingOptions &loggingOptions,
-                             std::shared_ptr<AICommon::IPollLoop> pollLoop) override;
+    void RegisterPollSources(int fd, std::shared_ptr<AICommon::IPollLoop> pollLoop) override;
 
     void DumpToLog(const int bufferFd) override;
 

--- a/rdkPlugins/Logging/source/NullSink.cpp
+++ b/rdkPlugins/Logging/source/NullSink.cpp
@@ -58,6 +58,7 @@ NullSink::~NullSink()
 
 void NullSink::SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions &options)
 {
+    std::lock_guard<std::mutex> locker(mLock);
     mLoggingOptions = options;
 }
 
@@ -103,7 +104,7 @@ void NullSink::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uin
                 }
 
                 // Something went wrong whilst reading
-                AI_LOG_SYS_ERROR(errno, "Read from container tty failed");
+                AI_LOG_SYS_ERROR(errno, "Read from container %s tty failed", mContainerId.c_str());
                 return;
             }
 

--- a/rdkPlugins/Logging/source/NullSink.cpp
+++ b/rdkPlugins/Logging/source/NullSink.cpp
@@ -1,3 +1,22 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #include "NullSink.h"
 
 #include <unistd.h>
@@ -15,8 +34,6 @@ NullSink::NullSink(const std::string &containerId, std::shared_ptr<rt_dobby_sche
       mContainerId(containerId),
       mBuf{}
 {
-    // Create a file descriptor we can write to
-    // journald will handle line breaks etc automatically
     AI_LOG_FN_ENTRY();
 
     mDevNullFd = open("/dev/null", O_CLOEXEC | O_WRONLY);

--- a/rdkPlugins/Logging/source/NullSink.h
+++ b/rdkPlugins/Logging/source/NullSink.h
@@ -30,15 +30,12 @@ public:
 public:
     void DumpLog(const int bufferFd) override;
 
-    void SetLogOptions(const IDobbyRdkLoggingPlugin::LoggingOptions& options) override;
-
-    void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
+    void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, epoll_event event) override;
 
 private:
     int mDevNullFd;
     const std::shared_ptr<rt_dobby_schema> mContainerConfig;
     const std::string mContainerId;
-    IDobbyRdkLoggingPlugin::LoggingOptions mLoggingOptions;
 
     char mBuf[PTY_BUFFER_SIZE];
 

--- a/rdkPlugins/Logging/source/NullSink.h
+++ b/rdkPlugins/Logging/source/NullSink.h
@@ -2,11 +2,11 @@
 
 #include "ILoggingSink.h"
 
-class JournaldSink : public ILoggingSink
+class NullSink : public ILoggingSink
 {
 public:
-    JournaldSink(const std::string &containerId, std::shared_ptr<rt_dobby_schema> &containerConfig);
-    ~JournaldSink();
+    NullSink(const std::string &containerId, std::shared_ptr<rt_dobby_schema> &containerConfig);
+    ~NullSink();
 
 public:
     void DumpLog(const int bufferFd) override;
@@ -16,7 +16,7 @@ public:
     void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, uint32_t events) override;
 
 private:
-    int mJournaldSteamFd;
+    int mDevNullFd;
     const std::shared_ptr<rt_dobby_schema> mContainerConfig;
     const std::string mContainerId;
     IDobbyRdkLoggingPlugin::LoggingOptions mLoggingOptions;

--- a/rdkPlugins/Logging/source/NullSink.h
+++ b/rdkPlugins/Logging/source/NullSink.h
@@ -1,3 +1,22 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #pragma once
 
 #include "ILoggingSink.h"

--- a/settings/include/IDobbySettings.h
+++ b/settings/include/IDobbySettings.h
@@ -188,6 +188,19 @@ public:
      *
      */
     virtual std::vector<std::string> defaultPlugins() const = 0;
+
+
+    struct LogRelaySettings
+    {
+        bool syslogEnabled;
+        bool journaldEnabled;
+
+        std::string syslogSocketPath;
+        std::string journaldSocketPath;
+    };
+
+    virtual LogRelaySettings logRelaySettings() const = 0;
+
 };
 
 #endif // !defined(IDOBBYSETTINGS_H)

--- a/settings/include/Settings.h
+++ b/settings/include/Settings.h
@@ -74,6 +74,8 @@ public:
     in_addr_t addressRange() const override;
     std::vector<std::string> defaultPlugins() const override;
 
+    LogRelaySettings logRelaySettings() const override;
+
     void dump(int aiLogLevel = -1) const;
 
 private:
@@ -119,6 +121,8 @@ private:
     std::vector<std::string> mExternalInterfaces;
     std::pair<std::string, in_addr_t> mAddressRange;
     std::vector<std::string>  mDefaultPlugins;
+
+    LogRelaySettings mLogRelaySettings;
 };
 
 #endif // !defined(SETTINGS_H)

--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -237,6 +237,43 @@ Settings::Settings(const Json::Value& settings)
         }
     }
 
+    // Process log relay
+    {
+        Json::Value logRelaySettings = Json::Path(".logRelay").resolve(settings);
+        if (!logRelaySettings.isNull())
+        {
+            if (logRelaySettings.isObject())
+            {
+                const Json::Value syslogSettings = logRelaySettings["syslog"];
+                const Json::Value journaldSettings = logRelaySettings["journald"];
+
+                if (syslogSettings.isObject())
+                {
+                    mLogRelaySettings.syslogEnabled = syslogSettings["enable"].asBool();
+                    mLogRelaySettings.syslogSocketPath = syslogSettings["socketPath"].asString();
+                }
+                else
+                {
+                    mLogRelaySettings.syslogEnabled = false;
+                }
+
+                if (journaldSettings.isObject())
+                {
+                    mLogRelaySettings.journaldEnabled = journaldSettings["enable"].asBool();
+                    mLogRelaySettings.journaldSocketPath = journaldSettings["socketPath"].asString();
+                }
+                else
+                {
+                    mLogRelaySettings.journaldEnabled = false;
+                }
+            }
+            else
+            {
+                AI_LOG_ERROR("Invalid logRelay type in settingsFile, should be object");
+            }
+        }
+    }
+
 }
 
 // -----------------------------------------------------------------------------
@@ -355,6 +392,16 @@ in_addr_t Settings::addressRange() const
 std::vector<std::string> Settings::defaultPlugins() const
 {
     return mDefaultPlugins;
+}
+
+ // -----------------------------------------------------------------------------
+ /**
+ *  @brief
+ *
+ */
+IDobbySettings::LogRelaySettings Settings::logRelaySettings() const
+{
+    return mLogRelaySettings;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
### Description
When containers attempt to log directly to journald (e.g. `sd_journal_print()`) or syslog, the log messages may not correctly appear in journald.

After adding `/run/systemd/journal/socket` into a container that directly calls `sd_journal_print`, the log messages are seen in `journalctl -f`. However, these messages are not tagged with a `_SYSTEMD_UNIT` tag. This is because the message unit is determined using the PID of the process, which does not match with a known unit PID when the process runs in a container.

As a result, when filtering the logs by unit (`journalctl -fu dobby`), the messages do not appear. This is an issue with RDK log collection scripts.

This PR makes the following changes:
* Based on the relevant setting in `/etc/dobby.json`, create dobby syslog and journald sockets that can be mounted into a container instead. When messages are received on these sockets, Dobby will forward the messages to the "real" socket on the host
    * Since Dobby sends the message to journald, the PID resolves to DobbyDaemon and the messages can be seen when doing `journalctl -fu dobby`
* Re-write much of Dobby logging code to use an epoll based implementation instead of spinning up a thread per-container
    * Since log relays are using epoll, it made sense to standardise all the logging methods to epoll at the same time
    * Improves performance and helps prevent lock-up during shutdown whilst we wait for loggers to finish
    * Observed significantly reduced CPU usage from DobbyDaemon during periods of high log output

### Test Procedure
**This is a high-risk change due to amount of code changed - please test thoroughly**

Create a simple C program with the following contents

```c
#include <systemd/sd-journal.h>
#include <syslog.h>

#include <stdio.h>
#include <unistd.h>

int main(int argc, char const *argv[])
{
    for (;;)
    {
        fprintf(stdout, "Hello world - stdout test!\n");
        fprintf(stderr, "Hello world - stderr test\n");
        syslog(LOG_INFO, "Hello world, this is a syslog test");
        sd_journal_print(LOG_INFO, "Hello world, this is a journald test");

        sleep(1);
    }

    return 0;
}
```

Create a container config to run this program.

Do the following (in Vagrant):
* Start Dobby as systemd service
* Add `/dev/log` and `/run/systemd/journal/socket` mounts to the container. 
    * Run `journalctl -f`. Observe the syslog and journald messages
    * Run `journalctl -f -u dobby`. Observe the syslog and journald messages **do not appear**

* Remove previous bind-mounts. Add `/tmp/dobby-syslog` and `/tmp/dobby-journald` mounts to the container. 
    * Run `journalctl -f`. Observe the syslog and journald messages
    * Run `journalctl -f -u dobby`. Observe the syslog and journald messages **do appear**

Due to the changes elsewhere to logging code, also test the following features:
* Logging to file works correctly
    * Ensure logs are correctly written even if container fails to start
    * Ensure log files are correctly re-written each time container starts (instead of appending)
* Logging to journald correctly
    * When journald logging enabled with container, with the test code provided earlier, observe all 4 messages appearing in journald
* Logging to devnull sink works correctly (e.g. no logs printed)
* Ensure Dobby shuts down without error

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)