### PR TITLE
Remove apt install libgtest-dev in yml file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: install-dependencies
         run: |
           sudo apt-get update -y -q
-          sudo apt-get install -q -y automake libtool autotools-dev software-properties-common build-essential cmake libsystemd-dev libctemplate-dev libjsoncpp-dev libdbus-1-dev libnl-3-dev libnl-route-3-dev libsystemd-dev libyajl-dev libcap-dev libboost-dev libgtest-dev lcov clang
+          sudo apt-get install -q -y automake libtool autotools-dev software-properties-common build-essential cmake libsystemd-dev libctemplate-dev libjsoncpp-dev libdbus-1-dev libnl-3-dev libnl-route-3-dev libsystemd-dev libyajl-dev libcap-dev libboost-dev lcov clang
 
       - name: Set clang toolchain
         if: ${{ matrix.compiler == 'clang' }}


### PR DESCRIPTION
### Description
Remove apt install libgtest-dev in yml file, since we are cloning and installing the Googletest in Install gmock step.

### Test Procedure
In github workflow L1 test is running and passing

### Type of Change
- Enhancing Dobby L1 test

### Requires Bitbake Recipe changes?
- Not required