### PR TITLE
RDKTV-20593 Closing the file 

### DIFF
--- a/bundle/lib/source/DobbyBundleConfig.cpp
+++ b/bundle/lib/source/DobbyBundleConfig.cpp
@@ -74,6 +74,9 @@ DobbyBundleConfig::DobbyBundleConfig(const std::shared_ptr<IDobbyUtils>& utils,
             std::ofstream dst(bundlePath + "/config.json", std::ios::binary);
             dst << src.rdbuf();
 
+            //close the file else on further operations on the file, the size of the file equals 32764 even if it is greater than 32764.
+            dst.close();
+
             // we need to re-run post installation hook, so remove success flag
             std::string postInstallPath = bundlePath + "/postinstallhooksuccess";
             remove(postInstallPath.c_str());
@@ -241,7 +244,7 @@ bool DobbyBundleConfig::parseOCIConfig(const std::string& bundlePath)
         return false;
     }
     bundleConfigFs.seekg(0, std::ifstream::end);
-    ssize_t length = bundleConfigFs.tellg();
+    uint32_t length = bundleConfigFs.tellg();
     bundleConfigFs.seekg(0, std::ifstream::beg);
     char* buffer = new char[length];
     bundleConfigFs.read(buffer, length);


### PR DESCRIPTION
### Description
Closing the file after file operations to avoid odd behavior and increased the size of length variable for storing larger values.

### Test Procedure
1. Open the config file and delete some lines `vi /opt/persistent/rdkservices/ResidentApp/Container/config.json`
2. Reboot.
3. Verify corrupted file is fixed and the deleted lines are auto populated.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)