### PR TITLE
LLAMA-5470: PollLoop sources should unregister themselves

### DIFF
--- a/AppInfrastructure/Common/include/IPollLoop.h
+++ b/AppInfrastructure/Common/include/IPollLoop.h
@@ -61,6 +61,7 @@ public:
     virtual bool modSource(const std::shared_ptr<IPollSource>& source, uint32_t events) = 0;
     virtual void delSource(const std::shared_ptr<IPollSource>& source, int fd = -1) = 0;
     virtual void delAllSources() = 0;
+    virtual bool hasSource(const std::shared_ptr<IPollSource>& source) = 0;
 };
 
 } // namespace AICommon

--- a/AppInfrastructure/Common/include/PollLoop.h
+++ b/AppInfrastructure/Common/include/PollLoop.h
@@ -71,6 +71,7 @@ public:
     virtual bool modSource(const std::shared_ptr<IPollSource>& source, uint32_t events) override;
     virtual void delSource(const std::shared_ptr<IPollSource>& source, int fd = -1) override;
     virtual void delAllSources() override;
+    virtual bool hasSource(const std::shared_ptr<IPollSource>& source) override;
 
     virtual std::thread::id threadId() const override;
     virtual pid_t gettid() const override;

--- a/AppInfrastructure/Common/source/PollLoop.cpp
+++ b/AppInfrastructure/Common/source/PollLoop.cpp
@@ -33,6 +33,7 @@
 #include <sys/timerfd.h>
 #include <sys/epoll.h>
 
+#include <algorithm>
 #include <thread>
 #include <mutex>
 #include <list>
@@ -417,6 +418,37 @@ void PollLoop::delAllSources()
     }
 
     AI_LOG_FN_EXIT();
+}
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Returns true if the specified source is currently installed in the
+ * pollLoop
+ *
+ * @param[in]  source   The source object to search for in the pollLoop
+ *
+ * @return True if source installed
+ *
+ */
+bool PollLoop::hasSource(const std::shared_ptr<IPollSource>& source)
+{
+    AI_LOG_FN_ENTRY();
+
+    std::lock_guard<Spinlock> locker(mLock);
+
+    if (source == nullptr)
+    {
+        return false;
+    }
+
+    auto it = std::find_if(mSources.begin(), mSources.end(), [&source](const auto& pollSource)
+    {
+        return source == pollSource.source.lock();
+    });
+
+    AI_LOG_FN_EXIT();
+
+    return it != mSources.end();
 }
 
 // -----------------------------------------------------------------------------

--- a/daemon/lib/source/DobbyLogRelay.cpp
+++ b/daemon/lib/source/DobbyLogRelay.cpp
@@ -106,6 +106,17 @@ void DobbyLogRelay::addToPollLoop(const std::shared_ptr<AICommon::IPollLoop> &po
     pollLoop->addSource(shared_from_this(), mSourceSocketFd, EPOLLIN);
 }
 
+
+/**
+ * @brief Removes the log relay to a given poll loop
+ *
+ * @param[in]   pollLoop    The poll loop to add ourselves to
+ */
+void DobbyLogRelay::removeFromPollLoop(const std::shared_ptr<AICommon::IPollLoop> &pollLoop)
+{
+    pollLoop->delSource(shared_from_this(), mSourceSocketFd);
+}
+
 /**
  * @brief Called on the poll loop. Forwards the data from the source to the destination
  * socket

--- a/daemon/lib/source/DobbyLogRelay.h
+++ b/daemon/lib/source/DobbyLogRelay.h
@@ -39,6 +39,7 @@ public:
 public:
     void process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, epoll_event event) override;
     void addToPollLoop(const std::shared_ptr<AICommon::IPollLoop> &pollLoop);
+    void removeFromPollLoop(const std::shared_ptr<AICommon::IPollLoop> &pollLoop);
 
 private:
     int createDgramSocket(const std::string& path);

--- a/daemon/lib/source/DobbyLogger.cpp
+++ b/daemon/lib/source/DobbyLogger.cpp
@@ -92,8 +92,17 @@ DobbyLogger::~DobbyLogger()
 {
     AI_LOG_FN_ENTRY();
 
-    // Stop the poll loop running
-    mPollLoop->delAllSources();
+    // Container loggers should remove themselves from the poll loop, but it doesn't really
+    // matter since if this class is being destructed the whole daemon is almost certainly
+    // shutting down
+    if (mJournaldRelay)
+    {
+        mJournaldRelay->removeFromPollLoop(mPollLoop);
+    }
+    if (mSyslogRelay)
+    {
+        mSyslogRelay->removeFromPollLoop(mPollLoop);
+    }
     mPollLoop->stop();
 
     //  Close all our open sockets

--- a/rdkPlugins/Logging/source/LoggingPlugin.cpp
+++ b/rdkPlugins/Logging/source/LoggingPlugin.cpp
@@ -57,6 +57,22 @@ LoggingPlugin::LoggingPlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
     AI_LOG_FN_EXIT();
 }
 
+LoggingPlugin::~LoggingPlugin()
+{
+    AI_LOG_FN_ENTRY();
+
+    // Make sure we clean up after ourselves
+    if (mSink && mPollLoop)
+    {
+        if (mPollLoop->hasSource(mSink))
+        {
+            mPollLoop->delSource(mSink);
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+}
+
 /**
  * @brief Set the bit flags for which hooks we're going to use
  *

--- a/rdkPlugins/Logging/source/LoggingPlugin.h
+++ b/rdkPlugins/Logging/source/LoggingPlugin.h
@@ -45,6 +45,8 @@ public:
                   const std::shared_ptr<DobbyRdkPluginUtils> &utils,
                   const std::string &rootfsPath);
 
+    ~LoggingPlugin();
+
 public:
     inline std::string name() const override
     {


### PR DESCRIPTION
### Description
Ensure that all pollLoop sources unregister themselves cleanly instead of just attempting to unregister all sources after the fact.

### Test Procedure
Ensure no segfault seen during DobbyDaemon shutdown

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)