### PR TITLE
ONEM-29861 Some DAC apps do not start: fix container state read

### DIFF
--- a/pluginLauncher/tool/source/Main.cpp
+++ b/pluginLauncher/tool/source/Main.cpp
@@ -175,10 +175,10 @@ std::shared_ptr<const rt_state_schema> getContainerState()
     std::mutex lock;
     std::lock_guard<std::mutex> locker(lock);
 
-    char buf[1000];
+    char buf[4096];
     bzero(buf, sizeof(buf));
 
-    if (read(STDIN_FILENO, buf, sizeof(buf)) < 0)
+    if (read(STDIN_FILENO, buf, sizeof(buf)-1) < 0)
     {
         AI_LOG_SYS_ERROR(errno, "failed to read stdin");
         return nullptr;
@@ -204,6 +204,10 @@ std::shared_ptr<const rt_state_schema> getContainerState()
 
     if (state.get() == nullptr || err)
     {
+        if (hookStdin.length() == sizeof(buf)-1)
+        {
+            AI_LOG_ERROR("Most probably the read buffer is too small and causes the parse error below!");
+        }
         AI_LOG_ERROR_EXIT("Failed to parse container state, err '%s'", err);
         return nullptr;
     }


### PR DESCRIPTION
Status was read into too small buffer and so parsing failed. Made bigger buffer and added logging to indicate better error for future "too small" buffer.

### Description
Problem happened with container that has several extra annotations. They seem to be returned with reading container state and the while state was > 1000 bytes.

### Test Procedure
Fix can be verified with a container with extra annotations

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

### Requires Bitbake Recipe changes?
- only SRCREV