### PR TITLE
RDK-36839 Less permissions for sockets

### DIFF
--- a/daemon/lib/source/DobbyLogger.cpp
+++ b/daemon/lib/source/DobbyLogger.cpp
@@ -128,7 +128,7 @@ int DobbyLogger::createUnixSocket(const std::string path)
 
     // This will probably fail since the socket should be deleted when Dobby
     // exits, but in case of crash clean up before we start
-    unlink(mSocketPath.c_str());
+    unlink(path.c_str());
 
     // Create a file descriptor for the socket
     int sockFd;
@@ -149,6 +149,14 @@ int DobbyLogger::createUnixSocket(const std::string path)
     {
         AI_LOG_SYS_ERROR(errno, "Failed to bind socket");
         return -1;
+    }
+
+    // Change permissions
+    if (chmod(path.c_str(), 0644) != 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "Failed to set permissions for socket");
+        // As previously we didn't change permissions I don't believe
+        // we should fail just because permission change failed
     }
 
     // Put the socket into listening state ready to accept connections


### PR DESCRIPTION

### Description
During security scaning it was detected that `dobbyPty.sock` has its permission set to have +x flag active. As this is security concern we are removing this permissions after socket is created.

### Test Procedure
Run any container. Verify permissions of dobbyPty.sock by: 
```
ls -la /tmp/dobbyPty.sock
```
It should not have `+x` permissions.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)