### PR TITLE
XIONE-7775: Handle containers that don't respond to SIGKILL during cleanup

### DIFF
--- a/daemon/lib/source/DobbyContainer.h
+++ b/daemon/lib/source/DobbyContainer.h
@@ -86,7 +86,7 @@ public:
 public:
     pid_t containerPid;
     bool hasCurseOfDeath;
-    enum class State { Starting, Running, Stopping, Paused } state;
+    enum class State { Starting, Running, Stopping, Paused, Unknown } state;
     std::string customConfigFilePath;
 
 public:

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -294,6 +294,7 @@ void DobbyManager::cleanupContainers()
     AI_LOG_INFO("%d old containers found - attempting to clean up", count);
 
     // Clean up time
+    int stuckContainerCount = 0;
     const std::list<DobbyRunC::ContainerListItem> containers = mRunc->list();
     for (const auto &container : containers)
     {
@@ -378,6 +379,7 @@ void DobbyManager::cleanupContainers()
         if (stuckContainer)
         {
             AI_LOG_FATAL("Failed to clean up container '%s'. We may be unable to launch app until next reboot!", id.c_str());
+            stuckContainerCount++;
             // Track the container so we can't start a container with the same name again
             std::unique_ptr<DobbyContainer> dobbyContainer(new DobbyContainer(nullptr, nullptr, nullptr));
             dobbyContainer->state = DobbyContainer::State::Unknown;
@@ -385,6 +387,15 @@ void DobbyManager::cleanupContainers()
             dobbyContainer->containerPid = container.pid;
             mContainers.emplace(id, std::move(dobbyContainer));
         }
+    }
+
+    if (stuckContainerCount > 0)
+    {
+        AI_LOG_INFO("%d containers are stuck and can't be destroyed. Starting regular cleanup job", stuckContainerCount);
+        // Try to clean up the container later so the user can restart the app again
+        mCleanupTaskTimerId = mUtilities->startTimer(std::chrono::seconds(10),
+                                false,
+                                std::bind(&DobbyManager::invalidContainerCleanupTask, this));
     }
 
     AI_LOG_FN_EXIT();
@@ -2381,4 +2392,80 @@ void DobbyManager::runcMonitorThread()
     AI_LOG_INFO("stopped SIGCHLD monitor thread");
 
     AI_LOG_FN_EXIT();
+}
+
+/**
+ * @brief Task that will try and cleanup invalid/unknown state containers
+ * periodically - if the container can be killed then kill it and release the id
+ * back to the pool so it can be restarted
+ *
+ */
+bool DobbyManager::invalidContainerCleanupTask()
+{
+    AI_LOG_FN_ENTRY();
+
+    std::lock_guard<std::mutex> locker(mLock);
+
+    // Find out how many containers are in an unknown state
+    const int stuckCount = std::count_if(mContainers.begin(), mContainers.end(), [](const std::pair<const ContainerId, std::unique_ptr<DobbyContainer>>& c)
+    {
+        return c.second->state == DobbyContainer::State::Unknown;
+    });
+    if (stuckCount == 0)
+    {
+        // No more stuck containers, our job here is done
+        return false;
+    }
+
+    auto it = mContainers.begin();
+    std::shared_ptr<DobbyDevNullStream> devNull = std::make_shared<DobbyDevNullStream>();
+    while (it != mContainers.end())
+    {
+        // Only care about containers in an unknown state
+        if (it->second->state == DobbyContainer::State::Unknown)
+        {
+            // Check if container PID is still valid
+            if (kill(it->second->containerPid, 0) != 0 && errno == ESRCH)
+            {
+                // Pid no longer exists, attempt to destroy container
+                if (mRunc->destroy(it->first, devNull))
+                {
+                    // Container destroyed successfully, stop tracking it
+                    AI_LOG_INFO("Previously stuck container %d has  been destroyed - releasing id back to the pool", it->second->descriptor);
+                    it = mContainers.erase(it);
+                }
+            }
+            else
+            {
+                // Pid is still valid. Attempt to send SIGKILL
+                mRunc->killCont(it->first, SIGKILL, true);
+
+                // Did we actually kill it? Give it some time, then check the status
+                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                DobbyRunC::ContainerStatus state = mRunc->state(it->first);
+
+                if (state != DobbyRunC::ContainerStatus::Running)
+                {
+                    // We killed it! Destroy it and remove from our list
+                    if (mRunc->destroy(it->first, devNull))
+                    {
+                        // Container destroyed successfully, stop tracking it
+                        AI_LOG_INFO("Previously stuck container %d has been destroyed - releasing id back to the pool", it->second->descriptor);
+                        it = mContainers.erase(it);
+                    }
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+    return true;
 }

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -57,6 +57,8 @@
 #include <sys/resource.h>
 #include <fstream>
 #include <unordered_map>
+#include <chrono>
+#include <thread>
 
 // The following are supported by all sky kernels, but some toolchains (ST)
 // aren't built against the correct kernel headers, hence need to define these
@@ -255,6 +257,9 @@ void DobbyManager::cleanupContainers()
     AI_LOG_FN_ENTRY();
 
     // Do a manual check for leftover containers ourselves to improve startup performance
+    // For consistency, we should really call out to crun list here, but in some scenarios
+    // that can fail. Since we're only interested in finding out if the container is running
+    // or stopped, do it ourselves
     const std::string workDir = mRunc->getWorkingDir();
     DIR *d = opendir(workDir.c_str());
     if (!d)
@@ -286,38 +291,99 @@ void DobbyManager::cleanupContainers()
         return;
     }
 
-    AI_LOG_INFO("%d old containers found - attenpting to clean up", count);
+    AI_LOG_INFO("%d old containers found - attempting to clean up", count);
 
-    // Now do a full callout to crun so that we can find what state the containers
-    // are in
-    const std::map<ContainerId, DobbyRunC::ContainerStatus> containers = mRunc->list();
+    // Clean up time
+    const std::list<DobbyRunC::ContainerListItem> containers = mRunc->list();
     for (const auto &container : containers)
     {
-        const ContainerId &id = container.first;
-        const DobbyRunC::ContainerStatus &status = container.second;
+        // If true, indicates we can't clean up the container - it's stuck in some way
+        bool stuckContainer = false;
 
-        AI_LOG_WARN("found old container '%s' in state %d, attempting to clean it up",
-                    id.c_str(), int(status));
+        const ContainerId &id = container.id;
+        DobbyRunC::ContainerStatus status = container.status;
 
-        switch (status)
+        AI_LOG_WARN("found old container '%s' with pid %d in state %d, cleaning it up",
+                    id.c_str(), container.pid, int(status));
+
+        if (status == DobbyRunC::ContainerStatus::Paused ||
+            status == DobbyRunC::ContainerStatus::Pausing ||
+            status == DobbyRunC::ContainerStatus::Running)
         {
-            case DobbyRunC::ContainerStatus::Paused:
-            case DobbyRunC::ContainerStatus::Pausing:
-            case DobbyRunC::ContainerStatus::Running:
-                AI_LOG_INFO("attempting to kill old container '%s'", id.c_str());
-                mRunc->killCont(id, SIGKILL, true);
-                // fall through
+            /*
+            There have been scenarios where SIGKILL doesn't work. Retry killing the container a
+            few times. If the container is still running, then we can't attempt to destroy
+            it (destroy will just hang forever)
 
-            case DobbyRunC::ContainerStatus::Created:
-            case DobbyRunC::ContainerStatus::Stopped:
-            case DobbyRunC::ContainerStatus::Unknown:
-                // Don't bother capturing hook logs here
-                std::shared_ptr<DobbyDevNullStream> nullstream = std::make_shared<DobbyDevNullStream>();
-                AI_LOG_INFO("attempting to destroy old container '%s'", id.c_str());
-                // Force delete by default as we have no idea what condition the container is in
-                // and it may not respond to a normal delete
-                mRunc->destroy(id, nullstream, true);
+            Seems to occur when a process gets stuck in an uninterruptible sleep
+            */
+            const int maxRetry = 3;
+            int retryCount = 1;
+            auto retryTime = std::chrono::milliseconds(50);
+
+            while (retryCount <= maxRetry)
+            {
+                AI_LOG_INFO("attempting to kill old container '%s' (attempt %d/%d)", id.c_str(), retryCount, maxRetry);
+                mRunc->killCont(id, SIGKILL, true);
+
+                // Did we actually kill it? Give it some time, then check the status
+                std::this_thread::sleep_for(retryTime * retryCount);
+                DobbyRunC::ContainerStatus state = mRunc->state(id);
+
+                if (state != DobbyRunC::ContainerStatus::Running)
+                {
+                    // Managed to kill the container, mark it as stopped so we destroy it next
+                    status = DobbyRunC::ContainerStatus::Stopped;
+                    break;
+                }
+
+                if (retryCount < maxRetry)
+                {
+                    AI_LOG_WARN("Failed to kill container '%s' (attempt %d/%d)", id.c_str(), retryCount, maxRetry);
+                }
+                else
+                {
+                    // We can't kill the container. This will leave dobby in a potentially bad state since there is a container
+                    // running that is stuck somewhere between life and death. However this is better than the whole daemon
+                    // locking up completely (and being killed by watchdog repeatedly)
+                    stuckContainer = true;
+                }
+                retryCount++;
+            }
+        }
+
+        if (status == DobbyRunC::ContainerStatus::Created ||
+            status == DobbyRunC::ContainerStatus::Stopped ||
+            status == DobbyRunC::ContainerStatus::Unknown)
+        {
+            std::shared_ptr<DobbyBufferStream> buffer = std::make_shared<DobbyBufferStream>();
+            AI_LOG_INFO("attempting to destroy old container '%s'", id.c_str());
+            // Dobby will try a normal delete, then a force delete
+            // Force delete may hang on old crun versions if process in uninterruptible sleep: https://github.com/containers/crun/issues/868
+            if (!mRunc->destroy(id, buffer))
+            {
+                AI_LOG_WARN("Could not destroy container %s with error %s", id.c_str(), buffer->getBuffer().data());
+                stuckContainer = true;
+            }
+            else
+            {
+                // Cleaned up successfully
                 break;
+            }
+        }
+
+        // If the container is stuck (i.e. we can't kill or destroy it), then
+        // add it in the Unknown state so we can't attempt to start a container with
+        // the same ID again
+        if (stuckContainer)
+        {
+            AI_LOG_FATAL("Failed to clean up container '%s'. We may be unable to launch app until next reboot!", id.c_str());
+            // Track the container so we can't start a container with the same name again
+            std::unique_ptr<DobbyContainer> dobbyContainer(new DobbyContainer(nullptr, nullptr, nullptr));
+            dobbyContainer->state = DobbyContainer::State::Unknown;
+            // Unfortunately we'll never actually receive the signal if/when this container does die since we're no longer it's parent
+            dobbyContainer->containerPid = container.pid;
+            mContainers.emplace(id, std::move(dobbyContainer));
         }
     }
 
@@ -1445,6 +1511,8 @@ int32_t DobbyManager::stateOfContainer(int32_t cd) const
                 return CONTAINER_STATE_PAUSED;
             case DobbyContainer::State::Stopping:
                 return CONTAINER_STATE_STOPPING;
+            default:
+                return CONTAINER_STATE_INVALID;
         }
     }
 
@@ -1533,6 +1601,9 @@ std::string DobbyManager::statsOfContainer(int32_t cd) const
                 break;
             case DobbyContainer::State::Paused:
                 jsonStats["state"] = "paused";
+                break;
+            case DobbyContainer::State::Unknown:
+                jsonStats["state"] = "unknown";
                 break;
         }
 
@@ -2017,7 +2088,7 @@ void DobbyManager::onChildExit()
 {
     AI_LOG_FN_ENTRY();
 
-    AI_LOG_INFO("detected child terminated signal");
+    AI_LOG_DEBUG("detected child terminated signal");
 
     // take the lock as we're being called from the signal monitor thread
     std::lock_guard<std::mutex> locker(mLock);
@@ -2029,6 +2100,14 @@ void DobbyManager::onChildExit()
     {
         const std::unique_ptr<DobbyContainer> &container = it->second;
         const pid_t containerPid = container->containerPid;
+
+        // If container has invalid pid or is in an unknown state, nothing we can do
+        // so move on
+        if (containerPid <= 0 || container->state == DobbyContainer::State::Unknown)
+        {
+            ++it;
+            continue;
+        }
 
         // check if the runc process has exited
         int status = 0;

--- a/daemon/lib/source/DobbyManager.h
+++ b/daemon/lib/source/DobbyManager.h
@@ -199,6 +199,8 @@ private:
     void stopRuncMonitorThread();
     void runcMonitorThread();
 
+    bool invalidContainerCleanupTask();
+
 private:
     const std::shared_ptr<IDobbyEnv> mEnvironment;
     const std::shared_ptr<IDobbyUtils> mUtilities;
@@ -212,6 +214,7 @@ private:
 private:
     std::thread mRuncMonitorThread;
     std::atomic<bool> mRuncMonitorTerminate;
+    int mCleanupTaskTimerId;
 
 #if defined(LEGACY_COMPONENTS)
 private:

--- a/daemon/lib/source/DobbyRunC.h
+++ b/daemon/lib/source/DobbyRunC.h
@@ -63,6 +63,14 @@ public:
         Stopped
     };
 
+    struct ContainerListItem
+    {
+        ContainerId id;
+        pid_t pid;
+        std::string bundlePath;
+        ContainerStatus status;
+    };
+
 public:
     std::pair<pid_t, pid_t> create(const ContainerId &id,
                                    const std::shared_ptr<const DobbyBundle> &bundle,
@@ -80,7 +88,7 @@ public:
                                  const std::string &command) const;
 
     ContainerStatus state(const ContainerId &id) const;
-    std::map<ContainerId, ContainerStatus> list() const;
+    std::list<ContainerListItem> list() const;
 
 public:
     pid_t run(const ContainerId &id,


### PR DESCRIPTION
### Description
In some scenarios on Xi1, processes can end up in a state where they don't respond to SIGKILL (assumed uninterruptible sleep).

In this case, Dobby may get stuck in a crash loop when attempting to cleanup the container. 

The following logic is introduced:
* At Dobby start, check for leftover containers
    * If container is in Running state, attempt to kill with SIGKILL
        * If SIGKILL success - delete container
        * If SIGKILL fail - mark container as "stuck" and do not attempt to delete
           * Add the container to our internal list of running containers in the Unknown state to prevent the container from being restarted
     * If container in stopped state, attempt to delete
         * If delete fails, then mark container as "stuck"
* If we have any containers marked as "stuck", regularly check if they are still stuck. Kill/delete and remove from our list if/when they eventually die.

### Test Procedure
Simulate container in uninterruptible sleep as per reproduction steps here: https://github.com/containers/crun/issues/868

Stop and restart dobby daemon. Dobby should handle the issue as per logic outlined above.

Test on STB and ensure no regressions

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)