### PR TITLE
Fix build issues with musl-based platforms

### DIFF
--- a/AppInfrastructure/Logging/include/Logging.h
+++ b/AppInfrastructure/Logging/include/Logging.h
@@ -24,6 +24,31 @@
 #ifndef LOGGING_H
 #define LOGGING_H
 
+#include <unistd.h>
+
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(exp)            \
+  ({                                       \
+    decltype(exp) _rc;                     \
+    do {                                   \
+      _rc = (exp);                         \
+    } while (_rc == -1 && errno == EINTR); \
+    _rc;                                   \
+  })
+#endif
+
+// There's no nice, reliable way to test which version of strerror_r
+// we have at compile time, so if building for a platform that uses the
+// XSI-compliant version (e.g. OS X), define HAVE_GNU_STRERROR_R as 0.
+#ifndef HAVE_GNU_STRERROR_R
+    #if defined(__APPLE__)
+        #define HAVE_GNU_STRERROR_R 0
+    #else
+        #define HAVE_GNU_STRERROR_R 1
+    #endif
+#endif
+
+
 
 /**
  * One of the following should be set by the SI build system, if they aren't

--- a/AppInfrastructure/Logging/source/Logging.cpp
+++ b/AppInfrastructure/Logging/source/Logging.cpp
@@ -205,9 +205,9 @@ extern "C" void __ai_debug_log_sys_printf(int err, int level, const char *file,
     char appendbuf[96];
     const char *append = nullptr;
 
-#if defined(__linux__)
+#ifdef HAVE_GNU_STRERROR_R
     errmsg = strerror_r(err, errbuf, sizeof(errbuf));
-#elif defined(__APPLE__)
+#else
     if (strerror_r(err, errbuf, sizeof(errbuf)) != 0)
         errmsg = "Unknown error";
     else

--- a/daemon/init/source/InitMain.cpp
+++ b/daemon/init/source/InitMain.cpp
@@ -50,6 +50,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libgen.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
@@ -64,6 +65,16 @@
 #include <string>
 #include <cstdlib>
 
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(exp)            \
+  ({                                       \
+    decltype(exp) _rc;                     \
+    do {                                   \
+      _rc = (exp);                         \
+    } while (_rc == -1 && errno == EINTR); \
+    _rc;                                   \
+  })
+#endif
 
 #if defined(USE_ETHANLOG)
 

--- a/daemon/lib/source/DobbyLogRelay.cpp
+++ b/daemon/lib/source/DobbyLogRelay.cpp
@@ -25,6 +25,7 @@
 #include <map>
 #include <sys/stat.h>
 #include <sys/un.h>
+#include <string.h>
 
 #include <Logging.h>
 
@@ -138,14 +139,13 @@ void DobbyLogRelay::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop
         iov[0].iov_base=mBuf;
         iov[0].iov_len=sizeof(mBuf);
 
-        struct msghdr message = {
-            .msg_name=&src_addr,
-            .msg_namelen=sizeof(src_addr),
-            .msg_iov=iov,
-            .msg_iovlen=1,
-            .msg_control=0,
-            .msg_controllen=0,
-        };
+        struct msghdr message{};
+        message.msg_name=&src_addr;
+        message.msg_namelen=sizeof(src_addr);
+        message.msg_iov=iov;
+        message.msg_iovlen=1;
+        message.msg_control=0;
+        message.msg_controllen=0;
 
         // This is effectively a UDP message, so we have to read the whole datagram in one chunk
         // The first byte returned by read will always be the start of the datagram. We've set

--- a/daemon/lib/source/DobbyStats.cpp
+++ b/daemon/lib/source/DobbyStats.cpp
@@ -27,6 +27,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
+#ifndef LONG_LONG_MAX
+#define LONG_LONG_MAX __LONG_LONG_MAX__
+#endif
+#ifndef ULONG_LONG_MAX
+#define ULONG_LONG_MAX (LONG_LONG_MAX * 2ULL + 1)
+#endif
+
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/plugins/EthanLog/client/cat/ethanlog-cat.cpp
+++ b/plugins/EthanLog/client/cat/ethanlog-cat.cpp
@@ -34,6 +34,16 @@
 #include <signal.h>
 #include <poll.h>
 
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(exp)            \
+  ({                                       \
+    decltype(exp) _rc;                     \
+    do {                                   \
+      _rc = (exp);                         \
+    } while (_rc == -1 && errno == EINTR); \
+    _rc;                                   \
+  })
+#endif
 
 /// The log level used for all messages from stdout
 static int gDefaultLogLevel = ETHAN_LOG_INFO;

--- a/rdkPlugins/Networking/source/IPAllocator.cpp
+++ b/rdkPlugins/Networking/source/IPAllocator.cpp
@@ -26,6 +26,8 @@
 #include <algorithm>
 #include <fcntl.h>
 #include <unistd.h>
+#include <libgen.h>
+#include <limits.h>
 
 IPAllocator::IPAllocator(const std::shared_ptr<DobbyRdkPluginUtils> &utils)
     : mUtils(utils),
@@ -198,7 +200,9 @@ bool IPAllocator::getNetworkInfo(const std::string &filePath, ContainerNetworkIn
     }
 
     const in_addr_t ip = std::stoi(ipStr);
-    networkInfo.containerId = basename(filePath.c_str());
+    char* filePathCopy = strdup(filePath.c_str());
+    networkInfo.containerId = basename(filePathCopy);
+    free(filePathCopy);
     networkInfo.ipAddressRaw = ip;
 
     // Convert the in_addr_t value to a human readable value (e.g. 100.64.11.x)

--- a/rdkPlugins/Networking/source/Netfilter.cpp
+++ b/rdkPlugins/Networking/source/Netfilter.cpp
@@ -36,6 +36,7 @@
 #include <cstdlib>
 #include <cerrno>
 #include <iterator>
+#include <libgen.h>
 
 #include <fcntl.h>
 #include <unistd.h>

--- a/rdkPlugins/Storage/source/ImageManager.cpp
+++ b/rdkPlugins/Storage/source/ImageManager.cpp
@@ -330,7 +330,7 @@ bool ImageManager::createFSImageAt(int dirFd,
 #else
     int imageFd = mkstemp(tempFilename);
     if (imageFd >= 0)
-        fcntl(fd, F_SETFD, (fcntl(fd, F_GETFD) | FD_CLOEXEC));
+        fcntl(imageFd, F_SETFD, (fcntl(imageFd, F_GETFD) | FD_CLOEXEC));
 #endif
     if (imageFd < 0)
     {

--- a/rdkPlugins/Storage/source/RefCountFile.cpp
+++ b/rdkPlugins/Storage/source/RefCountFile.cpp
@@ -23,6 +23,7 @@
 #include "RefCountFile.h"
 #include <stdio.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 RefCountFile::RefCountFile(std::string file): mFilePath(std::move(file)), mFd(-1), mOpen(false)
 {


### PR DESCRIPTION
### Description
Fix number of build issues seen when building Dobby for musl-based platforms (i.e. PrplOS)

Note there is no nice way to detect if a platform is using the GNU or XSI-compliant version of `strerror_r`, so might need to manually define `HAVE_GNU_STRERROR_R` as `0`.

### Test Procedure
Dobby should build without errors

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)