### PR TITLE
XIONE-7775: Fix cleanup loop with multiple containers

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -350,6 +350,7 @@ void DobbyManager::cleanupContainers()
                 {
                     // Managed to kill the container, mark it as stopped so we destroy it next
                     status = DobbyRunC::ContainerStatus::Stopped;
+                    // Quit the retry loop
                     break;
                 }
 
@@ -380,11 +381,6 @@ void DobbyManager::cleanupContainers()
             {
                 AI_LOG_WARN("Could not destroy container %s with error %s", id.c_str(), buffer->getBuffer().data());
                 stuckContainer = true;
-            }
-            else
-            {
-                // Cleaned up successfully
-                break;
             }
         }
 


### PR DESCRIPTION
### Description
Ensure we don't break out of the cleanupContainers loop too early.

Fix regression introduced by https://github.com/rdkcentral/Dobby/pull/173

### Test Procedure
Start multiple containers. Stop DobbyDaemon. Restart DobbyDaemon. All containers should be cleaned up

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)