### PR TITLE
SERXIONE-1401: Added ordering constraint to dbus.service

### DIFF
--- a/daemon/process/dobby.service
+++ b/daemon/process/dobby.service
@@ -35,7 +35,7 @@
 Description=RDK Dobby (Container) daemon
 Requires=dbus.socket dbus.service
 Before=wpeframework.service
-After=dbus.socket
+After=dbus.socket dbus.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
### Description
Added ordering constraint to dbus.service

If there is a corresponding JIRA ticket, please ensure it is in the title of the PR.

### Test Procedure
Restart device, check if dobby is stopped before dbus.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)