### PR TITLE
Setting sched_rt_runtime_us to -1 is dangerous

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -171,23 +171,6 @@ void DobbyManager::setupSystem()
                      " with container networking");
     }
 
-    // if we have cgroup RT scheduling enabled in the kernel then also set that
-    // to defaults
-    std::string cgrpCpuPath = mEnvironment->cgroupMountPath(IDobbyEnv::Cgroup::Cpu);
-    if (!cgrpCpuPath.empty())
-    {
-        cgrpCpuPath += "/cpu.rt_runtime_us";
-        if (access(cgrpCpuPath.c_str(), F_OK) == 0)
-        {
-            if (!mUtilities->writeTextFile(cgrpCpuPath, "-1\n", O_TRUNC | O_WRONLY, 0))
-            {
-                AI_LOG_FATAL("failed to write to '%s', you may have issues "
-                             "starting containers",
-                             cgrpCpuPath.c_str());
-            }
-        }
-    }
-
     // finally cisco, in their infinite hardening wisdom, keep monkeying around
     // with access permissions, so here we reset everything to sensible values
     DobbyFileAccessFixer fileFixer;

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -135,7 +135,6 @@ DobbyManager::~DobbyManager()
  *
  *      echo "1" > /proc/sys/net/ipv4/ip_forward
  *
- *      echo "-1" > /proc/sys/kernel/sched_rt_runtime_us
  *      echo "-1" > /sys/fs/cgroup/cpu/cpu.rt_runtime_us
  *
  *  See the comments in the code for why each step is needed
@@ -170,15 +169,6 @@ void DobbyManager::setupSystem()
     {
         AI_LOG_FATAL("failed to write to ip_forward file, you may have issues"
                      " with container networking");
-    }
-
-    // the following restores the old skool RT scheduling behaviour, and it's
-    // needed to ensure that containered apps can start in RT scheduling mode
-    if (!mUtilities->writeTextFile("/proc/sys/kernel/sched_rt_runtime_us", "-1\n",
-                                   O_TRUNC | O_WRONLY, 0))
-    {
-        AI_LOG_FATAL("failed to write to sched_rt_runtime_us file, you may have"
-                     " issues starting containers");
     }
 
     // if we have cgroup RT scheduling enabled in the kernel then also set that


### PR DESCRIPTION
### Description
Setting the value of sched_rt_runtime_us to -1 means that real-time tasks may use up to 100% of CPU times which could potentially lock up a system.
Therefore, removed the piece of code in DobbyManager where sched_rt_runtime_us is set to -1, so that the default value 950000 (95% of CPU bandwidth) will be set, allowing 5% of CPU time to be used by non-realtime tasks. This 5% of CPU time should be enough to get rid of the rogue processes.

Reference : https://access.redhat.com/solutions/1604133

### Test Procedure
Check whether containerized apps seem to run fine

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)