### PR TITLE
RDK-45299: Add Apparmor contol and profile name to the device specific container config

### DIFF
--- a/bundle/lib/include/DobbyConfig.h
+++ b/bundle/lib/include/DobbyConfig.h
@@ -132,6 +132,8 @@ public:
     void printCommand() const;
     bool enableSTrace(const std::string& logsDir);
 
+    void setApparmorProfile(const std::string& profileName);
+
 // protected methods for derived classes to use
 protected:
     bool writeConfigJsonImpl(const std::string& filePath) const;
@@ -144,8 +146,7 @@ protected:
     bool convertToCompliant(const ContainerId& id,
                             std::shared_ptr<rt_dobby_schema> cfg,
                             const std::string& bundlePath);
-    bool isApparmorProfileLoaded(char *profile);
-    bool setDobbyDefaultApparmorProfile(std::shared_ptr<rt_dobby_schema> cfg);
+    bool isApparmorProfileLoaded(const char *profile) const;
 
     struct DevNode
     {

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -651,6 +651,9 @@ bool DobbyManager::customiseConfig(const std::shared_ptr<DobbyConfig> &config,
 
     if (shouldEnableSTrace(config))
     {
+        // Start container with strace.
+        // It should be done in customiseConfig so that change in strace params
+        // would not require to reinstall container bundle.
         config->enableSTrace(mSettings->straceSettings().logsDir);
         changesMade = true;
     }
@@ -1013,6 +1016,12 @@ int32_t DobbyManager::startContainerFromBundle(const ContainerId &id,
     {
         AI_LOG_ERROR_EXIT("failed to create 'start state' object");
         return -1;
+    }
+
+    // Set Apparmor profile
+    if (mSettings->apparmorSetiings().enabled)
+    {
+        config->setApparmorProfile(mSettings->apparmorSetiings().profileName);
     }
 
     // Load the RDK plugins from disk (if necessary)

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1019,9 +1019,9 @@ int32_t DobbyManager::startContainerFromBundle(const ContainerId &id,
     }
 
     // Set Apparmor profile
-    if (mSettings->apparmorSetiings().enabled)
+    if (mSettings->apparmorSettings().enabled)
     {
-        config->setApparmorProfile(mSettings->apparmorSetiings().profileName);
+        config->setApparmorProfile(mSettings->apparmorSettings().profileName);
     }
 
     // Load the RDK plugins from disk (if necessary)

--- a/settings/include/IDobbySettings.h
+++ b/settings/include/IDobbySettings.h
@@ -232,9 +232,9 @@ public:
      *  Apparmor settings
      *
      *      - enabled
-     *          Path to directory where strace logs will be written
-     *      - apps
-     *          A list of app names that should be run with strace.
+     *          Specifies if apparmor profile should be set for containered apps
+     *      - profileName
+     *          A name of default apparmor profile used for containered apps
      *
      */
     struct ApparmorSettings
@@ -243,7 +243,7 @@ public:
         std::string profileName;
     };
 
-    virtual ApparmorSettings apparmorSetiings() const = 0;
+    virtual ApparmorSettings apparmorSettings() const = 0;
 };
 
 #endif // !defined(IDOBBYSETTINGS_H)

--- a/settings/include/IDobbySettings.h
+++ b/settings/include/IDobbySettings.h
@@ -226,6 +226,24 @@ public:
     };
 
     virtual StraceSettings straceSettings() const = 0;
+
+    // -------------------------------------------------------------------------
+    /**
+     *  Apparmor settings
+     *
+     *      - enabled
+     *          Path to directory where strace logs will be written
+     *      - apps
+     *          A list of app names that should be run with strace.
+     *
+     */
+    struct ApparmorSettings
+    {
+        bool enabled;
+        std::string profileName;
+    };
+
+    virtual ApparmorSettings apparmorSetiings() const = 0;
 };
 
 #endif // !defined(IDOBBYSETTINGS_H)

--- a/settings/include/Settings.h
+++ b/settings/include/Settings.h
@@ -78,7 +78,7 @@ public:
 
     LogRelaySettings logRelaySettings() const override;
     StraceSettings straceSettings() const override;
-    ApparmorSettings apparmorSetiings() const override;
+    ApparmorSettings apparmorSettings() const override;
 
     void dump(int aiLogLevel = -1) const;
 

--- a/settings/include/Settings.h
+++ b/settings/include/Settings.h
@@ -77,8 +77,8 @@ public:
     Json::Value rdkPluginsData() const override;
 
     LogRelaySettings logRelaySettings() const override;
-
     StraceSettings straceSettings() const override;
+    ApparmorSettings apparmorSetiings() const override;
 
     void dump(int aiLogLevel = -1) const;
 
@@ -130,6 +130,7 @@ private:
 
     LogRelaySettings mLogRelaySettings;
     StraceSettings mStraceSettings;
+    ApparmorSettings mApparmorSettings;
 };
 
 #endif // !defined(SETTINGS_H)

--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -508,7 +508,7 @@ IDobbySettings::StraceSettings Settings::straceSettings() const
     return mStraceSettings;
 }
 
-IDobbySettings::ApparmorSettings Settings::apparmorSetiings() const
+IDobbySettings::ApparmorSettings Settings::apparmorSettings() const
 {
     return mApparmorSettings;
 }

--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -333,6 +333,32 @@ Settings::Settings(const Json::Value& settings)
             }
         }
     }
+
+    // Process apparmor settings
+    {
+        Json::Value apparmorSettings = Json::Path(".apparmor").resolve(settings);
+        if (!apparmorSettings.isNull())
+        {
+            if (apparmorSettings.isObject())
+            {
+                const Json::Value enabled = apparmorSettings["enabled"];
+                if (enabled.isBool())
+                    mApparmorSettings.enabled = enabled.asBool();
+                else
+                    AI_LOG_ERROR("Invalid entry in apparmor.enabled in JSON settings file");
+
+                const Json::Value profile = apparmorSettings["defaultProfile"];
+                if (profile.isString())
+                    mApparmorSettings.profileName = profile.asString();
+                else
+                    AI_LOG_ERROR("Invalid entry in apparmor.defaultProfile in JSON settings file");
+            }
+            else
+            {
+                AI_LOG_ERROR("Invalid apparmor type in settings file, should be object");
+            }
+        }
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -348,9 +374,12 @@ void Settings::setDefaults()
 #if defined(RDK)
     mWorkspaceDir = getPathFromEnv("AI_WORKSPACE_PATH", "/var/volatile/rdk");
     mPersistentDir = getPathFromEnv("AI_PERSISTENT_PATH", "/opt/persistent/rdk");
+    mApparmorSettings.enabled = true;
+    mApparmorSettings.profileName = "dobby_default";
 #else
     mWorkspaceDir = getPathFromEnv("AI_WORKSPACE_PATH", "/tmp/ai-workspace-fallback");
     mPersistentDir = getPathFromEnv("AI_PERSISTENT_PATH", "/tmp/ai-flash-fallback");
+    mApparmorSettings.enabled = false;
 #endif
 }
 
@@ -479,6 +508,11 @@ IDobbySettings::StraceSettings Settings::straceSettings() const
     return mStraceSettings;
 }
 
+IDobbySettings::ApparmorSettings Settings::apparmorSetiings() const
+{
+    return mApparmorSettings;
+}
+
 // -----------------------------------------------------------------------------
 /**
  *  @brief Debugging function to dump the settings to the log - info level.
@@ -514,6 +548,9 @@ void Settings::dump(int aiLogLevel) const
     {
         __AI_LOG_PRINTF(aiLogLevel, "settings.straceSettings.apps[%u]='%s'", i++, app.c_str());
     }
+
+    __AI_LOG_PRINTF(aiLogLevel, "settings.apparmorSettings.enabled='%s'", mApparmorSettings.enabled ? "true" : "false");
+    __AI_LOG_PRINTF(aiLogLevel, "settings.apparmorSettings.defaultProfile='%s'", mApparmorSettings.profileName.c_str());
 
     dumpHardwareAccess(aiLogLevel, "gpu", mGpuHardwareAccess);
     dumpHardwareAccess(aiLogLevel, "vpu", mVpuHardwareAccess);

--- a/unit_tests/L1_testing/mocks/DobbyConfig.h
+++ b/unit_tests/L1_testing/mocks/DobbyConfig.h
@@ -46,6 +46,7 @@ public:
     virtual bool addWesterosMount(const std::string& socketPath) = 0;
     virtual bool addEnvironmentVar(const std::string& envVar) = 0;
     virtual bool enableSTrace(const std::string& logsDir) = 0;
+    virtual void setApparmorProfile(const std::string& profileName) = 0;
     virtual std::string configJson() const = 0;
 
 #if defined(LEGACY_COMPONENTS)
@@ -74,6 +75,7 @@ public:
     bool addWesterosMount(const std::string& socketPath);
     bool addEnvironmentVar(const std::string& envVar);
     bool enableSTrace(const std::string& logsDir);
+    void setApparmorProfile(const std::string& profileName);
     const std::string configJson() const;
 
 #if defined(LEGACY_COMPONENTS)

--- a/unit_tests/L1_testing/mocks/DobbyConfigMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyConfigMock.cpp
@@ -101,6 +101,13 @@ bool DobbyConfig::enableSTrace(const std::string& logsDir)
     return impl->enableSTrace(logsDir);
 }
 
+void DobbyConfig::setApparmorProfile(const std::string& profileName)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->setApparmorProfile(profileName);
+}
+
 const std::string DobbyConfig::configJson() const
 {
    EXPECT_NE(impl, nullptr);

--- a/unit_tests/L1_testing/mocks/DobbyConfigMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyConfigMock.h
@@ -34,6 +34,7 @@ public:
     MOCK_METHOD(bool, addWesterosMount, (const std::string& socketPath), (override));
     MOCK_METHOD(bool, addEnvironmentVar, (const std::string& envVar), (override));
     MOCK_METHOD(bool, enableSTrace, (const std::string& logsDir), (override));
+    MOCK_METHOD(void, setApparmorProfile, (const std::string& profileName), (override));
     MOCK_METHOD(std::string, configJson, (), (const,override));
 
 #if defined(LEGACY_COMPONENTS)

--- a/unit_tests/L1_testing/mocks/DobbySettingsMock.h
+++ b/unit_tests/L1_testing/mocks/DobbySettingsMock.h
@@ -36,5 +36,5 @@ class DobbySettingsMock : public IDobbySettings {
     MOCK_METHOD(Json::Value, rdkPluginsData, (), (const, override));
     MOCK_METHOD(LogRelaySettings, logRelaySettings, (), (const, override));
     MOCK_METHOD(StraceSettings, straceSettings, (), (const, override));
-    MOCK_METHOD(ApparmorSettings, apparmorSetiings, (), (const, override));
+    MOCK_METHOD(ApparmorSettings, apparmorSettings, (), (const, override));
 };

--- a/unit_tests/L1_testing/mocks/DobbySettingsMock.h
+++ b/unit_tests/L1_testing/mocks/DobbySettingsMock.h
@@ -36,4 +36,5 @@ class DobbySettingsMock : public IDobbySettings {
     MOCK_METHOD(Json::Value, rdkPluginsData, (), (const, override));
     MOCK_METHOD(LogRelaySettings, logRelaySettings, (), (const, override));
     MOCK_METHOD(StraceSettings, straceSettings, (), (const, override));
+    MOCK_METHOD(ApparmorSettings, apparmorSetiings, (), (const, override));
 };

--- a/unit_tests/L1_testing/mocks/IDobbySettingsMock.h
+++ b/unit_tests/L1_testing/mocks/IDobbySettingsMock.h
@@ -37,6 +37,6 @@ class IDobbySettingsMock : public IDobbySettings {
     MOCK_METHOD(Json::Value, rdkPluginsData, (), (const, override));
     MOCK_METHOD(LogRelaySettings, logRelaySettings, (), (const, override));
     MOCK_METHOD(StraceSettings, straceSettings, (), (const, override));
-    MOCK_METHOD(ApparmorSettings, apparmorSetiings, (), (const, override));
+    MOCK_METHOD(ApparmorSettings, apparmorSettings, (), (const, override));
 };
 

--- a/unit_tests/L1_testing/mocks/IDobbySettingsMock.h
+++ b/unit_tests/L1_testing/mocks/IDobbySettingsMock.h
@@ -37,5 +37,6 @@ class IDobbySettingsMock : public IDobbySettings {
     MOCK_METHOD(Json::Value, rdkPluginsData, (), (const, override));
     MOCK_METHOD(LogRelaySettings, logRelaySettings, (), (const, override));
     MOCK_METHOD(StraceSettings, straceSettings, (), (const, override));
+    MOCK_METHOD(ApparmorSettings, apparmorSetiings, (), (const, override));
 };
 

--- a/unit_tests/L1_testing/tests/DobbyManagerTest/CMakeLists.txt
+++ b/unit_tests/L1_testing/tests/DobbyManagerTest/CMakeLists.txt
@@ -88,12 +88,10 @@ add_executable(${PROJECT_NAME} ${TESTS})
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-    gmock_main
     DaemonDobbyManagerTest
-    ${GTEST_LIBRARIES}
+    GTest::gmock
     GTest::GTest
     GTest::Main
-    gmock
     ctemplate
     pthread
     jsoncpp

--- a/unit_tests/L1_testing/tests/DobbyTest/CMakeLists.txt
+++ b/unit_tests/L1_testing/tests/DobbyTest/CMakeLists.txt
@@ -78,12 +78,10 @@ add_executable(${PROJECT_NAME} ${TESTS})
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-    gmock_main
     DaemonDobbyTests
-    ${GTEST_LIBRARIES}
+    GTest::gmock
     GTest::GTest
     GTest::Main
-    gmock
     ctemplate
     pthread
     jsoncpp


### PR DESCRIPTION
### Description
RDK-45299: Add Apparmor contol and profile name to the device specific container config

### Test Procedure
Add to /etc/dobby.json
"apparmor": {
"enabled": true,
"defaultProfile": "dobby_default"
}
Check DobbyDaemon startup logs is /etc/dobby,json was correctly parsed.
Run any container and check if it uses dobby_default apparmor profile.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)