### PR TITLE
RDKTV-19597 Condition variable problem fix

### DIFF
--- a/AppInfrastructure/Common/include/ConditionVariable.h
+++ b/AppInfrastructure/Common/include/ConditionVariable.h
@@ -117,7 +117,7 @@ private:
         ts.tv_sec += std::chrono::duration_cast<std::chrono::seconds>(rel_time).count();
         ts.tv_nsec += (rel_time % std::chrono::seconds(1)).count();
 
-        if (ts.tv_nsec > 1000000000L)
+        if (ts.tv_nsec >= 1000000000L)
         {
             ts.tv_nsec -= 1000000000L;
             ts.tv_sec += 1;
@@ -221,6 +221,7 @@ public:
             }
             else if (err != 0)
             {
+                AI_LOG_FATAL("Condition variable error in wait_for '%d'", err);
                 __ConditionVariableThrowOnError(err);
             }
         }


### PR DESCRIPTION
### Description
It seams that 1 in 1'000'000'001 cases the value of tv_nsec was incorrect, as according to the specification it should be between 0-999'999'999, and we were allowing value of 1'000'000'000. I also added some extra log in case we have any more condition variable error in future.

### Test Procedure
- Not applicable (run 10 billion times and make sure no errors is not feasible)

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)