### PR TITLE
RDKTV-16945 IPv6 container fixes

### DIFF
--- a/rdkPlugins/Networking/README.md
+++ b/rdkPlugins/Networking/README.md
@@ -114,7 +114,7 @@ Only usable with network types 'open' and 'nat'.
 ##### Example
 ```json
 "data": {
-    "dnsmasq": "true"
+    "dnsmasq": true
 }
 ```
 

--- a/rdkPlugins/Networking/source/NetworkSetup.cpp
+++ b/rdkPlugins/Networking/source/NetworkSetup.cpp
@@ -188,6 +188,14 @@ std::vector<Netfilter::RuleSet> constructBridgeRules(const std::shared_ptr<Netfi
         }
     };
 
+    if (ipVersion == AF_INET6)
+    {
+        Netfilter::RuleSet::iterator appendFilterRules = appendRuleSet.find(Netfilter::TableType::Filter);
+        // add DobbyInputChain rule to accept Network Discovery Protocol messages, otherwise
+        // the Neigh table (which is equivalent of IPv4 ARP table) will not be able to update
+        appendFilterRules->second.emplace_front("DobbyInputChain -p ICMPv6 -j ACCEPT");
+    }
+
     // add addresses to rules depending on ipVersion
     std::string bridgeAddressRange;
     if (ipVersion == AF_INET)


### PR DESCRIPTION
### Description
Added rule for allowing Neighbor Discovery Protocol to be passed
between container and host so IPv6 containers could update
Neigh table.

### Test Procedure
Create container with only IPv6 support in Networking plugin. Run it, and force any connection i.e. with some curl command from inside container. Then check if running:
` ip -6 neigh`
Will return `REACHABLE` fields or are they  `FAILED`

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)