### PR TITLE
RDKTV-17779: Ensure dynamic mount destination path exists

### DIFF
--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -173,12 +173,8 @@ bool DynamicMountDetails::addMount() const
          mountData += *it;
     }
 
-    // Create target file on host within the container rootfs
-    std::string targetPath = mRootfsPath + mMountProperties.destination;
-    std::ofstream targetFile(targetPath);
-    targetFile.close();
-
     // Bind mount source into destination
+    std::string targetPath = mRootfsPath + mMountProperties.destination;
     if (mount(mMountProperties.source.c_str(),
               targetPath.c_str(),
               "",

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -57,15 +57,88 @@ DynamicMountDetails::~DynamicMountDetails()
 
 // -----------------------------------------------------------------------------
 /**
+ *  @brief Creates destination path so it exists before mounting
+ *
+ *  @return true on success, false on failure.
+ */
+bool DynamicMountDetails::onCreateRuntime() const
+{
+    AI_LOG_FN_ENTRY();
+
+    bool success = false;
+    std::string targetPath = mRootfsPath + mMountProperties.destination;
+    std::string dirPath;
+
+    struct stat buffer;
+    if (stat(mMountProperties.source.c_str(), &buffer) == 0)
+    {
+        bool isDir = S_ISDIR(buffer.st_mode);
+        // Determine path based on whether source is a directory or file
+        if (isDir)
+        {
+            dirPath = targetPath;
+        }
+        else
+        {
+            // Mounting a file so exclude filename from directory path
+            std::size_t found = targetPath.find_last_of("/");
+            dirPath = targetPath.substr(0, found);
+        }
+
+        // Recursively create destination directory structure
+        if (mUtils->mkdirRecursive(dirPath, 0755) || (errno == EEXIST))
+        {
+            if (isDir)
+            {
+                success = true;
+            }
+            else
+            {
+                // If mounting a file, make sure a file with the same name
+                // exists at the desination path prior to bind mounting.
+                // Otherwise the bind mount may fail if the destination path
+                // filesystem is read-only.
+                // Creating the file first ensures an inode exists for the
+                // bind mount to target.
+                int fd = open(targetPath.c_str(), O_RDONLY | O_CREAT, 0);
+                if ((fd == 0) || (errno == EEXIST))
+                {
+                    close(fd);
+                    success = true;
+                }
+                else
+                {
+                    AI_LOG_SYS_ERROR(errno, "failed to open or create destination '%s'", targetPath.c_str());
+                }
+            }
+        }
+        else
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to create mount destination path '%s' in storage plugin", targetPath.c_str());
+        }
+    }
+    else
+    {
+        // No mount source so ignore
+        success = true;
+        AI_LOG_INFO("Source '%s' does not exist, dynamic mount directory creation skipped", mMountProperties.source.c_str());
+    }
+
+    AI_LOG_FN_EXIT();
+    return success;
+}
+
+// -----------------------------------------------------------------------------
+/**
  *  @brief Adds bind mount only if source exists on the host
  *
  *  @return true on success, false on failure.
  */
-bool DynamicMountDetails::onCreateContainer()
+bool DynamicMountDetails::onCreateContainer() const
 {
     AI_LOG_FN_ENTRY();
-    bool success = false;
 
+    bool success = false;
     struct stat buffer;
     if (stat(mMountProperties.source.c_str(), &buffer) == 0)
     {
@@ -75,7 +148,7 @@ bool DynamicMountDetails::onCreateContainer()
     {
         // No mount source so ignore
         success = true;
-        AI_LOG_INFO("Source file [%s] does not exist, dynamic mount skipped", mMountProperties.source.c_str());
+        AI_LOG_INFO("Source '%s' does not exist, dynamic mount skipped", mMountProperties.source.c_str());
     }
 
     AI_LOG_FN_EXIT();
@@ -88,7 +161,7 @@ bool DynamicMountDetails::onCreateContainer()
  *
  *  @return true on success, false on failure.
  */
-bool DynamicMountDetails::addMount()
+bool DynamicMountDetails::addMount() const
 {
     // Create comma separated string of mount options
     std::string mountData;
@@ -100,9 +173,8 @@ bool DynamicMountDetails::addMount()
          mountData += *it;
     }
 
-    std::string targetPath = mRootfsPath + mMountProperties.destination;
-
     // Create target file on host within the container rootfs
+    std::string targetPath = mRootfsPath + mMountProperties.destination;
     std::ofstream targetFile(targetPath);
     targetFile.close();
 
@@ -113,8 +185,7 @@ bool DynamicMountDetails::addMount()
               mMountProperties.mountFlags | MS_BIND,
               mountData.data()) != 0)
     {
-        AI_LOG_SYS_ERROR(errno, "failed to add dynamic mount '%s' in storage plugin",
-                     mMountProperties.source.c_str());
+        AI_LOG_SYS_ERROR(errno, "failed to add dynamic mount '%s' in storage plugin", targetPath.c_str());
         return false;
     }
 

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -157,6 +157,41 @@ bool DynamicMountDetails::onCreateContainer() const
 
 // -----------------------------------------------------------------------------
 /**
+ *  @brief Unmounts dynamic mounts
+ *
+ *  @return true on success, false on failure.
+ */
+bool DynamicMountDetails::onPostStop() const
+{
+    AI_LOG_FN_ENTRY();
+
+    bool success = false;
+    std::string targetPath = mRootfsPath + mMountProperties.destination;
+    struct stat buffer;
+
+    if (stat(targetPath.c_str(), &buffer) == 0)
+    {
+        if (remove(targetPath.c_str()) == 0)
+        {
+            success = true;
+        }
+        else
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to remove dynamic mount '%s' in storage plugin", targetPath.c_str());
+        }
+    }
+    else
+    {
+        success = true;
+        AI_LOG_INFO("Mount '%s' does not exist, dynamic mount skipped", targetPath.c_str());
+    }
+
+    AI_LOG_FN_EXIT();
+    return success;
+}
+
+// -----------------------------------------------------------------------------
+/**
  *  @brief Add mount between source and destination.
  *
  *  @return true on success, false on failure.

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -100,7 +100,7 @@ bool DynamicMountDetails::onCreateRuntime() const
                 // filesystem is read-only.
                 // Creating the file first ensures an inode exists for the
                 // bind mount to target.
-                int fd = open(targetPath.c_str(), O_RDONLY | O_CREAT, 0);
+                int fd = open(targetPath.c_str(), O_RDONLY | O_CREAT, 0644);
                 if ((fd == 0) || (errno == EEXIST))
                 {
                     close(fd);

--- a/rdkPlugins/Storage/source/DynamicMountDetails.h
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.h
@@ -61,15 +61,14 @@ public:
                         const std::shared_ptr<DobbyRdkPluginUtils> &utils);
 
 public:
-    bool onCreateContainer();
-    bool changeOwnership();
+    bool onCreateRuntime() const;
+    bool onCreateContainer() const;
 
 private:
-    bool addMount();
+    bool addMount() const;
 
     const std::string mRootfsPath;
     DynamicMountProperties mMountProperties;
-
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
 };
 

--- a/rdkPlugins/Storage/source/DynamicMountDetails.h
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.h
@@ -63,6 +63,7 @@ public:
 public:
     bool onCreateRuntime() const;
     bool onCreateContainer() const;
+    bool onPostStop() const;
 
 private:
     bool addMount() const;

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -213,13 +213,25 @@ bool Storage::postStop()
 
     // here should be deleting the data.img file when non persistent option selected
 
-    std::vector<std::unique_ptr<LoopMountDetails>> mountDetails = getLoopMountDetails();
-    for(auto it = mountDetails.begin(); it != mountDetails.end(); it++)
+    std::vector<std::unique_ptr<LoopMountDetails>> loopMountDetails = getLoopMountDetails();
+    for(auto it = loopMountDetails.begin(); it != loopMountDetails.end(); it++)
     {
         // Clean up temp mount points
         if(!(*it)->removeNonPersistentImage())
         {
             AI_LOG_ERROR_EXIT("failed to clean up non persistent image");
+            // This is probably to late to fail but do it either way
+            return false;
+        }
+    }
+
+    std::vector<std::unique_ptr<DynamicMountDetails>> dynamicMountDetails = getDynamicMountDetails();
+    for(auto it = dynamicMountDetails.begin(); it != dynamicMountDetails.end(); it++)
+    {
+        // Clean up temp mount points
+        if(!(*it)->onPostStop())
+        {
+            AI_LOG_ERROR_EXIT("failed to remove dynamic mounts");
             // This is probably to late to fail but do it either way
             return false;
         }

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -112,6 +112,18 @@ bool Storage::createRuntime()
         }
     }
 
+    // create destination paths for each dynamic mount
+    std::vector<std::unique_ptr<DynamicMountDetails>> dynamicMountDetails = getDynamicMountDetails();
+    for(auto it = dynamicMountDetails.begin(); it != dynamicMountDetails.end(); it++)
+    {
+        // Creating destination paths inside container
+        if(!(*it)->onCreateRuntime())
+        {
+            AI_LOG_ERROR_EXIT("failed to execute createRuntime hook for dynamic mount");
+            return false;
+        }
+    }
+
     AI_LOG_FN_EXIT();
     return true;
 }
@@ -312,7 +324,7 @@ std::vector<std::unique_ptr<LoopMountDetails>> Storage::getLoopMountDetails() co
  *  type objects.
  *
  *
- *  @return vector of MountProperties that were in the config
+ *  @return vector of LoopMountProperties that were in the config
  */
 std::vector<LoopMountProperties> Storage::getLoopMounts() const
 {
@@ -440,7 +452,7 @@ std::vector<std::unique_ptr<DynamicMountDetails>> Storage::getDynamicMountDetail
  *  type objects.
  *
  *
- *  @return vector of MountProperties that were in the config
+ *  @return vector of DynamicMountProperties that were in the config
  */
 std::vector<DynamicMountProperties> Storage::getDynamicMounts() const
 {
@@ -452,7 +464,7 @@ std::vector<DynamicMountProperties> Storage::getDynamicMounts() const
     if (mContainerConfig->rdk_plugins->storage->data)
     {
         // loop though all the dynamic mounts for the given container and create individual
-        // LoopMountDetails::LoopMount objects for each
+        // DynamicMountProperties objects for each
         for (size_t i = 0; i < mContainerConfig->rdk_plugins->storage->data->dynamic_len; i++)
         {
             auto dynamic = mContainerConfig->rdk_plugins->storage->data->dynamic[i];


### PR DESCRIPTION
### Description
When creating dynamic/optional mounts the destination path must exist prior to bind mounting.
For file mounts at a newly created paths, it is necessary to first create the file within the container file system so that an inode exists to be mounted over. Otherwise the bind mount will fail when the destination path is targeting a read-only area of the file system.

### Test Procedure
Create dynamic mounts for directories and files at pre-existing or newly created destination paths.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)