### PR TITLE
RDKTV-16461: Support for dynamic mounts

### DIFF
--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -359,6 +359,34 @@
                                     }
                                 }
                             }
+                        },
+                        "dynamic": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "destination",
+                                    "flags",
+                                    "source"
+                                ],
+                                "properties": {
+                                    "destination": {
+                                        "type": "string"
+                                    },
+                                    "flags": {
+                                        "$ref": "defs.json#/definitions/int32"
+                                    },
+                                    "options": {
+                                        "$ref": "defs.json#/definitions/ArrayOfStrings"
+                                    },
+                                    "owner":{
+                                        "type": "string"
+                                    },
+                                    "source": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -379,9 +379,6 @@
                                     "options": {
                                         "$ref": "defs.json#/definitions/ArrayOfStrings"
                                     },
-                                    "owner":{
-                                        "type": "string"
-                                    },
                                     "source": {
                                         "type": "string"
                                     }

--- a/rdkPlugins/Storage/CMakeLists.txt
+++ b/rdkPlugins/Storage/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library( ${PROJECT_NAME}
         source/ImageManager.cpp
         source/StorageHelper.cpp
         source/LoopMountDetails.cpp
+        source/DynamicMountDetails.cpp
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/rdkPlugins/Storage/README.md
+++ b/rdkPlugins/Storage/README.md
@@ -26,8 +26,8 @@ space "destination".
 ```
 
 ### Dynamic Mounts
-Add the following section to your OCI runtime configuration `config.json` file to create dynamic mount. It will mount file from "source" field into container
-space "destination" and set the file ownership through "owner" in the example format given.
+Add the following section to your OCI runtime configuration `config.json` file to create dynamic mount. 
+It will mount "source" into container "destination" only if the source exists on the host.
 
 ```json
 {
@@ -43,7 +43,6 @@ space "destination" and set the file ownership through "owner" in the example fo
                             "ro",
                             "nodev"
                         ],
-                        "owner": "user:group",
                         "source": "/tmp/test"
                     }
                 ]
@@ -99,7 +98,6 @@ For every dynamic mount point the Storage plugin should create, there should be 
 | `flags`             | Mount flags, see linux documentation or "sys/mount.h" for details                                                                       |
 |---------------------| ----------------Below this point there are optionals things, with default value in square brackets "[]"---------------------------------|
 | `options`           | Mount options, this corresponds to mount "data" field. []                                                                               |
-| `owner`             | Owner to assign to mount inside the container, e.g. "username:group" []                                                                 |
 
 #### Example
 ```json
@@ -108,8 +106,7 @@ For every dynamic mount point the Storage plugin should create, there should be 
         {
             "destination": "/tmp/test",
             "flags": 2,
-            "source": "/tmp/test",
-            "owner": "root:root"
+            "source": "/tmp/test"
         }
     ]
 }

--- a/rdkPlugins/Storage/README.md
+++ b/rdkPlugins/Storage/README.md
@@ -1,6 +1,7 @@
 # Dobby RDK Storage Plugin
 
 ## Quick Start
+### Loop Mounts
 Add the following section to your OCI runtime configuration `config.json` file to create loop mount. It will mount file from "source" field into container
 space "destination".
 
@@ -23,14 +24,42 @@ space "destination".
     }
 }
 ```
+
+### Dynamic Mounts
+Add the following section to your OCI runtime configuration `config.json` file to create dynamic mount. It will mount file from "source" field into container
+space "destination" and set the file ownership through "owner" in the example format given.
+
+```json
+{
+    "rdkPlugins": {
+        "storage": {
+            "required": true,
+            "data": {
+                "dynamic": [
+                    {
+                        "destination": "/tmp/test",
+                        "options": [
+                            "rbind",
+                            "ro",
+                            "nodev"
+                        ],
+                        "owner": "user:group",
+                        "source": "/tmp/test"
+                    }
+                ]
+            }
+        }
+    }
+}
+```
 The Storage plugin will only create one loop device for a given source file. If multiple containers share
 the same source file, then the Storage plugin will bind mount the same loop device into the different containers. Thus, they share the same private storage.
 
 If you already have other RDK plugins in the bundle, then just add the storage plugin. Do not create multiple `rdkPlugin` sections.
 
 ## Options
-### Creating mount
-For every mount point the Storage plugin should create, there should be one item in the array of "loopback". The options inside this object goes as follows:
+### Creating loop mounts
+For every loop mount point the Storage plugin should create, there should be one item in the array of "loopback". The options inside this object goes as follows:
 
 | Option              | Value                                                                                                                                   |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -55,6 +84,32 @@ For every mount point the Storage plugin should create, there should be one item
             "source": "/tmp/data/data.img",
             "persistent": false,
             "imgsize": 10485760
+        }
+    ]
+}
+```
+
+### Creating dynamic mounts
+For every dynamic mount point the Storage plugin should create, there should be one item in the array of "dynamic". The options inside this object goes as follows:
+
+| Option              | Value                                                                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `destination`       | Directory (inside container space) in which mount should end up                                                                         |
+| `source`            | Path to the image file which contains all data (if doesn't exist it will get created)                                                   |
+| `flags`             | Mount flags, see linux documentation or "sys/mount.h" for details                                                                       |
+|---------------------| ----------------Below this point there are optionals things, with default value in square brackets "[]"---------------------------------|
+| `options`           | Mount options, this corresponds to mount "data" field. []                                                                               |
+| `owner`             | Owner to assign to mount inside the container, e.g. "username:group" []                                                                 |
+
+#### Example
+```json
+"data": {
+    "dynamic": [
+        {
+            "destination": "/tmp/test",
+            "flags": 2,
+            "source": "/tmp/test",
+            "owner": "root:root"
         }
     ]
 }

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -85,55 +85,6 @@ bool DynamicMountDetails::onCreateContainer()
 
 // -----------------------------------------------------------------------------
 /**
- *  @brief Change ownership of mount according to "owner" json configuration
- *
- *  @return true on success, false on failure.
- */
-bool DynamicMountDetails::changeOwnership()
-{
-    size_t pos = mMountProperties.owner.find(':');
-    if (pos == std::string::npos) {
-        AI_LOG_ERROR("failed to find colon delimiter in '%s'", mMountProperties.owner.c_str());
-        return false;
-    }
-    
-    std::string username = mMountProperties.owner.substr(0, pos);
-    std::string groupName = mMountProperties.owner.substr(pos + 1);
-
-    AI_LOG_DEBUG("username: %s, group: %s", username.c_str(), groupName.c_str());
-
-    struct passwd* pwd;
-    pwd = getpwnam(username.c_str());
-    if (pwd == NULL)
-    {
-        AI_LOG_ERROR("failed to get passwd for '%s'", username.c_str());
-        return false;
-    }
-    
-    struct group* grp;
-    grp = getgrnam(groupName.c_str());
-    if (grp == NULL)
-    {
-        AI_LOG_ERROR("failed to get group for '%s'", groupName.c_str());
-        return false;
-    }
-
-    uid_t uid = pwd->pw_uid;
-    gid_t gid = grp->gr_gid;
-
-    AI_LOG_DEBUG("uid: %d, gid: %d", uid, gid);
-    
-    if (chown(mMountProperties.source.c_str(), uid, gid) != 0)
-    {
-        AI_LOG_ERROR("failed to change ownership for '%s' - %d", mMountProperties.source.c_str(), errno);
-        return false;
-    }
-
-    return true;
-}
-
-// -----------------------------------------------------------------------------
-/**
  *  @brief Add mount between source and destination.
  *
  *  @return true on success, false on failure.
@@ -167,13 +118,6 @@ bool DynamicMountDetails::addMount()
                      mMountProperties.source.c_str());
         return false;
     }
-    
-    if (!changeOwnership())
-    {
-        AI_LOG_ERROR("failed to add dynamic mount '%s' in storage plugin",
-                     mMountProperties.source.c_str());
-        return false;
-    }
-   
+
     return true;
 }

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -75,8 +75,8 @@ bool DynamicMountDetails::onCreateContainer()
     }
     else
     {
-        AI_LOG_ERROR("failed to stat host file for dynamic mount for '%s' in storage plugin",
-                     mMountProperties.source.c_str());
+        // No mount source so ignore
+        success = true;
     }
     
     AI_LOG_FN_EXIT();
@@ -100,6 +100,8 @@ bool DynamicMountDetails::changeOwnership()
     std::string username = mMountProperties.owner.substr(0, pos);
     std::string groupName = mMountProperties.owner.substr(pos + 1);
 
+    AI_LOG_DEBUG("username: %s, group: %s", username.c_str(), groupName.c_str());
+
     struct passwd* pwd;
     pwd = getpwnam(username.c_str());
     if (pwd == NULL)
@@ -118,10 +120,12 @@ bool DynamicMountDetails::changeOwnership()
 
     uid_t uid = pwd->pw_uid;
     gid_t gid = grp->gr_gid;
+
+    AI_LOG_DEBUG("uid: %d, gid: %d", uid, gid);
     
     if (chown(mMountProperties.source.c_str(), uid, gid) != 0)
     {
-        AI_LOG_ERROR("failed to change ownership for '%s'", mMountProperties.source.c_str());
+        AI_LOG_ERROR("failed to change ownership for '%s' - %d", mMountProperties.source.c_str(), errno);
         return false;
     }
 

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -75,6 +75,7 @@ bool DynamicMountDetails::onCreateContainer()
     {
         // No mount source so ignore
         success = true;
+        AI_LOG_INFO("Source file [%s] does not exist, dynamic mount skipped", mMountProperties.source.c_str());
     }
     
     AI_LOG_FN_EXIT();

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -1,0 +1,175 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "DynamicMountDetails.h"
+#include "StorageHelper.h"
+#include "DobbyRdkPluginUtils.h"
+
+#include <fstream>
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sstream>
+#include <fstream>
+#include <dirent.h>
+#include <pwd.h>
+#include <grp.h>
+
+constexpr char MOUNT_TYPE[] = "bind";
+
+// Dynamic mount details constructor
+DynamicMountDetails::DynamicMountDetails(const std::string& rootfsPath,
+                                         const DynamicMountProperties& mountProperties,
+                                         const std::shared_ptr<DobbyRdkPluginUtils> &utils)
+    : mRootfsPath(rootfsPath),
+      mMountProperties(mountProperties),
+      mUtils(utils)
+{
+    AI_LOG_FN_ENTRY();
+
+    AI_LOG_FN_EXIT();
+}
+
+DynamicMountDetails::~DynamicMountDetails()
+{
+    AI_LOG_FN_ENTRY();
+
+    AI_LOG_FN_EXIT();
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Checks whether source exists and creates bind mount if found
+ *
+ *  @return true on success, false on failure.
+ */
+bool DynamicMountDetails::onCreateContainer()
+{
+    AI_LOG_FN_ENTRY();
+    bool success = false;
+
+    struct stat buffer;
+    if (stat(mMountProperties.source.c_str(), &buffer) == 0)
+    {
+        success = addMount();
+    }
+    else
+    {
+        AI_LOG_ERROR("failed to stat host file for dynamic mount for '%s' in storage plugin",
+                     mMountProperties.source.c_str());
+    }
+    
+    AI_LOG_FN_EXIT();
+    return success;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Change ownership of mount according to "owner" json configuration
+ *
+ *  @return true on success, false on failure.
+ */
+bool DynamicMountDetails::changeOwnership()
+{
+    size_t pos = mMountProperties.owner.find(':');
+    if (pos == std::string::npos) {
+        AI_LOG_ERROR("failed to find colon delimiter in '%s'", mMountProperties.owner.c_str());
+        return false;
+    }
+    
+    std::string username = mMountProperties.owner.substr(0, pos);
+    std::string groupName = mMountProperties.owner.substr(pos + 1);
+
+    struct passwd* pwd;
+    pwd = getpwnam(username.c_str());
+    if (pwd == NULL)
+    {
+        AI_LOG_ERROR("failed to get passwd for '%s'", username.c_str());
+        return false;
+    }
+    
+    struct group* grp;
+    grp = getgrnam(groupName.c_str());
+    if (grp == NULL)
+    {
+        AI_LOG_ERROR("failed to get group for '%s'", groupName.c_str());
+        return false;
+    }
+
+    uid_t uid = pwd->pw_uid;
+    gid_t gid = grp->gr_gid;
+    
+    if (chown(mMountProperties.source.c_str(), uid, gid) != 0)
+    {
+        AI_LOG_ERROR("failed to change ownership for '%s'", mMountProperties.source.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Add mount between source and destination.
+ *
+ *  @return true on success, false on failure.
+ */
+bool DynamicMountDetails::addMount()
+{   
+    // Create comma separated string of mount options 
+    std::string mountData;
+    std::list<std::string>::const_iterator it = mMountProperties.mountOptions.begin();
+    for (; it != mMountProperties.mountOptions.end(); ++it)
+    {
+        if (it != mMountProperties.mountOptions.begin())
+            mountData += ",";
+         mountData += *it;    
+    }
+    
+    std::string targetPath = mRootfsPath + mMountProperties.destination;    
+    
+    // Create target file on host within the container rootfs
+    std::ofstream targetFile(targetPath);
+    targetFile.close();
+
+    // Bind mount source into destination
+    if (mount(mMountProperties.source.c_str(),
+              targetPath.c_str(),
+              "", 
+              mMountProperties.mountFlags | MS_BIND, 
+              mountData.data()) != 0)
+    {
+        AI_LOG_ERROR("failed to add dynamic mount '%s' in storage plugin",
+                     mMountProperties.source.c_str());
+        return false;
+    }
+    
+    if (!changeOwnership())
+    {
+        AI_LOG_ERROR("failed to add dynamic mount '%s' in storage plugin",
+                     mMountProperties.source.c_str());
+        return false;
+    }
+   
+    return true;
+}

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -35,8 +35,6 @@
 #include <pwd.h>
 #include <grp.h>
 
-constexpr char MOUNT_TYPE[] = "bind";
-
 // Dynamic mount details constructor
 DynamicMountDetails::DynamicMountDetails(const std::string& rootfsPath,
                                          const DynamicMountProperties& mountProperties,
@@ -59,7 +57,7 @@ DynamicMountDetails::~DynamicMountDetails()
 
 // -----------------------------------------------------------------------------
 /**
- *  @brief Checks whether source exists and creates bind mount if found
+ *  @brief Adds bind mount only if source exists on the host
  *
  *  @return true on success, false on failure.
  */

--- a/rdkPlugins/Storage/source/DynamicMountDetails.h
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.h
@@ -17,11 +17,11 @@
 * limitations under the License.
 */
 /*
- * File: LoopMountDetails.h
+ * File: DynamicMountDetails.h
  *
  */
-#ifndef LOOPMOUNTDETAILS_H
-#define LOOPMOUNTDETAILS_H
+#ifndef DYNAMICMOUNTDETAILS_H
+#define DYNAMICMOUNTDETAILS_H
 
 #include "MountProperties.h"
 
@@ -32,61 +32,45 @@
 #include <list>
 #include <memory>
 
-class RefCountFile;
-
 
 // -----------------------------------------------------------------------------
 /**
- *  @class LoopMountDetails
- *  @brief Class that represents a single loop mount within a container
+ *  @class DynamicMountDetails
+ *  @brief Class that represents a single mount within a container when the
+ * source exists on the host.
  *
  *  This class is only intended to be used internally by Storage plugin
  *  do not use from external code.
  *
  *  @see Storage
  */
-class LoopMountDetails
+class DynamicMountDetails
 {
 public:
-    LoopMountDetails() = delete;
-    LoopMountDetails(LoopMountDetails&) = delete;
-    LoopMountDetails(LoopMountDetails&&) = delete;
-    ~LoopMountDetails();
+    DynamicMountDetails() = delete;
+    DynamicMountDetails(DynamicMountDetails&) = delete;
+    DynamicMountDetails(DynamicMountDetails&&) = delete;
+    ~DynamicMountDetails();
 
 private:
     friend class Storage;
 
 public:
-    LoopMountDetails(const std::string& rootfsPath,
-                     const LoopMountProperties& mount,
-                     const uid_t& userId,
-                     const gid_t& groupId,
-                     const std::shared_ptr<DobbyRdkPluginUtils> &utils);
+    DynamicMountDetails(const std::string& rootfsPath,
+                        const DynamicMountProperties& mount,
+                        const std::shared_ptr<DobbyRdkPluginUtils> &utils);
 
 public:
-    bool doLoopMount(const std::string& loopDevice);
-
-    bool onPreCreate();
-
-    bool setPermissions();
-
-    bool remountTempDirectory();
-
-    bool cleanupTempDirectory();
-
-    bool removeNonPersistentImage();
+    bool onCreateContainer();
+    bool changeOwnership();
 
 private:
-    std::unique_ptr<RefCountFile> getRefCountFile();
+    bool addMount();
 
-private:
-    std::string mMountPointInsideContainer;
-    std::string mTempMountPointOutsideContainer;
-    LoopMountProperties mMount;
-    uid_t mUserId;
-    gid_t mGroupId;
+    const std::string mRootfsPath;
+    DynamicMountProperties mMountProperties;
 
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
 };
 
-#endif // !defined(LOOPMOUNTDETAILS_H)
+#endif // !defined(DYNAMICMOUNTDETAILS_H)

--- a/rdkPlugins/Storage/source/LoopMountDetails.cpp
+++ b/rdkPlugins/Storage/source/LoopMountDetails.cpp
@@ -43,7 +43,7 @@
 
 // Loop mount details class
 LoopMountDetails::LoopMountDetails(const std::string& rootfsPath,
-                                   const MountProperties& mount,
+                                   const LoopMountProperties& mount,
                                    const uid_t& userId,
                                    const gid_t& groupId,
                                    const std::shared_ptr<DobbyRdkPluginUtils> &utils)

--- a/rdkPlugins/Storage/source/MountProperties.h
+++ b/rdkPlugins/Storage/source/MountProperties.h
@@ -29,9 +29,9 @@
 
 
 /**
-*  @brief MountProperties struct used for Storage plugin
+*  @brief LoopMountProperties struct used for Storage plugin
 */
-typedef struct _MountProperties
+typedef struct _LoopMountProperties
 {
     std::string fsImagePath;
     std::string fsImageType;
@@ -42,7 +42,19 @@ typedef struct _MountProperties
     int imgSize;
     bool imgManagement;
 
-} MountProperties;
+} LoopMountProperties;
 
+/**
+*  @brief DynamicMountProperties struct used for Storage plugin
+*/
+typedef struct _DynamicMountProperties
+{
+    std::string source;
+    std::string destination;
+    std::string owner;
+    std::list<std::string> mountOptions;
+    unsigned long mountFlags;
+
+} DynamicMountProperties;
 
 #endif // !defined(MOUNTPROPERTIES_H)

--- a/rdkPlugins/Storage/source/MountProperties.h
+++ b/rdkPlugins/Storage/source/MountProperties.h
@@ -51,7 +51,6 @@ typedef struct _DynamicMountProperties
 {
     std::string source;
     std::string destination;
-    std::string owner;
     std::list<std::string> mountOptions;
     unsigned long mountFlags;
 

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -82,10 +82,10 @@ bool Storage::preCreation()
 
     for(auto it = mountDetails.begin(); it != mountDetails.end(); it++)
     {
-        // Creating mounts and attaching it to temp mount inside container
+        // Creating loop mount and attaching it to temp mount inside container
         if(!(*it)->onPreCreate())
         {
-            AI_LOG_ERROR_EXIT("failed to execute preCreation loop hook");
+            AI_LOG_ERROR_EXIT("failed to execute preCreation hook for loop mount");
             return false;
         }
     }
@@ -125,13 +125,26 @@ bool Storage::createContainer()
     AI_LOG_FN_ENTRY();
 
     // Mount temp directory in proper place
-    std::vector<std::unique_ptr<LoopMountDetails>> mountDetails = getLoopMountDetails();
-    for(auto it = mountDetails.begin(); it != mountDetails.end(); it++)
+    std::vector<std::unique_ptr<LoopMountDetails>> loopMountDetails = getLoopMountDetails();
+    for(auto it = loopMountDetails.begin(); it != loopMountDetails.end(); it++)
     {
         // Remount temp directory into proper place
         if(!(*it)->remountTempDirectory())
         {
             AI_LOG_ERROR_EXIT("failed to execute createRuntime loop hook");
+            return false;
+        }
+    }
+
+    // create dynamic mounts for every point
+    std::vector<std::unique_ptr<DynamicMountDetails>> dynamicMountDetails = getDynamicMountDetails();
+
+    for(auto it = dynamicMountDetails.begin(); it != dynamicMountDetails.end(); it++)
+    {
+        // Creating dynamic mounts inside container where source exists on the host
+        if(!(*it)->onCreateContainer())
+        {
+            AI_LOG_ERROR_EXIT("failed to execute createContainer hook for dynamic mount");
             return false;
         }
     }
@@ -233,21 +246,21 @@ std::vector<std::string> Storage::getDependencies() const
 
 // -----------------------------------------------------------------------------
 /**
- *  @brief Create mount details vector from all mounts in config.
+ *  @brief Create loop mount details vector from all loopback mounts in config.
  *
  *
- *  @return vector of MountDetails's that were in the config
+ *  @return vector of LoopMountDetails that were in the config
  */
-std::vector<std::unique_ptr<LoopMountDetails>> Storage::getLoopMountDetails()
+std::vector<std::unique_ptr<LoopMountDetails>> Storage::getLoopMountDetails() const
 {
     AI_LOG_FN_ENTRY();
 
-    const std::vector<MountProperties> loopMounts = getLoopMounts();
+    const std::vector<LoopMountProperties> loopMounts = getLoopMounts();
 
     std::vector<std::unique_ptr<LoopMountDetails>> mountDetails;
     // loop though all the loop mounts for the given container and create individual
-    // DobbyLoopMount objects for each
-    for (const MountProperties &properties : loopMounts)
+    // LoopMountDetails objects for each
+    for (const LoopMountProperties &properties : loopMounts)
     {
         uid_t tmp_uid = 0;
         gid_t tmp_gid = 0;
@@ -296,28 +309,28 @@ std::vector<std::unique_ptr<LoopMountDetails>> Storage::getLoopMountDetails()
 
 // -----------------------------------------------------------------------------
 /**
- *  @brief Reads container config and creates all mount information in LoopMount
+ *  @brief Reads container config and creates all loop mounts in LoopMountProperties
  *  type objects.
  *
  *
  *  @return vector of MountProperties that were in the config
  */
-std::vector<MountProperties> Storage::getLoopMounts()
+std::vector<LoopMountProperties> Storage::getLoopMounts() const
 {
     AI_LOG_FN_ENTRY();
 
-    std::vector<MountProperties> mounts;
+    std::vector<LoopMountProperties> mounts;
 
     // Check if container has mount data
     if (mContainerConfig->rdk_plugins->storage->data)
     {
-        // loop though all the mounts for the given container and create individual
+        // loop though all the loopback mounts for the given container and create individual
         // LoopMountDetails::LoopMount objects for each
         for (size_t i = 0; i < mContainerConfig->rdk_plugins->storage->data->loopback_len; i++)
         {
             auto loopback = mContainerConfig->rdk_plugins->storage->data->loopback[i];
 
-            MountProperties mount;
+            LoopMountProperties mount;
             mount.fsImagePath = std::string(loopback->source);
             mount.destination = std::string(loopback->destination);
             mount.mountFlags  = loopback->flags;
@@ -390,6 +403,86 @@ std::vector<MountProperties> Storage::getLoopMounts()
 
 // -----------------------------------------------------------------------------
 /**
+ *  @brief Create dynamic mount details vector from all dynamic mounts in config.
+ *
+ *
+ *  @return vector of DynamicMountDetails that were in the config
+ */
+std::vector<std::unique_ptr<DynamicMountDetails>> Storage::getDynamicMountDetails() const
+{
+    AI_LOG_FN_ENTRY();
+
+    const std::vector<DynamicMountProperties> dynamicMounts = getDynamicMounts();
+
+    std::vector<std::unique_ptr<DynamicMountDetails>> mountDetails;
+    // loop though all the dynamic mounts for the given container and create individual
+    // DynamicMountDetails objects for each
+    for (const DynamicMountProperties &properties : dynamicMounts)
+    {
+        // create the dynamic mount and make sure it was constructed
+        auto dynamicMount = std::make_unique<DynamicMountDetails>(mRootfsPath,
+                                                                  properties,
+                                                                  mUtils);
+
+        if (dynamicMount)
+        {
+            mountDetails.emplace_back(std::move(dynamicMount));
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+
+    return mountDetails;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Reads container config and creates all dynamic mounts in DynamicMountProperties
+ *  type objects.
+ *
+ *
+ *  @return vector of MountProperties that were in the config
+ */
+std::vector<DynamicMountProperties> Storage::getDynamicMounts() const
+{
+    AI_LOG_FN_ENTRY();
+
+    std::vector<DynamicMountProperties> mounts;
+
+    // Check if container has mount data
+    if (mContainerConfig->rdk_plugins->storage->data)
+    {
+        // loop though all the dynamic mounts for the given container and create individual
+        // LoopMountDetails::LoopMount objects for each
+        for (size_t i = 0; i < mContainerConfig->rdk_plugins->storage->data->dynamic_len; i++)
+        {
+            auto dynamic = mContainerConfig->rdk_plugins->storage->data->dynamic[i];
+
+            DynamicMountProperties mount;
+            mount.source = std::string(dynamic->source);
+            mount.destination = std::string(dynamic->destination);
+            mount.owner = std::string(dynamic->owner);
+            mount.mountFlags  = dynamic->flags;
+
+            for (size_t j = 0; j < dynamic->options_len; j++)
+            {
+                mount.mountOptions.push_back(std::string(dynamic->options[j]));
+            }
+
+            mounts.push_back(mount);
+        }
+    }
+    else
+    {
+        AI_LOG_ERROR("No storage data in config file");
+    }
+
+    AI_LOG_FN_EXIT();
+    return mounts;
+}
+
+// -----------------------------------------------------------------------------
+/**
  *  @brief Gets userId or groupId based on mappings
  *
  *  @param[in]  id          Id we want to map
@@ -398,7 +491,7 @@ std::vector<MountProperties> Storage::getLoopMounts()
  *
  *  @return if found mapped id, if not found initial id
  */
-uint32_t Storage::getMappedId(uint32_t id, rt_defs_id_mapping **mapping, size_t mapping_len)
+uint32_t Storage::getMappedId(uint32_t id, rt_defs_id_mapping **mapping, size_t mapping_len) const
 {
     AI_LOG_FN_ENTRY();
 

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -89,7 +89,6 @@ bool Storage::preCreation()
             return false;
         }
     }
-
     AI_LOG_FN_EXIT();
     return true;
 }
@@ -461,7 +460,6 @@ std::vector<DynamicMountProperties> Storage::getDynamicMounts() const
             DynamicMountProperties mount;
             mount.source = std::string(dynamic->source);
             mount.destination = std::string(dynamic->destination);
-            mount.owner = std::string(dynamic->owner);
             mount.mountFlags  = dynamic->flags;
 
             for (size_t j = 0; j < dynamic->options_len; j++)

--- a/rdkPlugins/Storage/source/Storage.h
+++ b/rdkPlugins/Storage/source/Storage.h
@@ -24,6 +24,7 @@
 #define STORAGE_H
 
 #include "LoopMountDetails.h"
+#include "DynamicMountDetails.h"
 
 #include <RdkPluginBase.h>
 
@@ -61,7 +62,7 @@ public:
     // temp mount point (within container rootfs)
     bool preCreation() override;
 
-    // This hook changes privlidges of the mounted directorires
+    // This hook changes privileges of the mounted directories
     bool createRuntime() override;
 
     // This hook mounts temp directory to the proper one
@@ -83,16 +84,18 @@ public:
     std::vector<std::string> getDependencies() const override;
 
 private:
-    std::vector<MountProperties> getLoopMounts();
-    std::vector<std::unique_ptr<LoopMountDetails>> getLoopMountDetails();
-    
+    std::vector<LoopMountProperties> getLoopMounts() const;
+    std::vector<std::unique_ptr<LoopMountDetails>> getLoopMountDetails() const;
+    std::vector<DynamicMountProperties> getDynamicMounts() const;
+    std::vector<std::unique_ptr<DynamicMountDetails>> getDynamicMountDetails() const;
 
 private:
     const std::string mName;
     std::shared_ptr<rt_dobby_schema> mContainerConfig;
     const std::string mRootfsPath;
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
-    uint32_t getMappedId(uint32_t id, rt_defs_id_mapping **mapping, size_t mapping_len);
+
+    uint32_t getMappedId(uint32_t id, rt_defs_id_mapping **mapping, size_t mapping_len) const;
 };
 
 #endif // !defined(STORAGE_H)


### PR DESCRIPTION
### Description
Extends Storage plugin with dynamic mount functionality to allow bind mounts to be created only if the source exists on the host.

### Test Procedure
Ensure container config.json contains a storage plugin with one or more dynamic mounts specified as described in the associated README.md file.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)