### PR TITLE
RDK-45967 - Added L1 test cases for ociConfigOfContainer Api.

### DIFF
--- a/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -2666,7 +2666,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_CreateAndStartContainerF
 TEST_F(DaemonDobbyManagerTest, ociConfigOfContainer_Success)
 {
     int32_t cd = 123;
-
+    std::string jsonSpec = "{\"key\": \"value\", \"number\": 42}";
 #if defined(LEGACY_COMPONENTS)
     expect_startContainerFromSpec(cd);
 #endif //defined(LEGACY_COMPONENTS)


### PR DESCRIPTION
### Description
L1 test cases are added for ociConfigOfContainer and specOfContainer apis in Dobby master branch.

**UseCases**:
1. ociConfigOfContainer_Success
2. ociConfigOfContainer_FailedToFindContainer
3. ociConfigOfContainer_EmptyOCIConfigJsonSpec
4. specOfContainer_FailedToFindContainer
5. specOfContainer_SuccessWhenStarting
6. specOfContainer_EmptyJsonSpec

### Test Procedure
Run ./guthub/workflows/build.yml file. All unit tests should pass.

### Requires Bitbake Recipe changes?
No
