### PR TITLE
RDKTV-17814: Support for automatically setting UID/GID of mounts

### DIFF
--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -384,6 +384,29 @@
                                     }
                                 }
                             }
+                        },
+                        "mountOwner": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "source"
+                                ],
+                                "properties": {
+                                    "source": {
+                                        "type": "string"
+                                    },
+                                    "user": {
+                                        "type": "string"
+                                    },
+                                    "group": {
+                                        "type": "string"
+                                    },
+                                    "recursive": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/rdkPlugins/Storage/CMakeLists.txt
+++ b/rdkPlugins/Storage/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library( ${PROJECT_NAME}
         source/StorageHelper.cpp
         source/LoopMountDetails.cpp
         source/DynamicMountDetails.cpp
+        source/MountOwnerDetails.cpp
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/rdkPlugins/Storage/README.md
+++ b/rdkPlugins/Storage/README.md
@@ -24,6 +24,9 @@ space "destination".
     }
 }
 ```
+The Storage plugin will only create one loop device for a given source file. If multiple containers share
+the same source file, then the Storage plugin will bind mount the same loop device into the different containers.
+Thus, they share the same private storage.
 
 ### Dynamic Mounts
 Add the following section to your OCI runtime configuration `config.json` file to create dynamic mount. 
@@ -51,8 +54,29 @@ It will mount "source" into container "destination" only if the source exists on
     }
 }
 ```
-The Storage plugin will only create one loop device for a given source file. If multiple containers share
-the same source file, then the Storage plugin will bind mount the same loop device into the different containers. Thus, they share the same private storage.
+
+### Mount Owners
+Add the following section to your OCI runtime configuration `config.json` file to configure mount ownership.
+
+```json
+{
+    "rdkPlugins": {
+        "storage": {
+            "required": true,
+            "data": {
+                "": [
+                    {
+                        "source": "/tmp/test",
+                        "user": "root",
+                        "group": "root",
+                        "recursive": false
+                    }
+                ]
+            }
+        }
+    }
+}
+```
 
 If you already have other RDK plugins in the bundle, then just add the storage plugin. Do not create multiple `rdkPlugin` sections.
 
@@ -112,3 +136,26 @@ For every dynamic mount point the Storage plugin should create, there should be 
 }
 ```
 
+### Creating mount owners
+For every mount owner point the Storage plugin should create, there should be one item in the array of "mountOwner". The options inside this object goes as follows:
+
+| Option              | Value                                                                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`            | Directory or file which is the source of the mount, i.e. on host                                                                        |
+|---------------------| ----------------Below this point there are optionals things, with default value in square brackets "[]"---------------------------------|
+| `user`              | Name of user to change to  (if ommitted, use container default user)                                                                    |
+| `group`             | Name of group to change to  (if ommitted, use container default group)                                                                  |
+| `recursive`         | Whether to change ownership recursively when source is a directory (if ommitted, treated as false, e.g. non-recursive)                  |
+
+#### Example
+```json
+"data": {
+    "mountOwner": [
+        {
+            "source": "/tmp/test"
+        }
+    ]
+}
+```
+
+This will change ownership to the container default user and group, which will be applied non-recusively.

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -21,19 +21,9 @@
 #include "StorageHelper.h"
 #include "DobbyRdkPluginUtils.h"
 
-#include <fstream>
-#include <stdio.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
-#include <sys/ioctl.h>
-#include <sstream>
-#include <fstream>
-#include <dirent.h>
-#include <pwd.h>
-#include <grp.h>
 
 // Dynamic mount details constructor
 DynamicMountDetails::DynamicMountDetails(const std::string& rootfsPath,

--- a/rdkPlugins/Storage/source/MountOwnerDetails.cpp
+++ b/rdkPlugins/Storage/source/MountOwnerDetails.cpp
@@ -1,0 +1,241 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2022 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "MountOwnerDetails.h"
+#include "StorageHelper.h"
+#include "DobbyRdkPluginUtils.h"
+
+#include <unistd.h>
+#include <dirent.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <pwd.h>
+#include <grp.h>
+
+// -----------------------------------------------------------------------------
+/**
+    @class MountOwnerDetails
+ *  @brief Class that represents mount ownership and whether to apply recursively
+ *
+ *  This class is only intended to be used internally by Storage plugin
+ *  do not use from external code.
+ *
+ *  @param[in]  rootfsPath      Root FS path to apply ownership
+ *  @param[in]  mountProperties Structure holding mount ownership configuration
+ *  @param[in]  utils           Useful Dobby utilities
+ *
+ *  @see Storage
+ */
+MountOwnerDetails::MountOwnerDetails(const std::string& rootfsPath,
+                                     const MountOwnerProperties& mountOwnerProperties,
+                                     const uid_t& defaultUserId,
+                                     const gid_t& defaultGroupId,
+                                     const std::shared_ptr<DobbyRdkPluginUtils> &utils)
+    : mRootfsPath(rootfsPath),
+      mMountOwnerProperties(mountOwnerProperties),
+      mDefaultUserId(defaultUserId),
+      mDefaultGroupId(defaultGroupId),
+      mUtils(utils)
+{
+    AI_LOG_FN_ENTRY();
+    AI_LOG_FN_EXIT();
+}
+
+MountOwnerDetails::~MountOwnerDetails()
+{
+    AI_LOG_FN_ENTRY();
+    AI_LOG_FN_EXIT();
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Changes ownership of mount source according to MountOwnerProperties
+ * during the createRuntime hook
+ *
+ *  @return true on success, false on failure
+ */
+bool MountOwnerDetails::onCreateRuntime() const
+{
+    AI_LOG_FN_ENTRY();
+
+    bool success = false;
+    struct stat buffer;
+    if (stat(mMountOwnerProperties.source.c_str(), &buffer) == 0)
+    {
+        success = processOwners();
+    }
+    else
+    {
+        // Mount not found to ignore request to change ownership
+        success = true;
+        AI_LOG_INFO("Mount '%s' does not exist, change ownership skipped", mMountOwnerProperties.source.c_str());
+    }
+
+    AI_LOG_FN_EXIT();
+    return success;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Get user and group IDs based on their configured
+ *
+ *  @param[out]  userId  ID corresponding to the configured user name
+ *  @param[out]  groupId  ID corresponding to the configured group name
+ *  @return true on success, false on failure
+ */
+bool MountOwnerDetails::getOwnerIds(uid_t& userId, gid_t& groupId) const
+{
+    struct passwd *pwd;
+    struct group *grp;
+    if (mMountOwnerProperties.user.empty())
+    {
+        AI_LOG_INFO("Using default user '%d'", mDefaultUserId);
+        userId = mDefaultUserId;
+    }
+    else
+    {
+        pwd = getpwnam(mMountOwnerProperties.user.c_str());
+        if (pwd == NULL)
+        {
+            AI_LOG_SYS_ERROR(errno, "User '%s' not found", mMountOwnerProperties.user.c_str());
+            return false;
+        }
+        else
+        {
+            userId = pwd->pw_uid;
+        }
+    }
+
+    if (mMountOwnerProperties.group.empty())
+    {
+        AI_LOG_INFO("Using default group '%d'", mDefaultGroupId);
+        groupId = mDefaultGroupId;
+    }
+    else
+    {
+        grp = getgrnam(mMountOwnerProperties.group.c_str());
+        if (grp == NULL)
+        {
+            AI_LOG_SYS_ERROR(errno, "Group '%s' not found", mMountOwnerProperties.group.c_str());
+            return false;
+        }
+        else
+        {
+            groupId = grp->gr_gid;
+        }
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Process individual mount owner and change ownership either singularly
+ * or recursively
+ *
+ *  @return true on success, false on failure
+ */
+bool MountOwnerDetails::processOwners() const
+{
+    AI_LOG_FN_ENTRY();
+
+    uid_t userId = 0;
+    gid_t groupId = 0;
+
+    if (getOwnerIds(userId, groupId))
+    {
+        if (mMountOwnerProperties.recursive)
+        {
+            if (!changeOwnerRecursive(mMountOwnerProperties.source, userId, groupId))
+            {
+                AI_LOG_ERROR("Failed to change owner recursively of '%s' to '%d:%d",
+                             mMountOwnerProperties.source.c_str(),
+                             userId,
+                             groupId);
+                return false;
+            }
+        }
+        else
+        {
+            changeOwner(mMountOwnerProperties.source, userId, groupId);
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Change ownership recursively from the given path
+ *
+ *  @param[out]  path    Path to recurse from
+ *  @param[out]  userId  ID corresponding to the configured user name
+ *  @param[out]  groupId ID corresponding to the configured group name
+ *  @return true on success, false on failure
+ */
+bool MountOwnerDetails::changeOwnerRecursive(const std::string& path, uid_t userId, gid_t groupId) const
+{
+    bool success = true;
+    DIR* dir = opendir(path.c_str());
+    if (!dir) {
+        return success;
+    }
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL)
+    {
+        std::string nextPath = path + "/" + std::string(entry->d_name);
+        if (entry->d_type == DT_DIR)
+        {
+            if ((strcmp(entry->d_name, ".") == 0) || (strcmp(entry->d_name, "..") == 0))
+            {
+                continue;
+            }
+            success &= changeOwnerRecursive(nextPath, userId, groupId);
+        }
+        success &= changeOwner(nextPath, userId, groupId);
+    }
+    success &= changeOwner(path, userId, groupId);
+
+    closedir(dir);
+    return success;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Change ownership of mount according to properties structure
+ *
+ *  @param[in]  path    Path to change ownership of
+ *  @param[in]  userId  User ID to set
+ *  @param[in]  groupId Group ID to set
+ *  @return true on success, false on failure
+ */
+bool MountOwnerDetails::changeOwner(const std::string& path, uid_t userId, gid_t groupId) const
+{
+    AI_LOG_FN_ENTRY();
+
+    if (chown(path.c_str(), userId, groupId) != 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "Failed to change owner of '%s' to '%d:%d", path.c_str(), userId, groupId);
+        return false;
+    }
+
+    AI_LOG_FN_EXIT();
+    return true;
+}

--- a/rdkPlugins/Storage/source/MountOwnerDetails.h
+++ b/rdkPlugins/Storage/source/MountOwnerDetails.h
@@ -17,11 +17,11 @@
 * limitations under the License.
 */
 /*
- * File: DynamicMountDetails.h
+ * File: MountOwnerDetails.h
  *
  */
-#ifndef DYNAMICMOUNTDETAILS_H
-#define DYNAMICMOUNTDETAILS_H
+#ifndef MOUNTOWNERDETAILS_H
+#define MOUNTOWNERDETAILS_H
 
 #include "MountProperties.h"
 
@@ -34,42 +34,44 @@
 
 // -----------------------------------------------------------------------------
 /**
- *  @class DynamicMountDetails
- *  @brief Class that represents a single mount within a container when the
- * source exists on the host.
- *
- *  This class is only intended to be used internally by Storage plugin
+ *  @class MountOwnerDetails
+ *  @brief This class is only intended to be used internally by Storage plugin
  *  do not use from external code.
  *
  *  @see Storage
  */
-class DynamicMountDetails
+class MountOwnerDetails
 {
 public:
-    DynamicMountDetails() = delete;
-    DynamicMountDetails(DynamicMountDetails&) = delete;
-    DynamicMountDetails(DynamicMountDetails&&) = delete;
-    ~DynamicMountDetails();
+    MountOwnerDetails() = delete;
+    MountOwnerDetails(MountOwnerDetails&) = delete;
+    MountOwnerDetails(MountOwnerDetails&&) = delete;
+    ~MountOwnerDetails();
 
 private:
     friend class Storage;
 
 public:
-    DynamicMountDetails(const std::string& rootfsPath,
-                        const DynamicMountProperties& mount,
-                        const std::shared_ptr<DobbyRdkPluginUtils> &utils);
+    MountOwnerDetails(const std::string& rootfsPath,
+                      const MountOwnerProperties& mountOwnerProperties,
+                      const uid_t& defaultUserId,
+                      const gid_t& defaultGroupId,
+                      const std::shared_ptr<DobbyRdkPluginUtils> &utils);
 
 public:
     bool onCreateRuntime() const;
-    bool onCreateContainer() const;
-    bool onPostStop() const;
 
 private:
-    bool addMount() const;
+    bool getOwnerIds(uid_t& userId, gid_t& groupId) const;
+    bool processOwners() const;
+    bool changeOwnerRecursive(const std::string& path, uid_t userId, gid_t groupId) const;
+    bool changeOwner(const std::string& path, uid_t userId, gid_t groupId) const;
 
     const std::string mRootfsPath;
-    DynamicMountProperties mMountProperties;
+    MountOwnerProperties mMountOwnerProperties;
+    uid_t mDefaultUserId;
+    gid_t mDefaultGroupId;
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
 };
 
-#endif // !defined(DYNAMICMOUNTDETAILS_H)
+#endif // !defined(MOUNTOWNERDETAILS_H)

--- a/rdkPlugins/Storage/source/MountProperties.h
+++ b/rdkPlugins/Storage/source/MountProperties.h
@@ -56,4 +56,16 @@ typedef struct _DynamicMountProperties
 
 } DynamicMountProperties;
 
+/**
+*  @brief MountOwnerProperties struct used for Storage plugin
+*/
+typedef struct _MountOwnerProperties
+{
+    std::string source;
+    std::string user;
+    std::string group;
+    bool recursive;
+
+} MountOwnerProperties;
+
 #endif // !defined(MOUNTPROPERTIES_H)

--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -124,6 +124,19 @@ bool Storage::createRuntime()
         }
     }
 
+    // Change mount ownership for all configured items
+    std::vector<std::unique_ptr<MountOwnerDetails>> mountOwnerDetails = getMountOwnerDetails();
+
+    for(auto it = mountOwnerDetails.begin(); it != mountOwnerDetails.end(); it++)
+    {
+        // Change ownership of mount
+        if(!(*it)->onCreateRuntime())
+        {
+            AI_LOG_ERROR_EXIT("failed to execute createRuntime hook for mount owner");
+            return false;
+        }
+    }
+
     AI_LOG_FN_EXIT();
     return true;
 }
@@ -147,7 +160,7 @@ bool Storage::createContainer()
         }
     }
 
-    // create dynamic mounts for every point
+    // Create dynamic mounts for every point
     std::vector<std::unique_ptr<DynamicMountDetails>> dynamicMountDetails = getDynamicMountDetails();
 
     for(auto it = dynamicMountDetails.begin(); it != dynamicMountDetails.end(); it++)
@@ -279,45 +292,22 @@ std::vector<std::unique_ptr<LoopMountDetails>> Storage::getLoopMountDetails() co
     AI_LOG_FN_ENTRY();
 
     const std::vector<LoopMountProperties> loopMounts = getLoopMounts();
-
     std::vector<std::unique_ptr<LoopMountDetails>> mountDetails;
+
     // loop though all the loop mounts for the given container and create individual
     // LoopMountDetails objects for each
     for (const LoopMountProperties &properties : loopMounts)
     {
-        uid_t tmp_uid = 0;
-        gid_t tmp_gid = 0;
-
-        // Firstly get uid/gid from process
-        if(mContainerConfig->process &&
-           mContainerConfig->process->user)
-        {
-            if (mContainerConfig->process->user->uid_present)
-            {
-                tmp_uid = mContainerConfig->process->user->uid;
-            }
-
-            if (mContainerConfig->process->user->gid_present)
-            {
-                tmp_gid = mContainerConfig->process->user->gid;
-            }
-        }
-
-        // Then map it inside container
-        tmp_uid = getMappedId(tmp_uid,
-                                mContainerConfig->linux->uid_mappings,
-                                mContainerConfig->linux->uid_mappings_len);
-
-        tmp_gid = getMappedId(tmp_gid,
-                                mContainerConfig->linux->gid_mappings,
-                                mContainerConfig->linux->gid_mappings_len);
-
+        // Setup the user/group IDs
+        uid_t uid = 0;
+        gid_t gid = 0;
+        setupOwnerIds(uid, gid);
 
         // create the loop mount and make sure it was constructed
         auto loopMount = std::make_unique<LoopMountDetails>(mRootfsPath,
                                                             properties,
-                                                            tmp_uid,
-                                                            tmp_gid,
+                                                            uid,
+                                                            gid,
                                                             mUtils);
 
         if (loopMount)
@@ -501,6 +491,129 @@ std::vector<DynamicMountProperties> Storage::getDynamicMounts() const
 
     AI_LOG_FN_EXIT();
     return mounts;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Create mount owner details vector from all mount owners in config.
+ *
+ *
+ *  @return vector of MountOwnerDetails that were in the config
+ */
+std::vector<std::unique_ptr<MountOwnerDetails>> Storage::getMountOwnerDetails() const
+{
+    AI_LOG_FN_ENTRY();
+
+    const std::vector<MountOwnerProperties> mountOwners = getMountOwners();
+    std::vector<std::unique_ptr<MountOwnerDetails>> ownerDetails;
+
+    // Setup the user/group IDs
+    uid_t uid = 0;
+    gid_t gid = 0;
+    setupOwnerIds(uid, gid);
+
+    // loop though all the mount owners for the given container and create individual
+    // MountOwnerDetails objects for each
+    for (const MountOwnerProperties &properties : mountOwners)
+    {
+        // create the mount owner details and make sure it was constructed
+        auto mountOwner = std::make_unique<MountOwnerDetails>(mRootfsPath,
+                                                              properties,
+                                                              uid,
+                                                              gid,
+                                                              mUtils);
+
+        if (mountOwner)
+        {
+            ownerDetails.emplace_back(std::move(mountOwner));
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+
+    return ownerDetails;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Reads container config and creates all dynamic mounts in DynamicMountProperties
+ *  type objects.
+ *
+ *
+ *  @return vector of DynamicMountProperties that were in the config
+ */
+std::vector<MountOwnerProperties> Storage::getMountOwners() const
+{
+    AI_LOG_FN_ENTRY();
+
+    std::vector<MountOwnerProperties> mountOwners;
+
+    // Check if container has mount data
+    if (mContainerConfig->rdk_plugins->storage->data)
+    {
+        // loop though all the mount owners for the given container and create individual
+        // MountOwnerProperties objects for each
+        for (size_t i = 0; i < mContainerConfig->rdk_plugins->storage->data->mount_owner_len; i++)
+        {
+            auto mountOwner = mContainerConfig->rdk_plugins->storage->data->mount_owner[i];
+
+            MountOwnerProperties mountOwnerProps;
+            mountOwnerProps.source = std::string(mountOwner->source);
+            if (mountOwner->user)
+            {
+                mountOwnerProps.user = std::string(mountOwner->user);
+            }
+            if (mountOwner->group)
+            {
+                mountOwnerProps.group  = std::string(mountOwner->group);
+            }
+            mountOwnerProps.recursive = mountOwner->recursive_present ? mountOwner->recursive : false;
+            mountOwners.push_back(mountOwnerProps);
+        }
+    }
+    else
+    {
+        AI_LOG_ERROR("No storage data in config file");
+    }
+
+    AI_LOG_FN_EXIT();
+    return mountOwners;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Gets userId and groupId
+ *
+ *  @param[in]  id          Id we want to map
+ *  @param[in]  mapping     Mapping that should be used
+ *  @param[in]  mapping_len Length of mapping
+ *
+ *  @return if found mapped id, if not found initial id
+ */
+void Storage::setupOwnerIds(uid_t& uid, gid_t& gid) const
+{
+    // Get uid/gid from process
+    if(mContainerConfig->process && mContainerConfig->process->user)
+    {
+        if (mContainerConfig->process->user->uid_present)
+        {
+            uid = mContainerConfig->process->user->uid;
+        }
+
+        if (mContainerConfig->process->user->gid_present)
+        {
+            gid = mContainerConfig->process->user->gid;
+        }
+    }
+
+    // Then map it inside container
+    uid = getMappedId(uid,
+                      mContainerConfig->linux->uid_mappings,
+                      mContainerConfig->linux->uid_mappings_len);
+
+    gid = getMappedId(gid,
+                      mContainerConfig->linux->gid_mappings,
+                      mContainerConfig->linux->gid_mappings_len);
 }
 
 // -----------------------------------------------------------------------------

--- a/rdkPlugins/Storage/source/Storage.h
+++ b/rdkPlugins/Storage/source/Storage.h
@@ -25,6 +25,7 @@
 
 #include "LoopMountDetails.h"
 #include "DynamicMountDetails.h"
+#include "MountOwnerDetails.h"
 
 #include <RdkPluginBase.h>
 
@@ -86,8 +87,14 @@ public:
 private:
     std::vector<LoopMountProperties> getLoopMounts() const;
     std::vector<std::unique_ptr<LoopMountDetails>> getLoopMountDetails() const;
+
     std::vector<DynamicMountProperties> getDynamicMounts() const;
     std::vector<std::unique_ptr<DynamicMountDetails>> getDynamicMountDetails() const;
+
+    std::vector<MountOwnerProperties> getMountOwners() const;
+    std::vector<std::unique_ptr<MountOwnerDetails>> getMountOwnerDetails() const;
+
+    void setupOwnerIds(uid_t& uid, gid_t& gid) const;
 
 private:
     const std::string mName;


### PR DESCRIPTION
### Description
Added support for configuration of ownership of mounts to reduce the reliance on external scripts.
The user and group can be changed on file and directory mounts, with the latter able to be applied recursively.

### Test Procedure
Add "mountOwner" definitions in the container config.json as decribed in the README for the storage plugin.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)