### PR TITLE
Switch to Type=notify systemd service instead of Type=dbus

### DIFF
--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -552,7 +552,7 @@ void Dobby::run() const
     ret = sd_notify(0, "STOPPING=1");
     if (ret < 0)
     {
-        AI_LOG_WARN("Failed to notify systemd we're ready");
+        AI_LOG_WARN("Failed to notify systemd we're stopping");
     }
 #endif
 

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -536,8 +536,25 @@ void Dobby::run() const
         AI_LOG_ERROR("failed to emit 'ready' signal");
     }
 
+#if USE_SYSTEMD
+    int ret = sd_notify(0, "READY=1");
+    if (ret < 0)
+    {
+        AI_LOG_WARN("Failed to notify systemd we're ready");
+    }
+#endif
+
     // run the work event loop
     runWorkQueue();
+
+    // Event loop is finished, we're shutting down
+#if USE_SYSTEMD
+    ret = sd_notify(0, "STOPPING=1");
+    if (ret < 0)
+    {
+        AI_LOG_WARN("Failed to notify systemd we're ready");
+    }
+#endif
 
     AI_LOG_FN_EXIT();
 }

--- a/daemon/process/CMakeLists.txt
+++ b/daemon/process/CMakeLists.txt
@@ -135,11 +135,9 @@ install(
 
 
 if (USE_SYSTEMD)
-        configure_file(dobby.service.in dobby.service @ONLY)
-
         # Install a systemd launch service config and enables it by default
         install(
-                FILES       ${CMAKE_CURRENT_BINARY_DIR}/dobby.service
+                FILES       dobby.service
                 DESTINATION /lib/systemd/system/ )
 endif()
 

--- a/daemon/process/dobby.service
+++ b/daemon/process/dobby.service
@@ -33,12 +33,13 @@
 
 [Unit]
 Description=RDK Dobby (Container) daemon
+Requires=dbus.socket
+After=dbus.socket
 
 [Service]
-Type=dbus
-BusName=@DOBBY_SERVICE@
+Type=notify
 ExecStart=/usr/sbin/DobbyDaemon --nofork --noconsole --journald
-WatchdogSec=10
+WatchdogSec=30
 Restart=on-failure
 
 [Install]

--- a/daemon/process/dobby.service
+++ b/daemon/process/dobby.service
@@ -34,6 +34,7 @@
 [Unit]
 Description=RDK Dobby (Container) daemon
 Requires=dbus.socket
+Before=wpeframework.service
 After=dbus.socket
 
 [Service]


### PR DESCRIPTION
### Description
Change Dobby service from `Type=dbus` to `Type=notify` to ensure that systemd does not mark Dobby service as ready too early.

Update service file with following changes:
* Switch to notify service type
* Increase watchdog timeout from 10 seconds -> 30 seconds to help prevent DobbyDaemon being killed during bootup on some platforms
* Add `Before=wpeframework` condition to ensure Dobby starts before Thunder and shuts down afterwards
   * Note on platforms without Thunder this will not cause an issue as systemd will just ignore the condition

### Test Procedure
Ensure systemd reports `Started RDK Dobby (Container) daemon.` only when Dobby is completely ready

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)