### PR TITLE
Added possibility to specify extra mounts in dobby config

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -677,6 +677,21 @@ bool DobbyManager::customiseConfig(const std::shared_ptr<DobbyConfig> &config,
         changesMade = true;
     }
 
+    // Add the extra mounts
+    const std::list<IDobbySettings::ExtraMount>& extraMounts = mSettings->extraMounts();
+    if (!extraMounts.empty())
+    {
+        for (const auto& mount : extraMounts)
+        {
+            std::list<std::string> flags;
+            std::copy(mount.flags.begin(), mount.flags.end(), std::back_inserter(flags));
+
+            config->addMount(mount.source, mount.target, mount.type, 0, flags);
+            AI_LOG_ERROR("Added extra mount src: '%s', target: '%s', type: '%s'", mount.source.c_str(), mount.target.c_str(), mount.type.c_str());
+        }
+        changesMade = true;
+    }
+
     AI_LOG_FN_EXIT();
     return changesMade;
 }

--- a/settings/include/IDobbySettings.h
+++ b/settings/include/IDobbySettings.h
@@ -113,6 +113,14 @@ public:
 
     // -------------------------------------------------------------------------
     /**
+     *  @brief A list of extra mounts that will be set for all
+     *  containers.
+     *
+     */
+    virtual std::list<ExtraMount> extraMounts() const = 0;
+
+    // -------------------------------------------------------------------------
+    /**
      *  Describes the details of anything extra needed to enable access to
      *  certain hardware blocks, like the GPU or VPU.
      *

--- a/settings/include/Settings.h
+++ b/settings/include/Settings.h
@@ -64,6 +64,7 @@ public:
     std::string consoleSocketPath() const override;
 
     std::map<std::string, std::string> extraEnvVariables() const override;
+    std::list<ExtraMount> extraMounts() const override;
 
 public:
     std::shared_ptr<HardwareAccessSettings> gpuAccessSettings() const override;
@@ -116,6 +117,7 @@ private:
     std::string mConsoleSocketPath;
 
     std::map<std::string, std::string> mExtraEnvVars;
+    std::list<ExtraMount> mExtraMounts;
 
     std::shared_ptr<HardwareAccessSettings> mGpuHardwareAccess;
     std::shared_ptr<HardwareAccessSettings> mVpuHardwareAccess;

--- a/settings/include/Settings.h
+++ b/settings/include/Settings.h
@@ -110,6 +110,8 @@ private:
 
     void dumpHardwareAccess(int aiLogLevel, const std::string& name,
                             const std::shared_ptr<const HardwareAccessSettings>& hwAccess) const;
+    void dumpExtraMounts(int aiLogLevel, const std::string& path,
+                         const std::list<ExtraMount>& extraMouts) const;
 
 private:
     std::string mWorkspaceDir;

--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -152,6 +152,12 @@ Settings::Settings(const Json::Value& settings)
             getEnvVarsFromJson(settings, Json::Path(".extraEnvVariables"));
     }
 
+    // process the extra mounts
+    {
+        mExtraMounts =
+            getExtraMounts(settings, Json::Path(".extraMounts"));
+    }
+
     // process the gpu settings
     {
         mGpuHardwareAccess =
@@ -357,6 +363,16 @@ std::map<std::string, std::string> Settings::extraEnvVariables() const
  *  @brief
  *
  */
+std::list<IDobbySettings::ExtraMount> Settings::extraMounts() const
+{
+    return mExtraMounts;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief
+ *
+ */
 std::shared_ptr<IDobbySettings::HardwareAccessSettings> Settings::gpuAccessSettings() const
 {
     return mGpuHardwareAccess;
@@ -452,6 +468,13 @@ void Settings::dump(int aiLogLevel) const
     {
         __AI_LOG_PRINTF(aiLogLevel, "settings.extraEnvVariables[%u]='%s=%s'",
                         i++, envVar.first.c_str(), envVar.second.c_str());
+    }
+
+    i = 0;
+    for (const auto& mount : mExtraMounts)
+    {
+        __AI_LOG_PRINTF(aiLogLevel, "settings.extraMounts[%u]={src:'%s', target:'%s', type:'%s'}",
+                        i++, mount.source.c_str(), mount.target.c_str(), mount.type.c_str());
     }
 
     i = 0;
@@ -843,7 +866,7 @@ std::list<Settings::ExtraMount> Settings::getExtraMounts(const Json::Value& root
         // verify the value in an array is a string
         if (!extraMount.isObject())
         {
-            AI_LOG_ERROR("invalid JSON value in extra gpu mount var array in settings file");
+            AI_LOG_ERROR("invalid JSON value in extra mounts var array in settings file");
             return std::list<ExtraMount>();
         }
 

--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -470,12 +470,7 @@ void Settings::dump(int aiLogLevel) const
                         i++, envVar.first.c_str(), envVar.second.c_str());
     }
 
-    i = 0;
-    for (const auto& mount : mExtraMounts)
-    {
-        __AI_LOG_PRINTF(aiLogLevel, "settings.extraMounts[%u]={src:'%s', target:'%s', type:'%s'}",
-                        i++, mount.source.c_str(), mount.target.c_str(), mount.type.c_str());
-    }
+    dumpExtraMounts(aiLogLevel, "settings.extraMounts", mExtraMounts);
 
     i = 0;
     for (const auto& extIface : mExternalInterfaces)
@@ -487,6 +482,30 @@ void Settings::dump(int aiLogLevel) const
     dumpHardwareAccess(aiLogLevel, "gpu", mGpuHardwareAccess);
     dumpHardwareAccess(aiLogLevel, "vpu", mVpuHardwareAccess);
 }
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Debugging function to dump extra mounts.
+ *
+ *
+ */
+void Settings::dumpExtraMounts(int aiLogLevel, const std::string& path,
+                     const std::list<ExtraMount>& extraMounts) const
+{
+    int i = 0;
+    for (const auto& extraMount : extraMounts)
+    {
+        std::ostringstream flags;
+        for (const std::string& flag : extraMount.flags)
+            flags << flag << ", ";
+
+        __AI_LOG_PRINTF(aiLogLevel, "%s[%u]={ src='%s' dst='%s' type='%s' flags=[%s] }",
+                        path.c_str(), i++,
+                        extraMount.source.c_str(), extraMount.target.c_str(),
+                        extraMount.type.c_str(), flags.str().c_str());
+    }
+}
+
 
 // -----------------------------------------------------------------------------
 /**
@@ -511,18 +530,7 @@ void Settings::dumpHardwareAccess(int aiLogLevel, const std::string& name,
                         name.c_str(), i++, devNode.c_str());
     }
 
-    i = 0;
-    for (const auto& extraMount : hwAccess->extraMounts)
-    {
-        std::ostringstream flags;
-        for (const std::string& flag : extraMount.flags)
-            flags << flag << ", ";
-
-        __AI_LOG_PRINTF(aiLogLevel, "settings.%s.extraMounts[%u]={ src='%s' dst='%s' type='%s' flags=[%s] }",
-                        name.c_str(), i++,
-                        extraMount.source.c_str(), extraMount.target.c_str(),
-                        extraMount.type.c_str(), flags.str().c_str());
-    }
+    dumpExtraMounts(aiLogLevel, "settings." + name + ".extraMounts", hwAccess->extraMounts);
 
     i = 0;
     for (const auto& envVar : hwAccess->extraEnvVariables)


### PR DESCRIPTION
### Description
Added possibility to specify extra mounts in dobby config.

### Test Procedure
Add to dobby.json
    "extraMounts": [
      {
          "source": "/tmp/communicator",
          "destination": "/tmp/communicator",
          "type": "bind",
          "options": [ "bind", "nosuid", "nodev", "noexec"  ]
      }
    ],
Check in logs if it was parsed correctly and mount was added every container.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)