### PR TITLE
Fix crash when freeing rt_dobby_schema

### DIFF
--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -800,15 +800,15 @@ bool DobbyConfig::isApparmorProfileLoaded(char *profile)
         fgets (line, sizeof(line), fp);
         ptr = strchr(line,'\n');
 
-	if (ptr)
-          *ptr = '\0';
+        if (ptr)
+            *ptr = '\0';
 
-        str = line;
+            str = line;
 
-	if (str.find(profile )!= -1)
+        if (str.find(profile) != -1)
         {
             status = true;
-            AI_LOG_INFO("Apparmor profile [%s] is loaded",profile);
+            AI_LOG_INFO("Apparmor profile [%s] is loaded", profile);
             break;
         }
     }
@@ -828,8 +828,8 @@ bool DobbyConfig::setDobbyDefaultApparmorProfile(std::shared_ptr<rt_dobby_schema
 
     if (!status)
     {
-        cfg->process->apparmor_profile = "dobby_default";
-        status = isApparmorProfileLoaded( cfg->process->apparmor_profile);
+        cfg->process->apparmor_profile = strdup("dobby_default");
+        status = isApparmorProfileLoaded(cfg->process->apparmor_profile);
     }
 
     return status;


### PR DESCRIPTION
### Description
Fix crash when freeing rt_dobby_schema

### Test Procedure
Check if containers are stopped correctly when dobby_default apparmor profile is used.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)