### PR TITLE
RDKTV-21075 : Fixed dynamic mount issue 

### DIFF
--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -129,9 +129,56 @@ bool DynamicMountDetails::onCreateContainer() const
     AI_LOG_FN_ENTRY();
 
     bool success = false;
+    std::string targetPath = mRootfsPath + mMountProperties.destination;
+    std::string dirPath; 
+
     struct stat buffer;
     if (stat(mMountProperties.source.c_str(), &buffer) == 0)
     {
+        bool isDir = S_ISDIR(buffer.st_mode);
+        // Determine path based on whether source is a directory or file
+        if (isDir)
+        {
+            dirPath = targetPath;
+        }
+        else
+        {
+            // Mounting a file so exclude filename from directory path
+            std::size_t found = targetPath.find_last_of("/");
+            dirPath = targetPath.substr(0, found);
+        }
+
+        // Recursively create destination directory structure
+        if (mUtils->mkdirRecursive(dirPath, 0755) || (errno == EEXIST))
+        {
+            if (isDir)
+            {
+                success = true;
+            }
+            else
+            {
+                // If mounting a file, make sure a file with the same name
+                // exists at the desination path prior to bind mounting.
+                // Otherwise the bind mount may fail if the destination path
+                // filesystem is read-only.
+                // Creating the file first ensures an inode exists for the
+                // bind mount to target.
+                int fd = open(targetPath.c_str(), O_RDONLY | O_CREAT, 0644);
+                if ((fd == 0) || (errno == EEXIST))
+                {
+                    close(fd);
+                    success = true;
+                }
+                else
+                {
+                    AI_LOG_SYS_ERROR(errno, "failed to open or create destination '%s'", targetPath.c_str());
+                }
+            }
+        }
+        else
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to create mount destination path '%s' in storage plugin", targetPath.c_str());
+        }
         success = addMount();
     }
     else

--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -130,54 +130,57 @@ bool DynamicMountDetails::onCreateContainer() const
 
     bool success = false;
     std::string targetPath = mRootfsPath + mMountProperties.destination;
-    std::string dirPath; 
 
     struct stat buffer;
     if (stat(mMountProperties.source.c_str(), &buffer) == 0)
     {
         bool isDir = S_ISDIR(buffer.st_mode);
-        // Determine path based on whether source is a directory or file
-        if (isDir)
+        if (stat(targetPath.c_str(), &buffer) != 0)
         {
-            dirPath = targetPath;
-        }
-        else
-        {
-            // Mounting a file so exclude filename from directory path
-            std::size_t found = targetPath.find_last_of("/");
-            dirPath = targetPath.substr(0, found);
-        }
-
-        // Recursively create destination directory structure
-        if (mUtils->mkdirRecursive(dirPath, 0755) || (errno == EEXIST))
-        {
+            std::string dirPath; 
+            // Determine path based on whether target is a directory or file
             if (isDir)
             {
-                success = true;
+                dirPath = targetPath;
             }
             else
             {
-                // If mounting a file, make sure a file with the same name
-                // exists at the desination path prior to bind mounting.
-                // Otherwise the bind mount may fail if the destination path
-                // filesystem is read-only.
-                // Creating the file first ensures an inode exists for the
-                // bind mount to target.
-                int fd = open(targetPath.c_str(), O_RDONLY | O_CREAT, 0644);
-                if ((fd == 0) || (errno == EEXIST))
+                // Mounting a file so exclude filename from directory path
+                std::size_t found = targetPath.find_last_of("/");
+                dirPath = targetPath.substr(0, found);
+            }
+
+            // Recursively create destination directory structure
+            if (mUtils->mkdirRecursive(dirPath, 0755) || (errno == EEXIST))
+            {
+                if (isDir)
                 {
-                    close(fd);
                     success = true;
                 }
                 else
                 {
-                    AI_LOG_SYS_ERROR(errno, "failed to open or create destination '%s'", targetPath.c_str());
+                    // If mounting a file, make sure a file with the same name
+                    // exists at the desination path prior to bind mounting.
+                    // Otherwise the bind mount may fail if the destination path
+                    // filesystem is read-only.
+                    // Creating the file first ensures an inode exists for the
+                    // bind mount to target.
+                    int fd = open(targetPath.c_str(), O_RDONLY | O_CREAT, 0644);
+                    if ((fd == 0) || (errno == EEXIST))
+                    {
+                        close(fd);
+                        success = true;
+                    }
+                    else
+                    {
+                        AI_LOG_SYS_ERROR(errno, "failed to open or create destination '%s'", targetPath.c_str());
+                    }
                 }
             }
-        }
-        else
-        {
-            AI_LOG_SYS_ERROR(errno, "failed to create mount destination path '%s' in storage plugin", targetPath.c_str());
+            else
+            {
+                AI_LOG_SYS_ERROR(errno, "failed to create mount destination path '%s' in storage plugin", targetPath.c_str());
+            }
         }
         success = addMount();
     }


### PR DESCRIPTION
### Description
Previously we were not checking whether the destination path exists or not in the createContainer hook and the addMount() was called, which eventually fails to add the dynamic mount when the destination path is not present.

Fixed this issue by checking whether destination path already exists, if not then create it and the mount is added.

### Test Procedure
How to test this PR (if applicable)

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)