### PR TITLE
Fix spurious error messages

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -95,6 +95,7 @@ DobbyManager::DobbyManager(const std::shared_ptr<IDobbyEnv> &env,
     , mRuncMonitorTerminate(false)
 #if defined(LEGACY_COMPONENTS)
     , mLegacyPlugins(new DobbyLegacyPluginManager(env, utils))
+    , mCleanupTaskTimerId(0)
 #endif // defined(LEGACY_COMPONENTS)
 {
     AI_LOG_FN_ENTRY();

--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -272,6 +272,13 @@ Settings::Settings(const Json::Value& settings)
                 AI_LOG_ERROR("Invalid logRelay type in settingsFile, should be object");
             }
         }
+        else
+        {
+            // Default initailise the struct
+            mLogRelaySettings = {};
+            mLogRelaySettings.syslogEnabled = false;
+            mLogRelaySettings.journaldEnabled = false;
+        }
     }
 
 }


### PR DESCRIPTION
### Description
Fix some spurious error messages seen on STB due to uninitialised variables.

Ensure variables have correct default values instead of whatever randomly gets assigned to them.

### Test Procedure
Check the following spurious errors aren't present during startup or shutdown
```
failed to find timer with id 1952541797 to remove
```
```
Syslog relay enabled but no socket path set in settings
Journald relay enabled but no socket path set in settings
```

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)