### PR TITLE
RDKTV-17990: Setting pids cgroup limit

### DIFF
--- a/bundle/lib/include/DobbyConfig.h
+++ b/bundle/lib/include/DobbyConfig.h
@@ -131,8 +131,8 @@ public:
 
     void printCommand() const;
     bool enableSTrace(const std::string& logsDir);
-
     void setApparmorProfile(const std::string& profileName);
+    void setPidsLimit(int limit);
 
 // protected methods for derived classes to use
 protected:

--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -847,6 +847,36 @@ void DobbyConfig::setApparmorProfile(const std::string& defaultProfileName)
 
 // -----------------------------------------------------------------------------
 /**
+ *  @brief Set cgroup pids limit.
+ *
+ *  Limits the number of processes that containered app can create.
+ *
+ *  @see https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt
+ *
+ *  @param[in]  limit  limit of pids
+ */
+void DobbyConfig::setPidsLimit(int limit)
+{
+    std::shared_ptr<rt_dobby_schema> cfg = config();
+    if (cfg == nullptr)
+    {
+        AI_LOG_ERROR("Invalid bundle config");
+        return;
+    }
+
+    rt_config_linux_resources_pids* pids = cfg->linux->resources->pids;
+    if (pids == nullptr)
+    {
+        pids = (rt_config_linux_resources_pids*)calloc(1, sizeof(rt_config_linux_resources_pids));
+        cfg->linux->resources->pids = pids;
+    }
+
+    pids->limit = limit;
+    pids->limit_present = true;
+}
+
+// -----------------------------------------------------------------------------
+/**
  *  @brief Convert the input config.json into an OCI compliant bundle config
  *         that adds support for DobbyPluginLauncher to work with rdkPlugins.
  *

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1025,6 +1025,12 @@ int32_t DobbyManager::startContainerFromBundle(const ContainerId &id,
         config->setApparmorProfile(mSettings->apparmorSettings().profileName);
     }
 
+    // Set pids limit
+    if (mSettings->pidsSettings().enabled)
+    {
+        config->setPidsLimit(mSettings->pidsSettings().limit);
+    }
+
     // Load the RDK plugins from disk (if necessary)
     std::map<std::string, Json::Value> rdkPlugins = config->rdkPlugins();
     AI_LOG_DEBUG("There are %zd rdk plugins to run", rdkPlugins.size());

--- a/settings/include/IDobbySettings.h
+++ b/settings/include/IDobbySettings.h
@@ -244,6 +244,26 @@ public:
     };
 
     virtual ApparmorSettings apparmorSettings() const = 0;
+
+    // -------------------------------------------------------------------------
+    /**
+     *  Pids cgroup settings
+     *
+     *  @see https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt
+     *
+     *      - enabled
+     *          Specifies if pids cgroup limit should be set
+     *      - limit
+     *          A limit of tasks in cgroup
+     *
+     */
+    struct PidsSettings
+    {
+        bool enabled;
+        int limit;
+    };
+
+    virtual PidsSettings pidsSettings() const = 0;
 };
 
 #endif // !defined(IDOBBYSETTINGS_H)

--- a/settings/include/Settings.h
+++ b/settings/include/Settings.h
@@ -79,6 +79,7 @@ public:
     LogRelaySettings logRelaySettings() const override;
     StraceSettings straceSettings() const override;
     ApparmorSettings apparmorSettings() const override;
+    PidsSettings pidsSettings() const override;
 
     void dump(int aiLogLevel = -1) const;
 
@@ -131,6 +132,7 @@ private:
     LogRelaySettings mLogRelaySettings;
     StraceSettings mStraceSettings;
     ApparmorSettings mApparmorSettings;
+    PidsSettings mPidsSettings;
 };
 
 #endif // !defined(SETTINGS_H)

--- a/unit_tests/L1_testing/mocks/DobbyConfig.h
+++ b/unit_tests/L1_testing/mocks/DobbyConfig.h
@@ -46,6 +46,7 @@ public:
     virtual bool addEnvironmentVar(const std::string& envVar) = 0;
     virtual bool enableSTrace(const std::string& logsDir) = 0;
     virtual void setApparmorProfile(const std::string& profileName) = 0;
+    virtual void setPidsLimit(int limit) = 0;
     virtual std::string configJson() const = 0;
 
 };
@@ -69,6 +70,7 @@ public:
     bool addEnvironmentVar(const std::string& envVar);
     bool enableSTrace(const std::string& logsDir);
     void setApparmorProfile(const std::string& profileName);
+    void setPidsLimit(int limit);
     const std::string configJson() const;
 
 #if defined(LEGACY_COMPONENTS)

--- a/unit_tests/L1_testing/mocks/DobbyConfigMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyConfigMock.cpp
@@ -75,6 +75,13 @@ void DobbyConfig::setApparmorProfile(const std::string& profileName)
     return impl->setApparmorProfile(profileName);
 }
 
+void DobbyConfig::setPidsLimit(int limit)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->setPidsLimit(limit);
+}
+
 const std::string DobbyConfig::configJson() const
 {
    EXPECT_NE(impl, nullptr);

--- a/unit_tests/L1_testing/mocks/DobbyConfigMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyConfigMock.h
@@ -34,6 +34,7 @@ public:
     MOCK_METHOD(bool, addEnvironmentVar, (const std::string& envVar), (override));
     MOCK_METHOD(bool, enableSTrace, (const std::string& logsDir), (override));
     MOCK_METHOD(void, setApparmorProfile, (const std::string& profileName), (override));
+    MOCK_METHOD(void, setPidsLimit, (int limit), (override));
     MOCK_METHOD(std::string, configJson, (), (const,override));
 
 };

--- a/unit_tests/L1_testing/mocks/DobbySettingsMock.h
+++ b/unit_tests/L1_testing/mocks/DobbySettingsMock.h
@@ -37,4 +37,5 @@ class DobbySettingsMock : public IDobbySettings {
     MOCK_METHOD(LogRelaySettings, logRelaySettings, (), (const, override));
     MOCK_METHOD(StraceSettings, straceSettings, (), (const, override));
     MOCK_METHOD(ApparmorSettings, apparmorSettings, (), (const, override));
+    MOCK_METHOD(PidsSettings, pidsSettings, (), (const, override));
 };


### PR DESCRIPTION
### Description
RDKTV-17990: Setting pids cgroup limit

### Test Procedure
In /etc/dobby.json add 
"pids": {
  "enable": true,
  "limit":100
}
Restart Dobby, start an application and check /sys/fs/cgroup/pids/<app_name>/pids.max.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)