### PR TITLE
LLAMA-11078: Ensure logging plugin is correctly enabled

### DIFF
--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -991,6 +991,15 @@ bool DobbySpecConfig::processConsole(const Json::Value& value,
     if (value.isNull())
     {
         mConsoleDisabled = true;
+
+        // Even though console is disabled, we must still add the logging plugin so that
+        // the container ptty is configured correctly and there is something on the receiving
+        // end to drain it
+        Json::Value rdkPluginData;
+        rdkPluginData["sink"] = "devnull";
+        mRdkPluginsJson[RDK_LOGGING_PLUGIN_NAME]["data"] = rdkPluginData;
+        mRdkPluginsJson[RDK_LOGGING_PLUGIN_NAME]["required"] = false;
+
         return true;
     }
 
@@ -1003,7 +1012,19 @@ bool DobbySpecConfig::processConsole(const Json::Value& value,
     const Json::Value& path = value["path"];
     if (path.isNull())
     {
+        AI_LOG_WARN("Console option set but no path provided - cannot enable console redirection");
+
         mConsoleDisabled = true;
+
+        // Even though console is disabled, we must still add the logging plugin so that
+        // the container ptty is configured correctly and there is something on the receiving
+        // end to drain it
+        Json::Value rdkPluginData;
+        rdkPluginData["sink"] = "devnull";
+        mRdkPluginsJson[RDK_LOGGING_PLUGIN_NAME]["data"] = rdkPluginData;
+        mRdkPluginsJson[RDK_LOGGING_PLUGIN_NAME]["required"] = false;
+
+        return true;
     }
     else if (path.isString())
     {

--- a/rdkPlugins/Logging/source/NullSink.cpp
+++ b/rdkPlugins/Logging/source/NullSink.cpp
@@ -52,7 +52,7 @@ NullSink::~NullSink()
     {
         if (close(mDevNullFd) < 0)
         {
-            AI_LOG_SYS_ERROR(errno, "Failed to close journald stream");
+            AI_LOG_SYS_ERROR(errno, "Failed to close /dev/null stream");
         }
     }
 }
@@ -105,7 +105,7 @@ void NullSink::process(const std::shared_ptr<AICommon::IPollLoop> &pollLoop, epo
 
             if (write(mDevNullFd, mBuf, ret) < 0)
             {
-                AI_LOG_SYS_ERROR(errno, "Write to journald stream failed");
+                AI_LOG_SYS_ERROR(errno, "Write to /dev/null stream failed");
             }
         }
 


### PR DESCRIPTION
### Description
When setting console to null in the Dobby spec, we should still enable the logging plugin. Without it, the container stdout/err fds are not drained and just fill up forever - leading to memory increase over time.

### Test Procedure
Create a container using a Dobby spec with the console field set to `null`.

Ensure that from the perspective of the container, the stdout/err fds are connected to a ptty instead of a memfd.
```
bash-5.1# ls -alh /proc/1/fd
total 0
dr-x------ 2 root root  0 Jun 13 09:11 .
dr-xr-xr-x 9 root root  0 Jun 13 09:11 ..
lrwx------ 1 root root 64 Jun 13 09:11 0 -> /dev/pts/0
lrwx------ 1 root root 64 Jun 13 09:11 1 -> /dev/pts/0
lrwx------ 1 root root 64 Jun 13 09:11 2 -> /dev/pts/0
```

Ensure container memory does not increase over time as log messages are generated. Ensure no log file is created for the container.

Ensure the behaviour when a container has a console file configured is unchanged.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)