### PR TITLE
Remove duplicate settings messages at daemon start

### DIFF
--- a/daemon/process/source/Main.cpp
+++ b/daemon/process/source/Main.cpp
@@ -510,10 +510,6 @@ int main(int argc, char * argv[])
     __ai_debug_log_level = gLogLevel;
 
 
-    // Create object storing Dobby settings
-    const std::shared_ptr<Settings> settings = createSettings();
-
-
     AI_LOG_MILESTONE("starting Dobby daemon");
 
     // Daemonise ourselves to run in the background
@@ -532,6 +528,9 @@ int main(int argc, char * argv[])
         logTargets &= ~Dobby::Console;
         Dobby::setupLogging(logTargets);
     }
+
+    // Create object storing Dobby settings
+    const std::shared_ptr<Settings> settings = createSettings();
 
 
     // Setup signals, this MUST be done in the main thread before any other


### PR DESCRIPTION
### Description
Remove the duplicated log messages at daemon startup when running Dobby with `--noconsole --journald` arguments

### Test Procedure
Only one set of settings log messages should appear.

**Before**
```
Mar 16 12:16:54 dobby-vagrant-focal systemd[1]: Starting RDK Dobby (Container) daemon...
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.882522 <T-39850> NFO: < M:Main.cpp F:createSettings L:260 > parsing settings from file @ '/etc/dobby.json'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: parsing settings from file @ '/etc/dobby.json'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.884011 <T-39850> NFO: < M:Settings.cpp F:getPathFromEnv L:620 > missing 'AI_WORKSPACE_PATH' environment var, falling back to '/var/volatile/rdk'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.884110 <T-39850> NFO: < M:Settings.cpp F:getPathFromEnv L:620 > missing 'AI_PERSISTENT_PATH' environment var, falling back to '/opt/persistent/rdk'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.885395 <T-39850> NFO: < M:Settings.cpp F:dump L:425 > settings.paths.workspaceDir='/tmp/rdk'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.885445 <T-39850> NFO: < M:Settings.cpp F:dump L:426 > settings.paths.persistentDir='/opt/persistent/rdk'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.885472 <T-39850> NFO: < M:Settings.cpp F:dump L:427 > settings.paths.consoleSocket='/tmp/dobbyPty.sock'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.885498 <T-39850> NFO: < M:Settings.cpp F:dump L:432 > settings.extraEnvVariables[0]='ETHAN_STB_MODEL=VM'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.885523 <T-39850> NFO: < M:Settings.cpp F:dump L:432 > settings.extraEnvVariables[1]='ETHAN_STB_TYPE=IP'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.885547 <T-39850> NFO: < M:Settings.cpp F:dump L:439 > settings.network.externalInterfaces[0]='enp0s8'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.885572 <T-39850> NFO: < M:Settings.cpp F:dump L:439 > settings.network.externalInterfaces[1]='enp0s3'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.885609 <T-39850> NFO: < M:Settings.cpp F:dumpHardwareAccess L:491 > settings.network.addressRange=100.64.11.0
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.885637 <T-39850> NFO: < M:Settings.cpp F:dumpHardwareAccess L:491 > settings.network.addressRange=100.64.11.0
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: 0000009320.885661 <T-39850> MIL: < M:Main.cpp F:main L:517 > starting Dobby daemon
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: missing 'AI_WORKSPACE_PATH' environment var, falling back to '/var/volatile/rdk'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: missing 'AI_PERSISTENT_PATH' environment var, falling back to '/opt/persistent/rdk'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: settings.paths.workspaceDir='/tmp/rdk'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: settings.paths.persistentDir='/opt/persistent/rdk'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: settings.paths.consoleSocket='/tmp/dobbyPty.sock'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: settings.extraEnvVariables[0]='ETHAN_STB_MODEL=VM'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: settings.extraEnvVariables[1]='ETHAN_STB_TYPE=IP'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: settings.network.externalInterfaces[0]='enp0s8'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: settings.network.externalInterfaces[1]='enp0s3'
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: settings.network.addressRange=100.64.11.0
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: settings.network.addressRange=100.64.11.0
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: starting Dobby daemon
Mar 16 12:16:54 dobby-vagrant-focal DobbyDaemon[39850]: Breakpad support disabled
```

**After**
```
Mar 16 12:20:18 dobby-vagrant-focal systemd[1]: Starting RDK Dobby (Container) daemon...
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: 0000009524.605228 <T-41133> MIL: < M:Main.cpp F:main L:513 > starting Dobby daemon
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: starting Dobby daemon
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: parsing settings from file @ '/etc/dobby.json'
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: missing 'AI_WORKSPACE_PATH' environment var, falling back to '/var/volatile/rdk'
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: missing 'AI_PERSISTENT_PATH' environment var, falling back to '/opt/persistent/rdk'
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: settings.paths.workspaceDir='/tmp/rdk'
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: settings.paths.persistentDir='/opt/persistent/rdk'
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: settings.paths.consoleSocket='/tmp/dobbyPty.sock'
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: settings.extraEnvVariables[0]='ETHAN_STB_MODEL=VM'
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: settings.extraEnvVariables[1]='ETHAN_STB_TYPE=IP'
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: settings.network.externalInterfaces[0]='enp0s8'
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: settings.network.externalInterfaces[1]='enp0s3'
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: settings.network.addressRange=100.64.11.0
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: settings.network.addressRange=100.64.11.0
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: Breakpad support disabled
Mar 16 12:20:18 dobby-vagrant-focal DobbyDaemon[41133]: starting dbus service
```

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)