### PR TITLE
ONEM-32701 Give container more time to stop

### DIFF
--- a/daemon/lib/source/DobbyRunC.cpp
+++ b/daemon/lib/source/DobbyRunC.cpp
@@ -471,14 +471,14 @@ bool DobbyRunC::killCont(const ContainerId& id, int signal, bool all) const
                retryCounter > 0)
         {
             retryCounter--;
-            usleep(500);
+            usleep(50000);
             contStatus = state(id);
         }
 
         // Container wasn't killed
         if(retryCounter <= 0)
         {
-            AI_LOG_DEBUG("SIGTERM kill wasn't kill container (probably masked), "
+            AI_LOG_WARN("SIGTERM kill did not kill container (probably masked), "
                         "retrying kill with SIGKILL");
             // retry kill with SIGKILL now, its result will be proper result now
             returnValue = DobbyRunC::killCont(id, SIGKILL, all);


### PR DESCRIPTION
### Description

Scenario that caused problem:
1. start chocolate-doom DAC app
2. stop the chocolate-doom DAC app
3. repeat step 1-2 until you noticed dbg logging (-vvvv) "SIGTERM kill wasn't kill container (probably masked)"
4. sometimes that last call succeeds, sometimes not and thus an error is returned. Even though the container was in the end successfully killed.

This fix should give more time for the container to reach the ContainerStatus::Stopped state. 

### Test Procedure
See scenario above

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

### Requires Bitbake Recipe changes?
- 