### PR TITLE
Remove data field as required from localtime

### DIFF
--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -441,8 +441,7 @@
         "LocalTime": {
             "type": "object",
             "required": [
-                "required",
-                "data"
+                "required"
             ],
             "properties": {
                 "required": {


### PR DESCRIPTION
### Description
Since data fields(path and setTZ) in localtime are optional, it is removed from the required field

### Test Procedure
Check whether data fields in localtime are used whenever they are set, else no error should be seen if no data is provided

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)