### PR TITLE
RDKTV-17814: Support for automatically setting UID/GID of mounts

### DIFF
--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -384,6 +384,29 @@
                                     }
                                 }
                             }
+                        },
+                        "mountOwner": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "source"
+                                ],
+                                "properties": {
+                                    "source": {
+                                        "type": "string"
+                                    },
+                                    "user": {
+                                        "type": "string"
+                                    },
+                                    "group": {
+                                        "type": "string"
+                                    },
+                                    "recursive": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/rdkPlugins/Storage/CMakeLists.txt
+++ b/rdkPlugins/Storage/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library( ${PROJECT_NAME}
         source/StorageHelper.cpp
         source/LoopMountDetails.cpp
         source/DynamicMountDetails.cpp
+        source/MountOwnerDetails.cpp
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -173,12 +173,8 @@ bool DynamicMountDetails::addMount() const
          mountData += *it;
     }
 
-    // Create target file on host within the container rootfs
-    std::string targetPath = mRootfsPath + mMountProperties.destination;
-    std::ofstream targetFile(targetPath);
-    targetFile.close();
-
     // Bind mount source into destination
+    std::string targetPath = mRootfsPath + mMountProperties.destination;
     if (mount(mMountProperties.source.c_str(),
               targetPath.c_str(),
               "",

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -57,15 +57,88 @@ DynamicMountDetails::~DynamicMountDetails()
 
 // -----------------------------------------------------------------------------
 /**
+ *  @brief Creates destination path so it exists before mounting
+ *
+ *  @return true on success, false on failure.
+ */
+bool DynamicMountDetails::onCreateRuntime() const
+{
+    AI_LOG_FN_ENTRY();
+
+    bool success = false;
+    std::string targetPath = mRootfsPath + mMountProperties.destination;
+    std::string dirPath;
+
+    struct stat buffer;
+    if (stat(mMountProperties.source.c_str(), &buffer) == 0)
+    {
+        bool isDir = S_ISDIR(buffer.st_mode);
+        // Determine path based on whether source is a directory or file
+        if (isDir)
+        {
+            dirPath = targetPath;
+        }
+        else
+        {
+            // Mounting a file so exclude filename from directory path
+            std::size_t found = targetPath.find_last_of("/");
+            dirPath = targetPath.substr(0, found);
+        }
+
+        // Recursively create destination directory structure
+        if (mUtils->mkdirRecursive(dirPath, 0755) || (errno == EEXIST))
+        {
+            if (isDir)
+            {
+                success = true;
+            }
+            else
+            {
+                // If mounting a file, make sure a file with the same name
+                // exists at the desination path prior to bind mounting.
+                // Otherwise the bind mount may fail if the destination path
+                // filesystem is read-only.
+                // Creating the file first ensures an inode exists for the
+                // bind mount to target.
+                int fd = open(targetPath.c_str(), O_RDONLY | O_CREAT, 0);
+                if ((fd == 0) || (errno == EEXIST))
+                {
+                    close(fd);
+                    success = true;
+                }
+                else
+                {
+                    AI_LOG_SYS_ERROR(errno, "failed to open or create destination '%s'", targetPath.c_str());
+                }
+            }
+        }
+        else
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to create mount destination path '%s' in storage plugin", targetPath.c_str());
+        }
+    }
+    else
+    {
+        // No mount source so ignore
+        success = true;
+        AI_LOG_INFO("Source '%s' does not exist, dynamic mount directory creation skipped", mMountProperties.source.c_str());
+    }
+
+    AI_LOG_FN_EXIT();
+    return success;
+}
+
+// -----------------------------------------------------------------------------
+/**
  *  @brief Adds bind mount only if source exists on the host
  *
  *  @return true on success, false on failure.
  */
-bool DynamicMountDetails::onCreateContainer()
+bool DynamicMountDetails::onCreateContainer() const
 {
     AI_LOG_FN_ENTRY();
-    bool success = false;
 
+    bool success = false;
     struct stat buffer;
     if (stat(mMountProperties.source.c_str(), &buffer) == 0)
     {
@@ -75,7 +148,7 @@ bool DynamicMountDetails::onCreateContainer()
     {
         // No mount source so ignore
         success = true;
-        AI_LOG_INFO("Source file [%s] does not exist, dynamic mount skipped", mMountProperties.source.c_str());
+        AI_LOG_INFO("Source '%s' does not exist, dynamic mount skipped", mMountProperties.source.c_str());
     }
 
     AI_LOG_FN_EXIT();
@@ -88,7 +161,7 @@ bool DynamicMountDetails::onCreateContainer()
  *
  *  @return true on success, false on failure.
  */
-bool DynamicMountDetails::addMount()
+bool DynamicMountDetails::addMount() const
 {
     // Create comma separated string of mount options
     std::string mountData;
@@ -100,9 +173,8 @@ bool DynamicMountDetails::addMount()
          mountData += *it;
     }
 
-    std::string targetPath = mRootfsPath + mMountProperties.destination;
-
     // Create target file on host within the container rootfs
+    std::string targetPath = mRootfsPath + mMountProperties.destination;
     std::ofstream targetFile(targetPath);
     targetFile.close();
 
@@ -113,8 +185,7 @@ bool DynamicMountDetails::addMount()
               mMountProperties.mountFlags | MS_BIND,
               mountData.data()) != 0)
     {
-        AI_LOG_SYS_ERROR(errno, "failed to add dynamic mount '%s' in storage plugin",
-                     mMountProperties.source.c_str());
+        AI_LOG_SYS_ERROR(errno, "failed to add dynamic mount '%s' in storage plugin", targetPath.c_str());
         return false;
     }
 

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -157,6 +157,41 @@ bool DynamicMountDetails::onCreateContainer() const
 
 // -----------------------------------------------------------------------------
 /**
+ *  @brief Unmounts dynamic mounts
+ *
+ *  @return true on success, false on failure.
+ */
+bool DynamicMountDetails::onPostStop() const
+{
+    AI_LOG_FN_ENTRY();
+
+    bool success = false;
+    std::string targetPath = mRootfsPath + mMountProperties.destination;
+    struct stat buffer;
+
+    if (stat(targetPath.c_str(), &buffer) == 0)
+    {
+        if (remove(targetPath.c_str()) == 0)
+        {
+            success = true;
+        }
+        else
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to remove dynamic mount '%s' in storage plugin", targetPath.c_str());
+        }
+    }
+    else
+    {
+        success = true;
+        AI_LOG_INFO("Mount '%s' does not exist, dynamic mount skipped", targetPath.c_str());
+    }
+
+    AI_LOG_FN_EXIT();
+    return success;
+}
+
+// -----------------------------------------------------------------------------
+/**
  *  @brief Add mount between source and destination.
  *
  *  @return true on success, false on failure.

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -100,7 +100,7 @@ bool DynamicMountDetails::onCreateRuntime() const
                 // filesystem is read-only.
                 // Creating the file first ensures an inode exists for the
                 // bind mount to target.
-                int fd = open(targetPath.c_str(), O_RDONLY | O_CREAT, 0);
+                int fd = open(targetPath.c_str(), O_RDONLY | O_CREAT, 0644);
                 if ((fd == 0) || (errno == EEXIST))
                 {
                     close(fd);

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -21,19 +21,9 @@
 #include "StorageHelper.h"
 #include "DobbyRdkPluginUtils.h"
 
-#include <fstream>
-#include <stdio.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
-#include <sys/ioctl.h>
-#include <sstream>
-#include <fstream>
-#include <dirent.h>
-#include <pwd.h>
-#include <grp.h>
 
 // Dynamic mount details constructor
 DynamicMountDetails::DynamicMountDetails(const std::string& rootfsPath,

--- a/rdkPlugins/Storage/source/DynamicMountDetails.h
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.h
@@ -61,15 +61,14 @@ public:
                         const std::shared_ptr<DobbyRdkPluginUtils> &utils);
 
 public:
-    bool onCreateContainer();
-    bool changeOwnership();
+    bool onCreateRuntime() const;
+    bool onCreateContainer() const;
 
 private:
-    bool addMount();
+    bool addMount() const;
 
     const std::string mRootfsPath;
     DynamicMountProperties mMountProperties;
-
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
 };
 

--- a/rdkPlugins/Storage/source/DynamicMountDetails.h
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.h
@@ -63,6 +63,7 @@ public:
 public:
     bool onCreateRuntime() const;
     bool onCreateContainer() const;
+    bool onPostStop() const;
 
 private:
     bool addMount() const;

--- a/rdkPlugins/Storage/source/MountOwnerDetails.cpp
+++ b/rdkPlugins/Storage/source/MountOwnerDetails.cpp
@@ -1,0 +1,213 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "MountOwnerDetails.h"
+#include "StorageHelper.h"
+#include "DobbyRdkPluginUtils.h"
+
+#include <unistd.h>
+#include <dirent.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <pwd.h>
+#include <grp.h>
+
+// -----------------------------------------------------------------------------
+/**
+    @class MountOwnerDetails
+ *  @brief Class that represents mount ownership and whether to apply recursively
+ *
+ *  This class is only intended to be used internally by Storage plugin
+ *  do not use from external code.
+ *
+ *  @param[in]  rootfsPath      Root FS path to apply ownership
+ *  @param[in]  mountProperties Structure holding mount ownership configuration
+ *  @param[in]  utils           Useful Dobby utilities
+ * 
+ *  @see Storage
+ */
+MountOwnerDetails::MountOwnerDetails(const std::string& rootfsPath,
+                                     const MountOwnerProperties& mountOwnerProperties,
+                                     const std::shared_ptr<DobbyRdkPluginUtils> &utils)
+    : mRootfsPath(rootfsPath),
+      mMountOwnerProperties(mountOwnerProperties),
+      mUtils(utils)
+{
+    AI_LOG_FN_ENTRY();
+    AI_LOG_FN_EXIT();
+}
+
+MountOwnerDetails::~MountOwnerDetails()
+{
+    AI_LOG_FN_ENTRY();
+    AI_LOG_FN_EXIT();
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Changes ownership of mount source according to MountOwnerProperties
+ * during the createRuntime hook
+ *
+ *  @return true on success, false on failure
+ */
+bool MountOwnerDetails::onCreateRuntime() const
+{
+    AI_LOG_FN_ENTRY();
+
+    bool success = false;
+    struct stat buffer;
+    if (stat(mMountOwnerProperties.source.c_str(), &buffer) == 0)
+    {
+        success = processOwners();
+    }
+    else
+    {
+        // Mount not found to ignore request to change ownership
+        success = true;
+        AI_LOG_INFO("Mount '%s' does not exist, change ownership skipped", mMountOwnerProperties.source.c_str());
+    }
+
+    AI_LOG_FN_EXIT();
+    return success;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Get user and group IDs based on their configured
+ *
+ *  @param[out]  userId  ID corresponding to the configured user name
+ *  @param[out]  groupId  ID corresponding to the configured group name
+ */
+void MountOwnerDetails::getOwnerIds(uid_t& userId, gid_t& groupId) const
+{
+    struct passwd *pwd;
+    struct group *grp;
+
+    pwd = getpwnam(mMountOwnerProperties.user.c_str());
+    if (pwd == NULL)
+    {
+        AI_LOG_SYS_ERROR(errno, "User '%s' not found", mMountOwnerProperties.user.c_str());
+    }
+    else
+    {
+        userId = pwd->pw_uid;
+    }
+
+    grp = getgrnam(mMountOwnerProperties.group.c_str());
+    if (grp == NULL)
+    {
+        AI_LOG_SYS_ERROR(errno, "Group '%s' not found", mMountOwnerProperties.group.c_str());
+    }
+    else
+    {
+        groupId = grp->gr_gid;
+    }
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Process individual mount owner and change ownership either singularly
+ * or recursively
+ *
+ *  @return true on success, false on failure
+ */
+bool MountOwnerDetails::processOwners() const
+{
+    AI_LOG_FN_ENTRY();
+
+    uid_t userId = 0;
+    gid_t groupId = 0;
+    getOwnerIds(userId, groupId);
+
+    if (mMountOwnerProperties.recursive)
+    {
+        if (!changeOwnerRecursive(mMountOwnerProperties.source, userId, groupId))
+        {
+            AI_LOG_ERROR("Failed to change owner recursively of '%s' to '%d:%d",
+                         mMountOwnerProperties.source.c_str(),
+                         userId,
+                         groupId);
+            return false;
+        }
+    }
+    else
+    {
+        changeOwner(mMountOwnerProperties.source, userId, groupId);
+    }
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Change ownership recursively from the given path
+ *
+ *  @param[out]  path    Path to recurse from
+ *  @param[out]  userId  ID corresponding to the configured user name
+ *  @param[out]  groupId ID corresponding to the configured group name
+ *  @return true on success, false on failure
+ */
+bool MountOwnerDetails::changeOwnerRecursive(const std::string& path, uid_t userId, gid_t groupId) const
+{
+    bool success = true;
+    DIR* dir = opendir(path.c_str());
+    if (!dir) {
+        return success;
+    }
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL)
+    {
+        std::string nextPath = path + "/" + std::string(entry->d_name);
+        if (entry->d_type == DT_DIR)
+        {
+            if ((strcmp(entry->d_name, ".") == 0) || (strcmp(entry->d_name, "..") == 0))
+            {
+                continue;
+            }
+            success &= changeOwnerRecursive(nextPath, userId, groupId);
+        }
+        success &= changeOwner(nextPath, userId, groupId);
+    }
+    closedir(dir);
+    return success;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Change ownership of mount according to properties structure
+ *
+ *  @param[in]  path    Path to change ownership of
+ *  @param[in]  userId  User ID to set
+ *  @param[in]  groupId Group ID to set
+ *  @return true on success, false on failure
+ */
+bool MountOwnerDetails::changeOwner(const std::string& path, uid_t userId, gid_t groupId) const
+{
+    AI_LOG_FN_ENTRY();
+
+    if (chown(path.c_str(), userId, groupId) != 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "Failed to change owner of '%s' to '%d:%d", path.c_str(), userId, groupId);
+        return false;
+    }
+
+    AI_LOG_FN_EXIT();
+    return true;
+}

--- a/rdkPlugins/Storage/source/MountOwnerDetails.h
+++ b/rdkPlugins/Storage/source/MountOwnerDetails.h
@@ -17,11 +17,11 @@
 * limitations under the License.
 */
 /*
- * File: DynamicMountDetails.h
+ * File: MountOwnerDetails.h
  *
  */
-#ifndef DYNAMICMOUNTDETAILS_H
-#define DYNAMICMOUNTDETAILS_H
+#ifndef MOUNTOWNERDETAILS_H
+#define MOUNTOWNERDETAILS_H
 
 #include "MountProperties.h"
 
@@ -34,42 +34,40 @@
 
 // -----------------------------------------------------------------------------
 /**
- *  @class DynamicMountDetails
- *  @brief Class that represents a single mount within a container when the
- * source exists on the host.
- *
- *  This class is only intended to be used internally by Storage plugin
+ *  @class MountOwnerDetails
+ *  @brief This class is only intended to be used internally by Storage plugin
  *  do not use from external code.
  *
  *  @see Storage
  */
-class DynamicMountDetails
+class MountOwnerDetails
 {
 public:
-    DynamicMountDetails() = delete;
-    DynamicMountDetails(DynamicMountDetails&) = delete;
-    DynamicMountDetails(DynamicMountDetails&&) = delete;
-    ~DynamicMountDetails();
+    MountOwnerDetails() = delete;
+    MountOwnerDetails(MountOwnerDetails&) = delete;
+    MountOwnerDetails(MountOwnerDetails&&) = delete;
+    ~MountOwnerDetails();
 
 private:
     friend class Storage;
 
 public:
-    DynamicMountDetails(const std::string& rootfsPath,
-                        const DynamicMountProperties& mount,
-                        const std::shared_ptr<DobbyRdkPluginUtils> &utils);
+    MountOwnerDetails(const std::string& rootfsPath,
+                      const MountOwnerProperties& mountOwnerProperties,
+                      const std::shared_ptr<DobbyRdkPluginUtils> &utils);
 
 public:
     bool onCreateRuntime() const;
-    bool onCreateContainer() const;
-    bool onPostStop() const;
 
 private:
-    bool addMount() const;
+    void getOwnerIds(uid_t& userId, gid_t& groupId) const;
+    bool processOwners() const;
+    bool changeOwnerRecursive(const std::string& path, uid_t userId, gid_t groupId) const;
+    bool changeOwner(const std::string& path, uid_t userId, gid_t groupId) const;
 
     const std::string mRootfsPath;
-    DynamicMountProperties mMountProperties;
+    MountOwnerProperties mMountOwnerProperties;
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
 };
 
-#endif // !defined(DYNAMICMOUNTDETAILS_H)
+#endif // !defined(MOUNTOWNERDETAILS_H)

--- a/rdkPlugins/Storage/source/MountProperties.h
+++ b/rdkPlugins/Storage/source/MountProperties.h
@@ -56,4 +56,16 @@ typedef struct _DynamicMountProperties
 
 } DynamicMountProperties;
 
+/**
+*  @brief MountOwnerProperties struct used for Storage plugin
+*/
+typedef struct _MountOwnerProperties
+{
+    std::string source;
+    std::string user;
+    std::string group;
+    bool recursive;
+
+} MountOwnerProperties;
+
 #endif // !defined(MOUNTPROPERTIES_H)

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -213,13 +213,25 @@ bool Storage::postStop()
 
     // here should be deleting the data.img file when non persistent option selected
 
-    std::vector<std::unique_ptr<LoopMountDetails>> mountDetails = getLoopMountDetails();
-    for(auto it = mountDetails.begin(); it != mountDetails.end(); it++)
+    std::vector<std::unique_ptr<LoopMountDetails>> loopMountDetails = getLoopMountDetails();
+    for(auto it = loopMountDetails.begin(); it != loopMountDetails.end(); it++)
     {
         // Clean up temp mount points
         if(!(*it)->removeNonPersistentImage())
         {
             AI_LOG_ERROR_EXIT("failed to clean up non persistent image");
+            // This is probably to late to fail but do it either way
+            return false;
+        }
+    }
+
+    std::vector<std::unique_ptr<DynamicMountDetails>> dynamicMountDetails = getDynamicMountDetails();
+    for(auto it = dynamicMountDetails.begin(); it != dynamicMountDetails.end(); it++)
+    {
+        // Clean up temp mount points
+        if(!(*it)->onPostStop())
+        {
+            AI_LOG_ERROR_EXIT("failed to remove dynamic mounts");
             // This is probably to late to fail but do it either way
             return false;
         }

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -112,6 +112,18 @@ bool Storage::createRuntime()
         }
     }
 
+    // create destination paths for each dynamic mount
+    std::vector<std::unique_ptr<DynamicMountDetails>> dynamicMountDetails = getDynamicMountDetails();
+    for(auto it = dynamicMountDetails.begin(); it != dynamicMountDetails.end(); it++)
+    {
+        // Creating destination paths inside container
+        if(!(*it)->onCreateRuntime())
+        {
+            AI_LOG_ERROR_EXIT("failed to execute createRuntime hook for dynamic mount");
+            return false;
+        }
+    }
+
     AI_LOG_FN_EXIT();
     return true;
 }
@@ -312,7 +324,7 @@ std::vector<std::unique_ptr<LoopMountDetails>> Storage::getLoopMountDetails() co
  *  type objects.
  *
  *
- *  @return vector of MountProperties that were in the config
+ *  @return vector of LoopMountProperties that were in the config
  */
 std::vector<LoopMountProperties> Storage::getLoopMounts() const
 {
@@ -440,7 +452,7 @@ std::vector<std::unique_ptr<DynamicMountDetails>> Storage::getDynamicMountDetail
  *  type objects.
  *
  *
- *  @return vector of MountProperties that were in the config
+ *  @return vector of DynamicMountProperties that were in the config
  */
 std::vector<DynamicMountProperties> Storage::getDynamicMounts() const
 {
@@ -452,7 +464,7 @@ std::vector<DynamicMountProperties> Storage::getDynamicMounts() const
     if (mContainerConfig->rdk_plugins->storage->data)
     {
         // loop though all the dynamic mounts for the given container and create individual
-        // LoopMountDetails::LoopMount objects for each
+        // DynamicMountProperties objects for each
         for (size_t i = 0; i < mContainerConfig->rdk_plugins->storage->data->dynamic_len; i++)
         {
             auto dynamic = mContainerConfig->rdk_plugins->storage->data->dynamic[i];

--- a/rdkPlugins/Storage/source/Storage.h
+++ b/rdkPlugins/Storage/source/Storage.h
@@ -25,6 +25,7 @@
 
 #include "LoopMountDetails.h"
 #include "DynamicMountDetails.h"
+#include "MountOwnerDetails.h"
 
 #include <RdkPluginBase.h>
 
@@ -86,8 +87,12 @@ public:
 private:
     std::vector<LoopMountProperties> getLoopMounts() const;
     std::vector<std::unique_ptr<LoopMountDetails>> getLoopMountDetails() const;
+
     std::vector<DynamicMountProperties> getDynamicMounts() const;
     std::vector<std::unique_ptr<DynamicMountDetails>> getDynamicMountDetails() const;
+
+    std::vector<MountOwnerProperties> getMountOwners() const;
+    std::vector<std::unique_ptr<MountOwnerDetails>> getMountOwnerDetails() const;
 
 private:
     const std::string mName;


### PR DESCRIPTION
DO NOT MERGE - still requires documentation.
Awaiting review to determine whether this solution is viable as it changes ownership on the host OS.

### Description
Support for configuration and automatic setting of UID/GID for bind mounts.
Removes need for scripted chown calls which are more error prone and difficult to order and synchronise.

### Test Procedure
Create ownerMount definitions in container config.json and ensure UID/GID are changed accordingly.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)