### PR TITLE
Fix some Wreorder warnings from gcc

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -93,9 +93,9 @@ DobbyManager::DobbyManager(const std::shared_ptr<IDobbyEnv> &env,
     , mLogger(std::make_unique<DobbyLogger>(settings))
     , mRunc(std::make_unique<DobbyRunC>(utils, settings))
     , mRuncMonitorTerminate(false)
+    , mCleanupTaskTimerId(0)
 #if defined(LEGACY_COMPONENTS)
     , mLegacyPlugins(new DobbyLegacyPluginManager(env, utils))
-    , mCleanupTaskTimerId(0)
 #endif // defined(LEGACY_COMPONENTS)
 {
     AI_LOG_FN_ENTRY();


### PR DESCRIPTION
### Description
Fix gcc warnings:

```
In file included from /home/vagrant/srcDobby/daemon/lib/source/DobbyManager.cpp:24:
/home/vagrant/srcDobby/daemon/lib/source/DobbyManager.h: In constructor ‘DobbyManager::DobbyManager(const std::shared_ptr<IDobbyEnv>&, const std::shared_ptr<IDobbyUtils_v3>&, const std::shared_ptr<IDobbyIPCUtils>&, const std::shared_ptr<const IDobbySettings>&, const ContainerStartedFunc&, const ContainerStoppedFunc&)’:
/home/vagrant/srcDobby/daemon/lib/source/DobbyManager.h:221:47: warning: ‘DobbyManager::mLegacyPlugins’ will be initialized after [-Wreorder]
  221 |     std::unique_ptr<DobbyLegacyPluginManager> mLegacyPlugins;
      |                                               ^~~~~~~~~~~~~~
/home/vagrant/srcDobby/daemon/lib/source/DobbyManager.h:217:9: warning:   ‘int DobbyManager::mCleanupTaskTimerId’ [-Wreorder]
  217 |     int mCleanupTaskTimerId;
      |         ^~~~~~~~~~~~~~~~~~~
/home/vagrant/srcDobby/daemon/lib/source/DobbyManager.cpp:81:1: warning:   when initialized here [-Wreorder]
   81 | DobbyManager::DobbyManager(const std::shared_ptr<IDobbyEnv> &env,
```

### Test Procedure
Gcc warning should no longer appear

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)