### PR TITLE
[RDK-45574] Enhancing the L1 Unit Test for Dobby.h

### DIFF
--- a/unit_tests/L1_testing/README.md
+++ b/unit_tests/L1_testing/README.md
@@ -47,10 +47,23 @@ To Running the tests, need to be build the Dobby source and Test codes.
           filtered_coverage.info
 ```
 ## Writing tests
-To write new test:
+### To write new test:
 1. Create new folder and create new test file under the unit_tests/L1_testing/tests/DobbyXXXXTest/XXXXTest.cpp
 2. Create new CMakeLists.txt under this unit_tests/L1_testing/tests/DobbyXXXXTest/ folder
 3. Add add_subdirectory(DobbyXXXXTest) in unit_tests/L1_testing/tests/CMakeLists,txt
 4. Add the test cases using gtest framework
-5. Once added the new test, use above commands to build and run the test.
+### To write the mock
+1. Instead of incuding actual header file. Create a new heade file with same name in unit_tests/L1_testing/mocks/XXXX.h
+    #### Example:
+     If test requires DobbyContainer.h header file.
+     - Create [DobbyContainer.h](https://github.com/rdkcentral/Dobby/blob/master/unit_tests/L1_testing/mocks/DobbyContainer.h) file in [unit_tests/L1_testing/mocks/](https://github.com/rdkcentral/Dobby/blob/master/unit_tests/L1_testing/mocks/)
+     - Add the [DobbyContainer class](https://github.com/rdkcentral/Dobby/blob/master/unit_tests/L1_testing/mocks/DobbyContainer.h#L44) and required function methods.
+     - Create new class [DobbyContainerImpl](https://github.com/rdkcentral/Dobby/blob/master/unit_tests/L1_testing/mocks/DobbyContainer.h#L35) in this file and declared all methods as virtual
+     - Create an object for this Dobby container mock class and store it in [static member varaible(impl)](https://github.com/rdkcentral/Dobby/blob/master/unit_tests/L1_testing/mocks/DobbyContainer.h#L48) of DobbyContainer
+     - Create [DobbyContainerMock.h](https://github.com/rdkcentral/Dobby/blob/master/unit_tests/L1_testing/mocks/DobbyContainerMock.h#L26) for creating the mock functions using gmock (MOCK_METHOD). so gmock will create the definition for those methods
+     - [From test file](https://github.com/rdkcentral/Dobby/blob/master/unit_tests/L1_testing/tests/DobbyTest/DaemonDobbyTests.cpp#L114) need to create the object for mock and assign that value to impl member variable.
+     - Create [DobbyContainerMock.cpp](https://github.com/rdkcentral/Dobby/blob/master/unit_tests/L1_testing/mocks/DobbyContainerMock.cpp) and add definition for DobbyContainer class. Here need to call DobbyContainerImpl class methods using [impl](https://github.com/rdkcentral/Dobby/blob/master/unit_tests/L1_testing/mocks/DobbyContainerMock.cpp#L76) member variable
+
+Once added the new test, use above commands to build and run the test.
    Otherwise if add the changes in github, .github/workflows/build.yml will build and run the tests then give the results with coverage report.
+

--- a/unit_tests/L1_testing/mocks/DobbyManagerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyManagerMock.cpp
@@ -25,7 +25,14 @@ DobbyManager::DobbyManager()
 {
 }
 
-DobbyManager::DobbyManager(std::shared_ptr<DobbyEnv>&, std::shared_ptr<DobbyUtils>&, std::shared_ptr<DobbyIPCUtils>&, const std::shared_ptr<const IDobbySettings>&, std::function<void(int, const ContainerId&)>&, std::function<void(int, const ContainerId&, int)>&)
+DobbyManager::DobbyManager(std::shared_ptr<DobbyEnv>&,
+                                                    std::shared_ptr<DobbyUtils>&,
+                                                    std::shared_ptr<DobbyIPCUtils>&,
+                                                    const std::shared_ptr<const IDobbySettings>&,
+                                                    std::function<void(int, const ContainerId&)>& StartedFunc,
+                                                    std::function<void(int, const ContainerId&, int)>& StoppedFunc)
+: mContainerStartedCb(StartedFunc)
+, mContainerStoppedCb(StoppedFunc)
 {
 }
 
@@ -59,7 +66,7 @@ int32_t DobbyManager::startContainerFromSpec(const ContainerId& id,
 {
    EXPECT_NE(impl, nullptr);
 
-    return impl->startContainerFromSpec(id, jsonSpec, files, command, displaySocket, envVars);
+   return impl->startContainerFromSpec(id, jsonSpec, files, command, displaySocket, envVars, mContainerStartedCb);
 }
 
 std::string DobbyManager::specOfContainer(int32_t cd)
@@ -86,14 +93,14 @@ int32_t DobbyManager::startContainerFromBundle(const ContainerId& id,
 {
    EXPECT_NE(impl, nullptr);
 
-    return impl->startContainerFromBundle(id, bundlePath, files, command, displaySocket, envVars);
+   return impl->startContainerFromBundle(id, bundlePath, files, command, displaySocket, envVars, mContainerStartedCb);
 }
 
 bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
 {
    EXPECT_NE(impl, nullptr);
 
-    return impl->stopContainer(cd, withPrejudice);
+   return impl->stopContainer(cd, withPrejudice, mContainerStoppedCb);
 }
 
 bool DobbyManager::pauseContainer(int32_t cd)

--- a/unit_tests/L1_testing/mocks/DobbyManagerMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyManagerMock.h
@@ -32,7 +32,8 @@ public:
                                               const std::list<int>& files,
                                               const std::string& command,
                                               const std::string& displaySocket,
-                                              const std::vector<std::string>& envVars),(override));
+                                              const std::vector<std::string>& envVars,
+                                              const std::function<void(int32_t cd, const ContainerId& id)> containnerStartCb),(override));
 
     MOCK_METHOD(std::string, specOfContainer, (int32_t cd), (const,override));
 
@@ -45,9 +46,10 @@ public:
                                                 const std::list<int>& files,
                                                 const std::string& command,
                                                 const std::string& displaySocket,
-                                                const std::vector<std::string>& envVars), (override));
+                                                const std::vector<std::string>& envVars,
+                                                const std::function<void(int32_t cd, const ContainerId& id)> containnerStartCb), (override));
 
-    MOCK_METHOD(bool, stopContainer, (int32_t cd, bool withPrejudice), (override));
+    MOCK_METHOD(bool, stopContainer, (int32_t cd, bool withPrejudice, const std::function<void(int32_t cd, const ContainerId& id, int32_t status)> containnerStopCb), (override));
 
     MOCK_METHOD(bool, pauseContainer, (int32_t cd), (override));
 

--- a/unit_tests/L1_testing/mocks/dobbymanager/DobbyManager.h
+++ b/unit_tests/L1_testing/mocks/dobbymanager/DobbyManager.h
@@ -67,7 +67,8 @@ public:
                                           const std::list<int>& files,
                                           const std::string& command,
                                           const std::string& displaySocket,
-                                          const std::vector<std::string>& envVars) = 0;
+                                          const std::vector<std::string>& envVars,
+                                          const std::function<void(int32_t cd, const ContainerId& id)> containnerStartCb) = 0;
 
     virtual std::string specOfContainer(int32_t cd) const = 0;
 
@@ -81,9 +82,10 @@ public:
                                             const std::list<int>& files,
                                             const std::string& command,
                                             const std::string& displaySocket,
-                                            const std::vector<std::string>& envVars) = 0;
+                                            const std::vector<std::string>& envVars,
+                                            const std::function<void(int32_t cd, const ContainerId& id)> containnerStartCb) = 0;
 
-    virtual bool stopContainer(int32_t cd, bool withPrejudice) = 0;
+    virtual bool stopContainer(int32_t cd, bool withPrejudice, std::function<void(int32_t cd, const ContainerId& id, int32_t status)> containnerStopCb) = 0;
 
     virtual bool pauseContainer(int32_t cd) = 0;
 
@@ -114,7 +116,12 @@ public:
     typedef std::function<void(int32_t cd, const ContainerId& id)> ContainerStartedFunc;
     typedef std::function<void(int32_t cd, const ContainerId& id, int32_t status)> ContainerStoppedFunc;
     DobbyManager();
-    DobbyManager(std::shared_ptr<DobbyEnv>&, std::shared_ptr<DobbyUtils>&, std::shared_ptr<DobbyIPCUtils>&, const std::shared_ptr<const IDobbySettings>&, std::function<void(int, const ContainerId&)>&, std::function<void(int, const ContainerId&, int)>&);
+    DobbyManager(std::shared_ptr<DobbyEnv>&,
+                                  std::shared_ptr<DobbyUtils>&,
+                                  std::shared_ptr<DobbyIPCUtils>&,
+                                  const std::shared_ptr<const IDobbySettings>&,
+                                  std::function<void(int, const ContainerId&)>& StartedFunc,
+                                  std::function<void(int, const ContainerId&, int)>& StoppedFunc);
     ~DobbyManager();
 
     static void setImpl(DobbyManagerImpl* newImpl);
@@ -122,33 +129,35 @@ public:
 
 #if defined(LEGACY_COMPONENTS)
 
-    static int32_t startContainerFromSpec(const ContainerId& id,
+    int32_t startContainerFromSpec(const ContainerId& id,
                                           const std::string& jsonSpec,
                                           const std::list<int>& files,
                                           const std::string& command,
                                           const std::string& displaySocket,
                                           const std::vector<std::string>& envVars);
-    static std::string specOfContainer(int32_t cd);
-    static bool createBundle(const ContainerId& id, const std::string& jsonSpec);
+    std::string specOfContainer(int32_t cd);
+    bool createBundle(const ContainerId& id, const std::string& jsonSpec);
 #endif //defined(LEGACY_COMPONENTS)
 
-    static int32_t startContainerFromBundle(const ContainerId& id,
+    int32_t startContainerFromBundle(const ContainerId& id,
                                             const std::string& bundlePath,
                                             const std::list<int>& files,
                                             const std::string& command,
                                             const std::string& displaySocket,
                                             const std::vector<std::string>& envVars);
-    static bool stopContainer(int32_t cd, bool withPrejudice);
-    static bool pauseContainer(int32_t cd);
-    static bool resumeContainer(int32_t cd);
-    static bool execInContainer(int32_t cd,
+    bool stopContainer(int32_t cd, bool withPrejudice);
+    bool pauseContainer(int32_t cd);
+    bool resumeContainer(int32_t cd);
+    bool execInContainer(int32_t cd,
                                 const std::string& options,
                                 const std::string& command);
-    static std::list<std::pair<int32_t, ContainerId>> listContainers();
-    static int32_t stateOfContainer(int32_t cd);
-    static std::string statsOfContainer(int32_t cd);
-    static std::string ociConfigOfContainer(int32_t cd);
+    std::list<std::pair<int32_t, ContainerId>> listContainers();
+    int32_t stateOfContainer(int32_t cd);
+    std::string statsOfContainer(int32_t cd);
+    std::string ociConfigOfContainer(int32_t cd);
 
+    ContainerStartedFunc mContainerStartedCb;
+    ContainerStoppedFunc mContainerStoppedCb;
 };
 
 #endif // !defined(DOBBYMANAGER_H)


### PR DESCRIPTION
### Description
1. Checking whether onContainerStarted callback is triggering when startFromSpec, startFromBundle method calls
2. Checking whether onContainerStopped callback is triggering when stop mehod calls
3. Updated the README.md file

### Test Procedure
In github workflow L1 test is running and passing

### Type of Change
- Enhancing Dobby L1 test
- 
### Requires Bitbake Recipe changes?
- Not required