### PR TITLE
RDK-42218 Avoid popen system call wherever possible

### DIFF
--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -788,7 +788,7 @@ bool DobbyConfig::isApparmorProfileLoaded(char *profile)
     char* ptr;
     std::string str;
 
-    fp = popen("cat /sys/kernel/security/apparmor/profiles", "r");
+    fp = fopen("/sys/kernel/security/apparmor/profiles", "r");
 
     if (fp == nullptr)
     {


### PR DESCRIPTION
### Description
Replaced at one occurance with fopen() as fclose() is used for closing the file

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)