### PR TITLE
Thunder plugin should work in open network mode

### DIFF
--- a/rdkPlugins/Thunder/source/ThunderPlugin.h
+++ b/rdkPlugins/Thunder/source/ThunderPlugin.h
@@ -37,8 +37,6 @@
 #include <string>
 #include <memory>
 
-class ThunderSecurityAgent;
-
 // -----------------------------------------------------------------------------
 /**
  *  @class ThunderPlugin
@@ -95,6 +93,7 @@ private:
     std::string constructACCEPTRule(const std::string &containerIp,
                                     const std::string &vethName,
                                     in_port_t port) const;
+    bool isNatNetworkMode() const;
 
 private:
     const std::string mName;


### PR DESCRIPTION
### Description
Dobby Thunder plugin should not error if container is run in `open` network mode.

Whilst in production containers should use NAT network mode, for debugging it is often useful to use `open` network mode. The Thunder plugin should not attempt to add firewall rules or set THUNDER_ACCESS to the dobby bridge in this scenario

### Test Procedure
Configure a container with `open` network mode and the Thunder plugin. Container should start without error and should be able to access Thunder

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)