### PR TITLE
Run container with strace

### DIFF
--- a/bundle/lib/include/DobbyConfig.h
+++ b/bundle/lib/include/DobbyConfig.h
@@ -129,6 +129,8 @@ public:
 
     const std::string configJson() const;
 
+    void printCommand() const;
+    bool enableSTrace(const std::string& logsDir);
 
 // protected methods for derived classes to use
 protected:

--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -313,6 +313,10 @@ bool DobbyConfig::changeProcessArgs(const std::string& command)
     return true;
 }
 
+// -----------------------------------------------------------------------------
+/**
+ *  Prints startup command for the container.
+ */
 void DobbyConfig::printCommand() const
 {
     std::shared_ptr<rt_dobby_schema> cfg = config();
@@ -332,6 +336,14 @@ void DobbyConfig::printCommand() const
     AI_LOG_DEBUG("%s", ss.str().c_str());
 }
 
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Enables strace for the container
+ *
+ *  @param[in]  logsDir      Directory to which strace logs will be written
+ *
+ *  @return true if strace was sucessfully enabled for the container, otherwise false.
+ */
 bool DobbyConfig::enableSTrace(const std::string& logsDir)
 {
     AI_LOG_FN_ENTRY();
@@ -367,6 +379,7 @@ bool DobbyConfig::enableSTrace(const std::string& logsDir)
             new_args[new_args_len - 1 - i] = new_args[cfg->process->args_len - 1 - i];
         }
 
+        // copy the new params at the start of new args list
         for (size_t i = 0; i < params.size(); ++i)
         {
             new_args[i] = strdup(params[i].c_str());

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -677,6 +677,12 @@ bool DobbyManager::customiseConfig(const std::shared_ptr<DobbyConfig> &config,
         changesMade = true;
     }
 
+    if (shouldEnableSTrace(config))
+    {
+        config->enableSTrace(mSettings->straceSettings().logsDir);
+        changesMade = true;
+    }
+
     AI_LOG_FN_EXIT();
     return changesMade;
 }
@@ -2623,4 +2629,16 @@ bool DobbyManager::invalidContainerCleanupTask()
 
     AI_LOG_FN_EXIT();
     return true;
+}
+
+bool DobbyManager::shouldEnableSTrace(const std::shared_ptr<DobbyConfig> &config) const
+{
+    std::shared_ptr<rt_dobby_schema> containerConfig(config->config());
+    if (containerConfig == nullptr)
+        return false;
+
+    const std::string hostName{containerConfig->hostname};
+    const std::vector<std::string> apps = mSettings->straceSettings().apps;
+
+    return std::find(apps.begin(), apps.end(), hostName) != apps.end();
 }

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -2638,7 +2638,7 @@ bool DobbyManager::shouldEnableSTrace(const std::shared_ptr<DobbyConfig> &config
         return false;
 
     const std::string hostName{containerConfig->hostname};
-    const std::vector<std::string> apps = mSettings->straceSettings().apps;
+    const std::vector<std::string>& apps = mSettings->straceSettings().apps;
 
     return std::find(apps.begin(), apps.end(), hostName) != apps.end();
 }

--- a/daemon/lib/source/DobbyManager.h
+++ b/daemon/lib/source/DobbyManager.h
@@ -200,6 +200,8 @@ private:
 
     bool invalidContainerCleanupTask();
 
+    bool shouldEnableSTrace(const std::shared_ptr<DobbyConfig> &config) const;
+
 private:
     const std::shared_ptr<IDobbyEnv> mEnvironment;
     const std::shared_ptr<IDobbyUtils> mUtilities;

--- a/settings/include/IDobbySettings.h
+++ b/settings/include/IDobbySettings.h
@@ -208,6 +208,24 @@ public:
 
     virtual LogRelaySettings logRelaySettings() const = 0;
 
+    // -------------------------------------------------------------------------
+    /**
+     *  Settings needed for running an app with strace
+     *
+     *      - logsDir
+     *          Path to directory where strace logs will be written
+     *      - apps
+     *          A list of app names that should be run with strace.
+     *          Hostname field from containers config is used as app name.
+     *
+     */
+    struct StraceSettings
+    {
+        std::string logsDir;
+        std::vector<std::string> apps;
+    };
+
+    virtual StraceSettings straceSettings() const = 0;
 };
 
 #endif // !defined(IDOBBYSETTINGS_H)

--- a/settings/include/Settings.h
+++ b/settings/include/Settings.h
@@ -78,6 +78,8 @@ public:
 
     LogRelaySettings logRelaySettings() const override;
 
+    StraceSettings straceSettings() const override;
+
     void dump(int aiLogLevel = -1) const;
 
 private:
@@ -127,6 +129,7 @@ private:
     Json::Value mRdkPluginsData;
 
     LogRelaySettings mLogRelaySettings;
+    StraceSettings mStraceSettings;
 };
 
 #endif // !defined(SETTINGS_H)

--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -232,7 +232,7 @@ Settings::Settings(const Json::Value& settings)
                     else if(pluginName.isObject())
                     {
                         for (const auto& value : pluginName.getMemberNames())
-			{
+			            {
                             mDefaultPlugins.push_back(value);
                             mRdkPluginsData[value] = pluginName[value];
                         }
@@ -292,6 +292,60 @@ Settings::Settings(const Json::Value& settings)
         }
     }
 
+    // Process strace settings
+    {
+        Json::Value straceSettings = Json::Path(".strace").resolve(settings);
+        if (!straceSettings.isNull())
+        {
+            if (straceSettings.isObject())
+            {
+                const Json::Value logsDir = straceSettings["logsDir"];
+                if (!logsDir.isNull() && logsDir.isString())
+                {
+                    mStraceSettings.logsDir = logsDir.asString();
+                }
+                else
+                {
+                    AI_LOG_ERROR("unable to read strace.logsDir, uses default (\"%s\")", mStraceSettings.logsDir.c_str());
+                }
+
+                if (!AICommon::mkdirRecursive(mStraceSettings.logsDir, DEFFILEMODE))
+                {
+                    AI_LOG_ERROR("unable to create strace.logsDir(\"%s\")", mStraceSettings.logsDir.c_str());
+                }
+                else
+                {
+                    struct stat sb;
+                    if (stat(mStraceSettings.logsDir.c_str(), &sb) != 0)
+                    {
+                        AI_LOG_ERROR("failed to create strace.logsDir(\"%s\")", mStraceSettings.logsDir.c_str());
+                    }
+                    else
+                    {
+                        if (sb.st_mode & DEFFILEMODE == 0)
+                        {
+                            chmod(mStraceSettings.logsDir.c_str(), sb.st_mode | DEFFILEMODE);
+                        }
+
+                        // read apps only if we're able to create directory for strace logs.
+                        // If we can not create logs directory, we don't want to run any apps with strace,
+                        // because strace would close when not able to create it's output file.
+                        const Json::Value apps = straceSettings["apps"];
+                        if (apps.isArray())
+                        {
+                            for (const Json::Value &app : apps)
+                            {
+                                if (app.isString())
+                                    mStraceSettings.apps.push_back(app.asString());
+                                else
+                                    AI_LOG_ERROR("invalid entry in strace.apps in JSON settings file");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -302,6 +356,7 @@ Settings::Settings(const Json::Value& settings)
 void Settings::setDefaults()
 {
     mConsoleSocketPath = "/tmp/dobbyPty.sock";
+    mStraceSettings.logsDir = "/tmp/strace";
 
 #if defined(RDK)
     mWorkspaceDir = getPathFromEnv("AI_WORKSPACE_PATH", "/var/volatile/rdk");
@@ -430,6 +485,11 @@ Json::Value Settings::rdkPluginsData() const
 IDobbySettings::LogRelaySettings Settings::logRelaySettings() const
 {
     return mLogRelaySettings;
+}
+
+IDobbySettings::StraceSettings Settings::straceSettings() const
+{
+    return mStraceSettings;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
### Description
Adds possibility to start container with strace enabled.
List of apps to start with strace enabled and directory in which strace output will be stored can be specified in /etc/dobby.json like this:
    "strace": {
	    "apps": ["sleepy_bundle", "other_app"],
	    "logsDir": "/tmp/strace"
    }


### Test Procedure
1. Add to /etc/dobby.json
    "strace": {
	    "apps": ["sleepy_bundle", "other_app"],
	    "logsDir": "/tmp/strace"
    }
2. start DobbyDaemon
3. Run sleepy_bundle
4. Check for strace logs in /tmp/strace

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)