### PR TITLE
RDKTV-20457 EnvironmentVariable Plugin added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,7 @@ option(PLUGIN_HTTPPROXY "Include HttpProxy plugin" OFF)
 option(PLUGIN_APPSERVICES "Include AppServices plugin" OFF)
 option(PLUGIN_IONMEMORY "Include ION Memory plugin" OFF)
 option(PLUGIN_DEVICEMAPPER "Include DeviceMapper plugin" OFF)
+option(PLUGIN_ENVIRONMENTVARIABLE "Include EnvironmentVariable plugin" ON)
 
 
 if(PLUGIN_TESTPLUGIN)
@@ -357,6 +358,10 @@ endif()
 
 if(PLUGIN_OOMCRASH)
 	add_subdirectory(rdkPlugins/OOMCrash)
+endif()
+
+if(PLUGIN_ENVIRONMENTVARIABLE)
+	add_subdirectory(rdkPlugins/EnvironmentVariable)
 endif()
 
 # Export targets in Dobby package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,7 @@ option(PLUGIN_HTTPPROXY "Include HttpProxy plugin" OFF)
 option(PLUGIN_APPSERVICES "Include AppServices plugin" OFF)
 option(PLUGIN_IONMEMORY "Include ION Memory plugin" OFF)
 option(PLUGIN_DEVICEMAPPER "Include DeviceMapper plugin" OFF)
-option(PLUGIN_ENVIRONMENTVARIABLE "Include EnvironmentVariable plugin" ON)
+option(PLUGIN_ENVIRONMENTVARIABLE "Include EnvironmentVariable plugin" OFF)
 
 
 if(PLUGIN_TESTPLUGIN)

--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -412,6 +412,32 @@
                 }
             }
         },
+        "EnvironmentVariable": {
+            "type": "object",
+            "required": [
+                "required",
+                "data"
+            ],
+            "properties": {
+                "required": {
+                    "type": "boolean"
+                },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
+                },
+                "data": {
+                    "type": "object",
+                    "required": [
+                        "variables"
+                    ],
+                    "properties": {
+                        "variables": {
+                            "$ref": "defs.json#/definitions/ArrayOfStrings"
+                        }
+                    }
+                }
+            }
+        },
         "Minidump": {
             "type": "object",
             "required": [
@@ -664,6 +690,9 @@
                 },
                 "storage": {
                     "$ref": "#/definitions/Storage"
+                },
+                "environmentvariable": {
+                    "$ref": "#/definitions/EnvironmentVariable"
                 },
                 "minidump": {
                     "$ref": "#/definitions/Minidump"

--- a/rdkPlugins/EnvironmentVariable/CMakeLists.txt
+++ b/rdkPlugins/EnvironmentVariable/CMakeLists.txt
@@ -1,0 +1,44 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 Sky UK
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reference CMake file for the simplest Dobby RDK Plugin
+
+# Project name should match the name of the plugin
+# CMake will prefix this with "lib"
+project(EnvironmentVariablePlugin)
+
+add_library( ${PROJECT_NAME}
+        SHARED
+        source/EnvironmentVariablePlugin.cpp
+        )
+
+target_include_directories(${PROJECT_NAME}
+        PRIVATE
+        $<TARGET_PROPERTY:DobbyDaemonLib,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+install(
+        TARGETS ${PROJECT_NAME}
+        LIBRARY DESTINATION lib/plugins/dobby
+        NAMELINK_SKIP
+        )
+
+target_link_libraries(${PROJECT_NAME}
+        DobbyRdkPluginCommonLib
+)
+
+set_target_properties( ${PROJECT_NAME} PROPERTIES SOVERSION 1 )

--- a/rdkPlugins/EnvironmentVariable/README.md
+++ b/rdkPlugins/EnvironmentVariable/README.md
@@ -1,0 +1,37 @@
+# Dobby RDK Environment Variable Plugin
+
+## Quick Start
+The main task of EnvironmentVariable Plugin is to inport hosts environment variable into container. If variable exists
+during preCreation hook then its value will be copied into container. If environment variable is not present during
+preCreation hook then it will be skipped.
+
+NOTE: In case of value being changed in the host after preCreation hook, it will not be reflected inside container.
+
+Add the following section to your OCI runtime configuration `config.json` file to trigger Environment Variable plugin.
+
+```json
+{
+    "rdkPlugins": {
+        "environmentvariable": {
+            "required": false,
+            "data": {
+                "variables": [
+                    "LANG",
+                    "HOME"
+                ]
+            }
+        }
+    }
+}
+```
+
+If you already have other RDK plugins in the bundle, then just add the environmentvariable plugin. Do not create multiple `rdkPlugin` sections.
+
+## Options
+The options inside this object goes as follows:
+
+| Option              | Value                                                                                                         |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `variables`         | Variable which should be copied from host into container                                                        |
+
+

--- a/rdkPlugins/EnvironmentVariable/source/EnvironmentVariablePlugin.cpp
+++ b/rdkPlugins/EnvironmentVariable/source/EnvironmentVariablePlugin.cpp
@@ -1,0 +1,121 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2020 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "EnvironmentVariablePlugin.h"
+
+/**
+ * Need to do this at the start of every plugin to make sure the correct
+ * C methods are visible to allow PluginLauncher to find the plugin
+ */
+REGISTER_RDK_PLUGIN(EnvironmentVariablePlugin);
+
+/**
+ * @brief Constructor - called when plugin is loaded by PluginLauncher
+ *
+ * Do not change the parameters for this constructor - must match C methods
+ * created by REGISTER_RDK_PLUGIN macro
+ *
+ * Note plugin name is not case sensitive
+ */
+EnvironmentVariablePlugin::EnvironmentVariablePlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
+                                                    const std::shared_ptr<DobbyRdkPluginUtils> &utils,
+                                                    const std::string &rootfsPath)
+    : mName("EnvironmentVariable"),
+      mContainerConfig(containerConfig),
+      mRootfsPath(rootfsPath),
+      mUtils(utils)
+{
+    AI_LOG_FN_ENTRY();
+
+    AI_LOG_FN_EXIT();
+}
+
+/**
+ * @brief Set the bit flags for which hooks we're going to use
+ *
+ * This plugin uses all the hooks so set all the flags
+ */
+unsigned EnvironmentVariablePlugin::hookHints() const
+{
+    return (
+        IDobbyRdkPlugin::HintFlags::PreCreationFlag);
+}
+
+// Begin Hook Methods
+
+/**
+ * @brief Dobby Hook - run in host namespace before container creation process
+ */
+bool EnvironmentVariablePlugin::preCreation()
+{
+    if (!mContainerConfig)
+    {
+        AI_LOG_WARN("Container config is null");
+        return false;
+    }
+
+    std::vector<std::string> variables_list;
+    for (size_t i = 0; i < mContainerConfig->rdk_plugins->environmentvariable->data->variables_len; i++)
+    {
+        variables_list.push_back(std::string(mContainerConfig->rdk_plugins->environmentvariable->data->variables[i]));
+    }
+
+    for (std::string item : variables_list)
+    {
+        AI_LOG_DEBUG("Expecting variable '%s'", item.c_str());
+        const char* value = getenv(item.c_str());
+        if (value)
+        {
+            std::string fullVariable = item + "=" + std::string(value);
+            AI_LOG_DEBUG("Adding environment variable '%s'", fullVariable.c_str());
+
+            mUtils->addEnvironmentVar(fullVariable);
+        }
+        else
+        {
+            AI_LOG_DEBUG("Variable '%s' not found", item.c_str());
+        }
+    }
+    return true;
+}
+
+// End hook methods
+
+/**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> EnvironmentVariablePlugin::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+    const rt_defs_plugins_environment_variable* pluginConfig = mContainerConfig->rdk_plugins->environmentvariable;
+
+    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    {
+        dependencies.push_back(pluginConfig->depends_on[i]);
+    }
+
+    return dependencies;
+}
+
+// Begin private methods

--- a/rdkPlugins/EnvironmentVariable/source/EnvironmentVariablePlugin.h
+++ b/rdkPlugins/EnvironmentVariable/source/EnvironmentVariablePlugin.h
@@ -1,0 +1,74 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2020 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File: EnvironmentVariablePlugin.h
+ *
+ */
+#ifndef ENVIRONMENTVARIABLEPLUGIN_H
+#define ENVIRONMENTVARIABLEPLUGIN_H
+
+#include <RdkPluginBase.h>
+
+#include <sys/types.h>
+#include <netinet/in.h>
+
+#include <unistd.h>
+#include <string>
+#include <memory>
+
+/**
+ * @brief Simple Dobby RDK Plugin
+ *
+ * Implements all hook points to print a simple statement showing the hook has been
+ * called successfully.
+ *
+ * Can be used as a reference implementation for future plugins
+ */
+class EnvironmentVariablePlugin : public RdkPluginBase
+{
+public:
+    EnvironmentVariablePlugin(std::shared_ptr<rt_dobby_schema>& containerConfig,
+                            const std::shared_ptr<DobbyRdkPluginUtils> &utils,
+                            const std::string &rootfsPath);
+
+public:
+    inline std::string name() const override
+    {
+        return mName;
+    };
+
+    // Override to return the appropriate hints for what we implement
+    unsigned hookHints() const override;
+
+    // This test hook implements preCreation hook only
+public:
+
+    bool preCreation() override;
+
+public:
+    std::vector<std::string> getDependencies() const override;
+
+private:
+    const std::string mName;
+    std::shared_ptr<rt_dobby_schema> mContainerConfig;
+    const std::string mRootfsPath;
+    const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
+};
+
+#endif // !defined(ENVIRONMENTVARIABLEPLUGIN_H)


### PR DESCRIPTION
### Description
We need to be able to add environment variable from host into container. This plugin provides said functionality.

### Test Procedure

1.  Add Environment Variable into the container config i.e.
```
        "environmentvariable": {
            "required": false,
            "data": {
                "variables": [
                    "LANG",
                    "HOME"
                ]
            }
        }
```
2. Start container i.e. `DobbyTool start sleepy ./sleepy_bundle`
3. Open sh inside container `crun --root /run/rdk/crun exec --tty <container_name> /bin/bash`
4. Check if environment variables are set `env`

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)