### PR TITLE
RDK-42156: Add support for seccomp in spec files

### DIFF
--- a/bundle/lib/include/DobbySpecConfig.h
+++ b/bundle/lib/include/DobbySpecConfig.h
@@ -142,6 +142,7 @@ private:
     JSON_FIELD_PROCESSOR(processCpu);
     JSON_FIELD_PROCESSOR(processDevices);
     JSON_FIELD_PROCESSOR(processCapabilities);
+    JSON_FIELD_PROCESSOR(processSeccomp);
 
     #undef JSON_FIELD_PROCESSOR
 
@@ -154,6 +155,7 @@ private:
                                  const Json::Value& pluginData);
     bool processRdkPlugins(const Json::Value& value,
                            ctemplate::TemplateDictionary* dictionary);
+    bool processSeccompAction(const Json::Value& value) const;
 
 private:
     template <std::size_t N>

--- a/bundle/lib/include/DobbySpecConfig.h
+++ b/bundle/lib/include/DobbySpecConfig.h
@@ -155,7 +155,7 @@ private:
                                  const Json::Value& pluginData);
     bool processRdkPlugins(const Json::Value& value,
                            ctemplate::TemplateDictionary* dictionary);
-    bool processSeccompAction(const Json::Value& value) const;
+    bool validateSeccompAction(const Json::Value& value) const;
 
 private:
     template <std::size_t N>

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -2582,7 +2582,7 @@ bool DobbySpecConfig::processSeccomp(const Json::Value& value,
     }
 
     const Json::Value& defaultAction = value["defaultAction"];
-    if (!processSeccompAction(defaultAction))
+    if (!validateSeccompAction(defaultAction))
     {
         AI_LOG_ERROR("invalid 'seccomp.defaultAction' field");
         return false;
@@ -2596,7 +2596,7 @@ bool DobbySpecConfig::processSeccomp(const Json::Value& value,
     }
 
     const Json::Value& action = syscalls["action"];
-    if (!processSeccompAction(action))
+    if (!validateSeccompAction(action))
     {
         AI_LOG_ERROR("invalid 'seccomp.syscalls.action' field");
         return false;
@@ -2640,7 +2640,15 @@ bool DobbySpecConfig::processSeccomp(const Json::Value& value,
     return true;
 }
 
-bool DobbySpecConfig::processSeccompAction(const Json::Value& value) const
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Validates the seccomp action field value
+ *
+ *  @param[in]  value       seccomp action field value
+ *
+ *  @return true if correct seccomp action value, otherwise false.
+ */
+bool DobbySpecConfig::validateSeccompAction(const Json::Value& value) const
 {
     if (!value.isString())
     {

--- a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
@@ -279,6 +279,19 @@ static const char* ociJsonTemplate = R"JSON(
             {{/ADDITIONAL_GIDS}}
         ],
         {{/USERNS_ENABLED}}
+        {{#SECCOMP_ENABLED}}
+        "seccomp": {
+            "defaultAction": "{{SECCOMP_DEFAULT_ACTION}}",
+            "syscalls": [
+                {
+                    "action": "{{SECCOMP_ACTION}}",
+                    "names": [
+                        {{SECCOMP_SYSCALLS}}
+                    ]
+                }
+            ]
+        },
+        {{/SECCOMP_ENABLED}}
         "devices": [
             {{#ADDITIONAL_DEVICE_NODES}}
             {

--- a/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
@@ -290,6 +290,19 @@ static const char* ociJsonTemplate = R"JSON(
             {{/ADDITIONAL_GIDS}}
         ],
         {{/USERNS_ENABLED}}
+        {{#SECCOMP_ENABLED}}
+        "seccomp": {
+            "defaultAction": "{{SECCOMP_DEFAULT_ACTION}}",
+            "syscalls": [
+                {
+                    "action": "{{SECCOMP_ACTION}}",
+                    "names": [
+                        {{SECCOMP_SYSCALLS}}
+                    ]
+                }
+            ]
+        },
+        {{/SECCOMP_ENABLED}}
         "devices": [
             {{#ADDITIONAL_DEVICE_NODES}}
             {


### PR DESCRIPTION
### Description
RDK-42156: Add support for seccomp in spec files.

### Test Procedure
Run sleepy container using spec file with the following root object added:
    "seccomp": {
    	"defaultAction": "SCMP_ACT_ALLOW",
    	"syscalls": {
            "names": [
		"chdir"
            ],
            "action": "SCMP_ACT_ERRNO"
        }    	
    }
Check /proc/sleepy_pid/status. Seccomp should be set to 2.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)