### PR TITLE
RDKTV-20651 Added new drop all rule for none network

### DIFF
--- a/rdkPlugins/Networking/source/NetworkSetup.cpp
+++ b/rdkPlugins/Networking/source/NetworkSetup.cpp
@@ -334,8 +334,6 @@ Netfilter::RuleSet createDropAllRule(const std::string &vethName)
     rules.emplace_back(std::string(filterRule));
     memset(filterRule, 0, sizeof(filterRule));
 
-    AI_LOG_ERROR("Koczek inside");
-
     // return the rule in the default filter table
     return Netfilter::RuleSet {{ Netfilter::TableType::Filter, rules}};
 }


### PR DESCRIPTION

### Description
When "none" is selected as network mode, there should be no outgoing network connection. Previously connection was established now it is not.

### Test Procedure
1. Create container with network "none"
2. Start container i.e. `DobbyTool start sleepy ./sleepy_bundle`
3. Open sh inside container `crun --root /run/rdk/crun exec --tty <container_name> /bin/bash`
4. Change directory to /tmp `cd /tmp` (otherwise you will get read-only filesystem warning in next step)
5. Try to get resource (without DNS) `wget 185.157.233.196`

Without this fix the wget was successful, now it will be failed.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)