### PR TITLE
RDKTV-19656 Fixed endless loop for deepsleep containers

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -505,6 +505,12 @@ void DobbyManager::cleanupContainersShutdown()
             // notified of the container stop event
             if (!stopContainer(it->second->descriptor, false))
             {
+                // As DobbyRunC::killCont already handles problem of masked SIGTERM in
+                // case we failed to stop it means that it tried to SIGKILL too, so
+                // container must be in uninterrable sleep and we cannot do anything
+                // Remove it container from the list (even though it wasn't clean up)
+                // to avoid repeating indefinitely. It will be cleaned on boot-up
+                it = mContainers.erase(it);
                 AI_LOG_ERROR("Failed to stop container %s. Will attempt to clean up at daemon restart", it->first.c_str());
             }
             else


### PR DESCRIPTION
### Description
Before this change it was possible to endlessly try to close the container during cleanupContainersShutdown, now we try to close it once. It will be clean-up after next boot-up either way.


### Test Procedure
Check if container in uninterruptible sleep will not cause infinite loop during shutdown

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)