### PR TITLE
[DELIA-64116] [Dobby] Hang during the cleanupContainersShutdown() whe…

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -470,7 +470,8 @@ void DobbyManager::cleanupContainersShutdown()
     auto it = mContainers.begin();
     while (it != mContainers.end())
     {
-        if (it->second->state == DobbyContainer::State::Running)
+        if ((it->second->state == DobbyContainer::State::Running) || \
+            (it->second->state == DobbyContainer::State::Paused))
         {
             AI_LOG_INFO("Stopping container %s", it->first.c_str());
             // By calling the "proper" stop method here, any listening services will be


### PR DESCRIPTION
…n a container is in the paused state

### Description
Changes Done:
1. Removed the paused state containers by checking paused state.

JIRA ticket: https://github.com/rdkcentral/Dobby/issues/290

### Test Procedure
NA

### Type of Change
- [ ] Bug fix

### Requires Bitbake Recipe changes?
- [ ] None