### PR TITLE
LLAMA-8016 Fixed race with veth devices

### DIFF
--- a/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
@@ -40,6 +40,7 @@
 #include <list>
 #include <mutex>
 #include <arpa/inet.h>
+#include <vector>
 
 
 // TODO:: This would be better stored in the dobby workspace dir rather than /tmp,
@@ -129,6 +130,7 @@ public:
     pid_t getContainerPid() const;
     std::string getContainerId() const;
     bool getContainerNetworkInfo(ContainerNetworkInfo &networkInfo);
+    bool getTakenVeths(std::vector<std::string> &takenVeths);
 
     bool writeTextFile(const std::string &path,
                        const std::string &str,

--- a/rdkPlugins/Networking/include/Netlink.h
+++ b/rdkPlugins/Networking/include/Netlink.h
@@ -104,7 +104,8 @@ public:
 
 public:
     std::string createVeth(const std::string& peerVethName,
-                           pid_t peerPid);
+                           pid_t peerPid,
+                           std::vector<std::string> &takenVeths);
     bool checkVeth(const std::string& vethName);
 
 public:

--- a/rdkPlugins/Networking/source/Netlink.cpp
+++ b/rdkPlugins/Networking/source/Netlink.cpp
@@ -1409,7 +1409,9 @@ std::string Netlink::createVeth(const std::string& peerVethName,
         if (already_taken)
         {
             AI_LOG_WARN("Tried to use already taken vethName '%s', continue looking", vethName.c_str());
-            vethNameStartIndex++;
+            // if more than one container is on we can "jump" to the next free one, we don't need
+            // to iterate one by one
+            vethNameStartIndex = std::stoi(vethName.erase(0, 4)) + 1;
             continue;
         }
 

--- a/rdkPlugins/Networking/source/Netlink.cpp
+++ b/rdkPlugins/Networking/source/Netlink.cpp
@@ -1350,13 +1350,16 @@ std::string Netlink::getAvailableVethName(const int startIndex) const
  *  @param[in]  peerPid         The pid of the process which has the netns we
  *                              want to create the veth in (i.e. the pid of
  *                              init process within the container).
+ *  @param[in]  takenVeths      Veth devices reserved by other containers.
+ *                              We want to check that in case of races.
  *
  *  @return on success the interface name of the veth pair, this is the name
  *  outside the container and will be of the form veth%d, ie veth0, veth1, etc.
  *  On failure an empty string is returned.
  */
 std::string Netlink::createVeth(const std::string& peerVethName,
-                                const pid_t peerPid)
+                                const pid_t peerPid,
+                                std::vector<std::string> &takenVeths)
 {
     AI_LOG_FN_ENTRY();
 
@@ -1390,6 +1393,24 @@ std::string Netlink::createVeth(const std::string& peerVethName,
         {
             AI_LOG_ERROR("no free veth%%d names available");
             break;
+        }
+
+        // check if some other container doesn't already claims this veth
+        bool already_taken = false;
+        for (auto & taken : takenVeths)
+        {
+            if(vethName.compare(taken) == 0)
+            {
+                already_taken = true;
+                break;
+            }
+        }
+
+        if (already_taken)
+        {
+            AI_LOG_WARN("Tried to use already taken vethName '%s', continue looking", vethName.c_str());
+            vethNameStartIndex++;
+            continue;
         }
 
         // create the veth pair

--- a/rdkPlugins/Networking/source/NetworkSetup.cpp
+++ b/rdkPlugins/Networking/source/NetworkSetup.cpp
@@ -725,7 +725,10 @@ bool NetworkSetup::setupVeth(const std::shared_ptr<DobbyRdkPluginUtils> &utils,
 
     // step 3 - create a veth pair for the container, using the name of the
     // first external interface defined in Dobby settings
-    std::string vethName = netlink->createVeth(PEER_NAME, containerPid);
+    std::vector<std::string> takenVeths;
+    utils->getTakenVeths(takenVeths);
+
+    std::string vethName = netlink->createVeth(PEER_NAME, containerPid, takenVeths);
     if (vethName.empty())
     {
         AI_LOG_ERROR_EXIT("failed to create veth pair for container '%s'",


### PR DESCRIPTION
### Description
Fixed the race when one container was closed and second was started at the same time. It resulted with situation when container A still held information about some vethX, while container B was already assigning it to itself, so when container A postHaltHook was done it removed all traces of vethX which made container B loose the network.

### Test Procedure
1. Start any container
2. Copy its network setup to some temp file i.e.
 `cp /tmp/dobby/plugin/networking/sleepy /tmp/dobby/plugin/networking/tmp_name`
3. Close original container
4. Start original container again
5. There should be a message:
` Tried to use already taken vethName 'veth0', continue looking`
and container should take next available veth instead

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)