### PR TITLE
 RDK-41482 : make localtime symlink path configurable

### DIFF
--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -456,7 +456,10 @@
                     "properties": {
                         "setTZ" : {
                             "type": "string"
-                        }
+                        },
+                       "path" : {
+                               "type": "string"
+                       }
                     }
                 }
             }

--- a/rdkPlugins/LocalTime/README.md
+++ b/rdkPlugins/LocalTime/README.md
@@ -1,7 +1,7 @@
 # Dobby RDK LocalTime Plugin
 
 ## Quick Start
-Add the following section to your OCI runtime configuration `config.json` file to automatically symlink the real `/etc/localtime` file to the container's rootfs at `/etc/localtime`.
+Add the following section to your OCI runtime configuration `config.json` file to automatically symlink the mentioned path to the container's rootfs.
 
 ```json
 {
@@ -9,6 +9,7 @@ Add the following section to your OCI runtime configuration `config.json` file t
         "localtime": {
             "required": true,
             "data": {
+                "path": "<path>",
                 "setTZ": "<path>"
             }
         }
@@ -20,8 +21,11 @@ If you already have other RDK plugins in the bundle, then just add the localtime
 
 ## Prerequisites
 
-`/etc/localtime` symlink must be available and point to the correct file based on locale.
+File mentioned in the path must be available and point to the correct file based on locale.
 
 ## Options
+### path
+localtime symlink path should be set.
+
 ### setTZ
 Optional parameter, if set it should contain a path to file holding time stamp. This time stamp will be placed in containers env variable called TZ

--- a/rdkPlugins/LocalTime/README.md
+++ b/rdkPlugins/LocalTime/README.md
@@ -19,13 +19,9 @@ Add the following section to your OCI runtime configuration `config.json` file t
 
 If you already have other RDK plugins in the bundle, then just add the localtime plugin. Do not create multiple `rdkPlugin` sections.
 
-## Prerequisites
-
-File mentioned in the path must be available and point to the correct file based on locale.
-
 ## Options
 ### path
-localtime symlink path should be set.
+Optional parameter, if set, localtime symlink path should be set, else the default path `etc/localtime` is set.
 
 ### setTZ
 Optional parameter, if set it should contain a path to file holding time stamp. This time stamp will be placed in containers env variable called TZ

--- a/rdkPlugins/LocalTime/source/LocalTimePlugin.cpp
+++ b/rdkPlugins/LocalTime/source/LocalTimePlugin.cpp
@@ -59,6 +59,15 @@ bool LocalTimePlugin::postInstallation()
     AI_LOG_FN_ENTRY();
 
     const char* path = mContainerConfig->rdk_plugins->localtime->data->path;
+    if (path)
+    {
+        AI_LOG_INFO("Set localtime path %s",path);
+    }
+    else
+    {
+        path = "/etc/localtime";
+        AI_LOG_INFO("Set default path %s", path);
+    }
 
     // get the real path to the correct local time zone
     char pathBuf[PATH_MAX];

--- a/rdkPlugins/LocalTime/source/LocalTimePlugin.cpp
+++ b/rdkPlugins/LocalTime/source/LocalTimePlugin.cpp
@@ -58,17 +58,19 @@ bool LocalTimePlugin::postInstallation()
 {
     AI_LOG_FN_ENTRY();
 
+    const char* path = mContainerConfig->rdk_plugins->localtime->data->path;
+
     // get the real path to the correct local time zone
     char pathBuf[PATH_MAX];
-    ssize_t len = readlink("/etc/localtime", pathBuf, sizeof(pathBuf));
+    ssize_t len = readlink(path, pathBuf, sizeof(pathBuf));
     if (len <= 0)
     {
-        AI_LOG_SYS_ERROR_EXIT(errno, "readlink failed on '/etc/localtime'");
+        AI_LOG_SYS_ERROR_EXIT(errno, "readlink failed on %s", path);
         return false;
     }
 
     const std::string localtimeInHost(pathBuf, len);
-    const std::string localtimeInContainer = mRootfsPath + "/etc/localtime";
+    const std::string localtimeInContainer = mRootfsPath + path;
 
     if (localtimeInHost.empty())
     {
@@ -77,7 +79,7 @@ bool LocalTimePlugin::postInstallation()
     }
     else if (symlink(localtimeInHost.c_str(), localtimeInContainer.c_str()) < 0)
     {
-        AI_LOG_SYS_ERROR_EXIT(errno, "failed to create /etc/localtime symlink");
+        AI_LOG_SYS_ERROR_EXIT(errno, "failed to create %s symlink", path);
         return false;
     }
 


### PR DESCRIPTION
### Description
Added path param to localTime plugin

### Test Procedure
Set path param in localTime plugin and check in the config.json whether the path is correctly set

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)