### PR TITLE
RDKTV-20457: Added setTZ param to localTime plugin

### DIFF
--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -453,7 +453,11 @@
                 },
                 "data": {
                     "type": "object",
-                    "properties": {}
+                    "properties": {
+                        "setTZ" : {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/rdkPlugins/LocalTime/README.md
+++ b/rdkPlugins/LocalTime/README.md
@@ -8,16 +8,20 @@ Add the following section to your OCI runtime configuration `config.json` file t
     "rdkPlugins": {
         "localtime": {
             "required": true,
-            "data": {}
+            "data": {
+                "setTZ": "<path>"
+            }
         }
     }
 }
 ```
-
-**Note:** This plugin takes no data, so the `data` field should be left empty.
 
 If you already have other RDK plugins in the bundle, then just add the localtime plugin. Do not create multiple `rdkPlugin` sections.
 
 ## Prerequisites
 
 `/etc/localtime` symlink must be available and point to the correct file based on locale.
+
+## Options
+### setTZ
+Optional parameter, if set it should contain a path to file holding time stamp. This time stamp will be placed in containers env variable called TZ

--- a/rdkPlugins/LocalTime/source/LocalTimePlugin.h
+++ b/rdkPlugins/LocalTime/source/LocalTimePlugin.h
@@ -46,6 +46,7 @@ public:
 
 public:
     bool postInstallation() override;
+    bool preCreation() override;
 
 public:
     std::vector<std::string> getDependencies() const override;
@@ -54,6 +55,7 @@ private:
     const std::string mName;
     const std::string mRootfsPath;
     std::shared_ptr<rt_dobby_schema> mContainerConfig;
+    const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
 };
 
 #endif // !defined(LOCALTIMEPLUGIN_H)


### PR DESCRIPTION
### Description
Added setTZ param to localTime plugin

### Test Procedure
Set setTZ param in localTime plugin of sleepy container, check logs if Dobby reads it

### Type of Change
- [x] New feature (non-breaking change which adds functionality)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)