### PR TITLE
RDKTV-17862 Fixed order of ipv6 rules

### DIFF
--- a/rdkPlugins/Networking/source/Netfilter.cpp
+++ b/rdkPlugins/Networking/source/Netfilter.cpp
@@ -801,7 +801,7 @@ bool Netfilter::addRules(RuleSet &ruleSet, const int ipVersion, Operation operat
         else
         {
             // table exists, merge new rules to the end of it
-            cacheRuleSetTable->second.merge(it.second);
+            cacheRuleSetTable->second.splice(cacheRuleSetTable->second.end(), it.second);
         }
     }
 

--- a/rdkPlugins/Networking/source/NetworkSetup.cpp
+++ b/rdkPlugins/Networking/source/NetworkSetup.cpp
@@ -839,7 +839,7 @@ bool NetworkSetup::setupVeth(const std::shared_ptr<DobbyRdkPluginUtils> &utils,
             ipv4RuleSet = createDropAllRule(vethName);
         }
 
-        if (!netfilter->addRules(ipv4RuleSet, AF_INET, Netfilter::Operation::Insert))
+        if (!netfilter->addRules(ipv4RuleSet, AF_INET, Netfilter::Operation::Append))
         {
             AI_LOG_ERROR_EXIT("failed to add iptables rule to drop veth packets");
             return false;
@@ -857,7 +857,7 @@ bool NetworkSetup::setupVeth(const std::shared_ptr<DobbyRdkPluginUtils> &utils,
             ipv6RuleSet = createDropAllRule(vethName);
         }
 
-        if (!netfilter->addRules(ipv6RuleSet, AF_INET6, Netfilter::Operation::Insert))
+        if (!netfilter->addRules(ipv6RuleSet, AF_INET6, Netfilter::Operation::Append))
         {
             AI_LOG_ERROR_EXIT("failed to add iptables rule to drop veth packets");
             return false;


### PR DESCRIPTION
### Description
Previously the ICMPv6 rule was too low, making it not activated. Now the order is proper which means that communication should work fine.

Before the fix only the unicast address inside container was `REACHABLE`, as the router advertisement went from it, while all other ICMPv6 rules were dropped by the anti-spoofing rule due to them having "improper" address, By changing the the order of operations now we save all neighbor discovery frames.

### Test Procedure
1. Start container with ipv6 networking on
2. Get bash inside container `crun --root /run/rdk/crun exec --tty <container_name> /bin/bash`
3. Check IP address inside container `ifconfig`
4. From outside container try to access local type IPv6 address (starts with `fe80::`) i.e. `ping -c 1 fe80::dccf:8aff:fee1:923c`
5. From outside container check neighbor table `ip -6 neigh` container should be in `REACHABLE` state
6. From inside container check neighbor table `ip -6 neigh` host should be in `REACHABLE` state

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)