### PR TITLE
LLAMA-4034: Ensure StartFromSpec() respects runtime customisations

### DIFF
--- a/client/tool/source/Main.cpp
+++ b/client/tool/source/Main.cpp
@@ -378,7 +378,7 @@ static void startCommand(const std::shared_ptr<IDobbyProxy> &dobbyProxy,
 
         std::string jsonSpec(buffer, length);
         delete[] buffer;
-        cd = dobbyProxy->startContainerFromSpec(id, jsonSpec, files, command, displaySocketPath);
+        cd = dobbyProxy->startContainerFromSpec(id, jsonSpec, files, command, displaySocketPath, envVars);
 #else
         readLine->printLnError("please provide the path to a bundle directory");
         return;

--- a/daemon/lib/source/DobbyManager.h
+++ b/daemon/lib/source/DobbyManager.h
@@ -148,18 +148,14 @@ private:
                         const std::unique_ptr<DobbyContainer> &container,
                         const std::list<int> &files);
 
-    std::string createCustomConfig(const std::unique_ptr<DobbyContainer> &container,
-                                   const std::shared_ptr<DobbyConfig> &config,
-                                   const std::string &command,
-                                   const std::string &displaySocket,
-                                   const std::vector<std::string> &envVars);
+    bool customiseConfig(const std::shared_ptr<DobbyConfig> &config,
+                        const std::string &command,
+                        const std::string &displaySocket,
+                        const std::vector<std::string> &envVars);
 
     bool createAndStartContainer(const ContainerId& id,
                                  const std::unique_ptr<DobbyContainer>& container,
-                                 const std::list<int>& files,
-                                 const std::string& command = "",
-                                 const std::string& displaySocket = "",
-                                 const std::vector<std::string>& envVars = std::vector<std::string>());
+                                 const std::list<int>& files);
 
     bool restartContainer(const ContainerId& id,
                           const std::unique_ptr<DobbyContainer>& container);


### PR DESCRIPTION
### Description
`StartFromSpec()` should correctly add custom arguments, environment variables and westeros sockets provided in config.

Previously whilst the function took those arguments, they were not reflected in the generated config file.

### Test Procedure
Start container from Dobby spec - should work as normal
```
DobbyTool start sleepy ~/srcDobby/tests/dobby_specs/sleepy.json
```

Now start the same spec with a custom argument
```
DobbyTool start sleepy3 ~/srcDobby/tests/dobby_specs/sleepy.json echo hello
```

The container should run the provided command instead of the argument specified in the spec file (in this case `echo hello`)

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)