### PR TITLE
RDKSEC-68 Added the dobby default apparmor file support in Dobby container

### DIFF
--- a/bundle/lib/include/DobbyConfig.h
+++ b/bundle/lib/include/DobbyConfig.h
@@ -142,6 +142,8 @@ protected:
     bool convertToCompliant(const ContainerId& id,
                             std::shared_ptr<rt_dobby_schema> cfg,
                             const std::string& bundlePath);
+    bool isApparmorProfileLoaded(char *profile);
+    bool setDobbyDefaultApparmorProfile(std::shared_ptr<rt_dobby_schema> cfg);
 
     struct DevNode
     {

--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -741,13 +741,9 @@ bool DobbyConfig::setDobbyDefaultApparmorProfile(std::shared_ptr<rt_dobby_schema
     if (cfg->process->apparmor_profile)
     {
         status = isApparmorProfileLoaded(cfg->process->apparmor_profile);
-        if (!status)
-        {
-            cfg->process->apparmor_profile = "dobby_default";
-            status = isApparmorProfileLoaded( cfg->process->apparmor_profile);
-        }
     }
-    else
+
+    if (!status)
     {
         cfg->process->apparmor_profile = "dobby_default";
         status = isApparmorProfileLoaded( cfg->process->apparmor_profile);

--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -687,6 +687,74 @@ bool DobbyConfig::updateBundleConfig(const ContainerId& id, std::shared_ptr<rt_d
     return true;
 }
 
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Verify and Write bundle config apparmorProfile string to a file.
+ *
+ *  @param[in]  profile  The name of apparmor profile to write to.
+ *
+ *  @return true if the apparmor profile was loaded in kernel space, otherwise false.
+ */
+
+bool DobbyConfig::isApparmorProfileLoaded(char *profile)
+{
+    FILE *fp = nullptr;
+    char line[256];
+    bool status = false;
+    char* ptr;
+    std::string str;
+
+    fp = popen("cat /sys/kernel/security/apparmor/profiles", "r");
+
+    if (fp == nullptr)
+    {
+        AI_LOG_ERROR("/sys/kernel/security/apparmor/profiles open failed");
+        return status;
+    }
+
+    while (!feof(fp))
+    {
+        fgets (line, sizeof(line), fp);
+        ptr = strchr(line,'\n');
+
+	if (ptr)
+          *ptr = '\0';
+
+        str = line;
+
+	if (str.find(profile )!= -1)
+        {
+            status = true;
+            AI_LOG_INFO("Apparmor profile [%s] is loaded",profile);
+            break;
+        }
+    }
+
+    fclose(fp);
+    return status;
+}
+
+bool DobbyConfig::setDobbyDefaultApparmorProfile(std::shared_ptr<rt_dobby_schema> cfg)
+{
+    bool status = false;
+
+    if (cfg->process->apparmor_profile)
+    {
+        status = isApparmorProfileLoaded(cfg->process->apparmor_profile);
+        if (!status)
+        {
+            cfg->process->apparmor_profile = "dobby_default";
+            status = isApparmorProfileLoaded( cfg->process->apparmor_profile);
+        }
+    }
+    else
+    {
+        cfg->process->apparmor_profile = "dobby_default";
+        status = isApparmorProfileLoaded( cfg->process->apparmor_profile);
+    }
+
+    return status;
+}
 
 // -----------------------------------------------------------------------------
 /**
@@ -708,6 +776,12 @@ bool DobbyConfig::convertToCompliant(const ContainerId& id, std::shared_ptr<rt_d
     {
         AI_LOG_ERROR_EXIT("Invalid bundle config");
         return false;
+    }
+
+    if (!setDobbyDefaultApparmorProfile(cfg))
+    {
+       cfg->process->apparmor_profile = nullptr;
+       AI_LOG_INFO("No apparmor profile is loaded");
     }
 
     // check config version and process as needed


### PR DESCRIPTION
RDKSEC-68 Added the dobby default apparmor file support in Dobby container

Reason for change:Generic dobby default apparmor profile for all applications in Dobby container (if custom apparmor profile is not present)
Test Procedure: Verify the container application process using apparmor profile.
Risks: None.

### Description
What does this PR change/fix and why?

If there is a corresponding JIRA ticket, please ensure it is in the title of the PR.

### Test Procedure
How to test this PR (if applicable)

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)