### PR TITLE
[RDK-44357] Adding the L1 Unit Test for DobbyManager.h - API List

### DIFF
--- a/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -65,7 +65,6 @@
 #include "DobbyProtocol.h"
 
 #define MAX_TIMEOUT_CONTAINER_STARTED (5000) /* 5sec */
-#define WAIT_TIME (10000)
 #define LIST_CONTAINERS_HUGE_COUNT 8
 
 DobbyContainerImpl* DobbyContainer::impl = nullptr;
@@ -264,11 +263,6 @@ protected:
            }));
 
            dobbyManager_test = std::make_shared<NiceMock<DobbyManager>>(p_env,p_utils,p_ipcutils,p_dobbysettingsMock,startcb,stopcb);
-           /* Github issue: 294: pthread_kill() is failing in stopRuncMonitorThread() which is calling from destructor.
-            * runcMonitorThread() is starting late, with in the time, if dobbymanager object is deleted, pthread_kill() is failing because the thread is not yet started.
-            * 10ms sleep is added to avoid the time issue */
-           usleep(WAIT_TIME);
-
         }
 
         virtual void TearDown()

--- a/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -62,9 +62,11 @@
 #include "DobbyStreamMock.h"
 #include "ContainerIdMock.h"
 #include "IDobbyRdkLoggingPluginMock.h"
+#include "DobbyProtocol.h"
 
 #define MAX_TIMEOUT_CONTAINER_STARTED (5000) /* 5sec */
-#define WAIT_TIME (10000) 
+#define WAIT_TIME (10000)
+#define LIST_CONTAINERS_HUGE_COUNT 8
 
 DobbyContainerImpl* DobbyContainer::impl = nullptr;
 DobbyRdkPluginManagerImpl* DobbyRdkPluginManager::impl = nullptr;
@@ -108,6 +110,7 @@ protected:
 
     typedef std::function<void(int32_t cd, const ContainerId& id)> ContainerStartedFunc;
     typedef std::function<void(int32_t cd, const ContainerId& id, int32_t status)> ContainerStoppedFunc;
+    std::function<bool()> Test_invalidContainerCleanupTask;
 
     ContainerStartedFunc startcb =
         std::bind(&DaemonDobbyManagerTest::onContainerStarted, this,
@@ -227,20 +230,44 @@ protected:
            const std::shared_ptr<DobbyUtils> p_utils = std::make_shared<DobbyUtils>();
            const std::shared_ptr<DobbyIPCUtils> p_ipcutils = std::make_shared<DobbyIPCUtils>("dobbymanager",nullptr);
 
-            EXPECT_CALL(dynamic_cast<DobbyUtilsMock&>(*p_utilsMock),writeTextFile(::testing::_, ::testing::_, ::testing::_, ::testing::_))
-                .Times(1)
-                    .WillOnce(::testing::Return(true));
+           EXPECT_CALL(*p_utilsMock,writeTextFile(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+               .Times(1)
+               .WillOnce(::testing::Return(true));
 
-            const std::string expectedWorkDir = "unit_tests/L1_testing/tests";
-            EXPECT_CALL(*p_runcMock, getWorkingDir())
-                .Times(1)
-                .WillOnce(::testing::Return(expectedWorkDir));
+           const std::string expectedWorkDir = "unit_tests/L1_testing/tests";
+           EXPECT_CALL(*p_runcMock, getWorkingDir())
+               .Times(2)
+               .WillRepeatedly(::testing::Return(expectedWorkDir));
 
-            dobbyManager_test = std::make_shared<NiceMock<DobbyManager>>(p_env,p_utils,p_ipcutils,p_dobbysettingsMock,startcb,stopcb);
-            /* Github issue: 294: pthread_kill() is failing in stopRuncMonitorThread() which is calling from destructor.
+           int32_t cd = 4444;
+           ContainerId id = ContainerId::create("UnknownContainer");
+           DobbyRunC::ContainerListItem container = { id, 1234, "/path/to/bundle",DobbyRunC::ContainerStatus::Unknown };
+           std::list<DobbyRunC::ContainerListItem> containers;
+
+           containers.emplace_back(container);
+
+           EXPECT_CALL(*p_runcMock, list())
+               .Times(1)
+               .WillOnce(::testing::Return(containers));
+
+           EXPECT_CALL(*p_containerMock, allocDescriptor())
+               .Times(1)
+               .WillOnce(::testing::Return(cd));
+
+           ON_CALL(*p_utilsMock, startTimerImpl(::testing::_,::testing::_,::testing::_))
+               .WillByDefault(::testing::Invoke(
+                   [this](const std::chrono::microseconds& timeout,
+                       bool oneShot,
+                      const std::function<bool()>& handler) {
+                      Test_invalidContainerCleanupTask = handler;
+           return 123456;
+           }));
+
+           dobbyManager_test = std::make_shared<NiceMock<DobbyManager>>(p_env,p_utils,p_ipcutils,p_dobbysettingsMock,startcb,stopcb);
+           /* Github issue: 294: pthread_kill() is failing in stopRuncMonitorThread() which is calling from destructor.
             * runcMonitorThread() is starting late, with in the time, if dobbymanager object is deleted, pthread_kill() is failing because the thread is not yet started.
             * 10ms sleep is added to avoid the time issue */
-            usleep(WAIT_TIME);
+           usleep(WAIT_TIME);
 
         }
 
@@ -398,7 +425,8 @@ protected:
 
 
         }
-        void expect_startContainerFromBundle(int32_t cd)
+
+        void expect_startContainerFromBundle(int32_t cd, ContainerId &id)
         {
             EXPECT_CALL(*p_bundleConfigMock, isValid())
                 .Times(1)
@@ -422,8 +450,7 @@ protected:
 
         // Set the expectation to return the sample data
             EXPECT_CALL(*p_bundleConfigMock, rdkPlugins())
-                .Times(2)
-                    .WillOnce(::testing::ReturnRef(sampleData))
+                .Times(1)
                     .WillOnce(::testing::ReturnRef(sampleData));
 
             EXPECT_CALL(*p_containerMock, allocDescriptor())
@@ -434,13 +461,8 @@ protected:
 
         // Set the expectation to return the valid path
             EXPECT_CALL(*p_rootfsMock, path())
-                .Times(6)
-                    .WillOnce(::testing::ReturnRef(validPath))
-                    .WillOnce(::testing::ReturnRef(validPath))
-                    .WillOnce(::testing::ReturnRef(validPath))
-                    .WillOnce(::testing::ReturnRef(validPath))
-                    .WillOnce(::testing::ReturnRef(validPath))
-                    .WillOnce(::testing::ReturnRef(validPath));
+                 .Times(4)
+                    .WillRepeatedly(::testing::ReturnRef(validPath));
 
             std::string valid_path = "/unit_tests/L1_testing/tests/DobbyManagerTest";
 
@@ -468,12 +490,8 @@ protected:
             data["key2"] = Json::Value("value2");
 
             EXPECT_CALL(*p_bundleConfigMock, legacyPlugins())
-                .Times(5)
-                    .WillOnce(testing::ReturnRef(data))
-                    .WillOnce(testing::ReturnRef(data))
-                    .WillOnce(testing::ReturnRef(data))
-                    .WillOnce(testing::ReturnRef(data))
-                    .WillOnce(testing::ReturnRef(data));
+                .Times(3)
+                    .WillRepeatedly(testing::ReturnRef(data));
 
             EXPECT_CALL(*p_legacyPluginManagerMock, executePostConstructionHooks(::testing::_, ::testing::_, ::testing::_, ::testing::_))
                 .Times(1)
@@ -510,8 +528,7 @@ protected:
                     .WillOnce(::testing::Return(std::list<int>{1, 2, 3}));
 
             EXPECT_CALL(*p_rdkPluginManagerMock, getContainerLogger())
-                .Times(2)
-                    .WillOnce(::testing::Return(std::make_shared<IDobbyRdkLoggingPluginMock>()))
+                .Times(1)
                     .WillOnce(::testing::Return(std::make_shared<IDobbyRdkLoggingPluginMock>()));
 
             pid_t pid1 = 1234;
@@ -531,20 +548,6 @@ protected:
                         return true;
             }));
 
-            EXPECT_CALL(*p_legacyPluginManagerMock, executePostStopHooks(::testing::_, ::testing::_,::testing::_))
-                .Times(1)
-                .WillOnce(::testing::Invoke(
-                [](const std::map<std::string, Json::Value>& plugins,const ContainerId& id,const std::string& rootfsPath) {
-                    return true;
-            }));
-
-            EXPECT_CALL(*p_legacyPluginManagerMock, executePreDestructionHooks(::testing::_, ::testing::_,::testing::_))
-                .Times(1)
-                .WillOnce(::testing::Invoke(
-                [](const std::map<std::string, Json::Value>& plugins,const ContainerId& id,const std::string& rootfsPath) {
-                    return true;
-            }));
-
             EXPECT_CALL(*p_runcMock, create(::testing::_,::testing::_,::testing::_,::testing::_,::testing::_))
                 .Times(1)
                     .WillOnce(::testing::Invoke(
@@ -553,17 +556,8 @@ protected:
             }));
 
             EXPECT_CALL(*p_loggerMock, DumpBuffer(::testing::_,::testing::_,::testing::_))
-                .Times(3)
-                    .WillOnce(::testing::Invoke(
-                    [](int bufferMemFd,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin){
-                        return true;
-            }))
-                    .WillOnce(::testing::Invoke(
-                    [](int bufferMemFd,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin){
-                        return true;
-            }))
-
-                .WillOnce(::testing::Invoke(
+                .Times(2)
+                .WillRepeatedly(::testing::Invoke(
                 [](int bufferMemFd,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin){
                     return true;
             }));
@@ -582,22 +576,6 @@ protected:
                         return true;
             }));
 
-            EXPECT_CALL(*p_runcMock, killCont(::testing::_,::testing::_,::testing::_))
-                .Times(1)
-                 .WillOnce(::testing::Invoke(
-                 [](const ContainerId &id, int signal, bool all) {
-                     return true;
-            }));
-
-            EXPECT_CALL(*p_runcMock, destroy(::testing::_,::testing::_,::testing::_))
-                .Times(1)
-                 .WillOnce(::testing::Invoke(
-                 [](const ContainerId &id, const std::shared_ptr<const IDobbyStream> &console, bool force) {
-                     return true;
-            }));
-
-
-            const ContainerId id = ContainerId::create("container_123");
             const std::string bundlePath = "/path/to/bundle";
             const std::list<int> files = {1, 2, 3};
             const std::string command = "ls -l";
@@ -612,7 +590,8 @@ protected:
             EXPECT_TRUE(waitForContainerStarted(MAX_TIMEOUT_CONTAINER_STARTED));
 
         }
-        #ifdef LEGACY_COMPONENTS
+
+#ifdef LEGACY_COMPONENTS
         void expect_startContainerFromSpec(int32_t cd)
         {
             EXPECT_CALL(*p_bundleMock, isValid())
@@ -800,10 +779,191 @@ protected:
             EXPECT_EQ(result, cd);
             EXPECT_TRUE(waitForContainerStarted(MAX_TIMEOUT_CONTAINER_STARTED));
 
-}
-     #endif //defined(LEGACY_COMPONENTS)
+        }
+#endif //defined(LEGACY_COMPONENTS)
 
-    };
+        /*Unknown container is added in SetUp(), so every test should call this function to remove unknown container */
+        void expect_invalidContainerCleanupTask()
+        {
+            ASSERT_NE(Test_invalidContainerCleanupTask,nullptr);
+            EXPECT_CALL(*p_runcMock, destroy(::testing::_,::testing::_,::testing::_))
+                .Times(1)
+                .WillOnce(::testing::Return(true));
+
+            Test_invalidContainerCleanupTask();
+        }
+
+        void expect_stopContainerOnCleanup()
+        {
+            EXPECT_CALL(*p_runcMock, killCont(::testing::_,::testing::_,::testing::_))
+                .Times(testing::AtLeast(1))
+                .WillRepeatedly(::testing::Invoke(
+                    [](const ContainerId &id, int signal, bool all) {
+                        return true;
+                    }));
+        }
+
+        void expect_handleContainerTerminate()
+        {
+            std::map<std::string, Json::Value> data;
+            data["key1"] = Json::Value("value1");
+            data["key2"] = Json::Value("value2");
+
+            EXPECT_CALL(*p_legacyPluginManagerMock, executePostStopHooks(::testing::_,::testing::_,::testing::_))
+                .Times(testing::AtLeast(1))
+                .WillRepeatedly(::testing::Return(true));
+
+            EXPECT_CALL(*p_bundleConfigMock, legacyPlugins())
+                .Times(testing::AtLeast(2))
+                .WillRepeatedly(testing::ReturnRef(data));
+
+            std::string valid_path = "/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp";
+            EXPECT_CALL(*p_rootfsMock, path())
+                .Times(testing::AtLeast(2))
+                .WillRepeatedly(::testing::ReturnRef(valid_path));
+
+            EXPECT_CALL(*p_containerMock, shouldRestart(::testing::_))
+                .Times(testing::AtLeast(1))
+                .WillRepeatedly(::testing::Return(false));
+
+            EXPECT_CALL(*p_legacyPluginManagerMock, executePreDestructionHooks(::testing::_,::testing::_,::testing::_))
+                .Times(testing::AtLeast(1))
+                .WillRepeatedly(::testing::Return(true));
+
+            std::map<std::string, Json::Value> sampleData;
+            sampleData["plugin1"] = Json::Value("value1");
+            sampleData["plugin2"] = Json::Value("value2");
+
+            /* Set the expectation to return the sample data */
+            EXPECT_CALL(*p_bundleConfigMock, rdkPlugins())
+                .Times(testing::AtLeast(1))
+                .WillRepeatedly(::testing::ReturnRef(sampleData));
+
+            EXPECT_CALL(*p_rdkPluginManagerMock, setExitStatus(::testing::_)).Times(testing::AtLeast(1));
+
+            EXPECT_CALL(*p_rdkPluginManagerMock, runPlugins(::testing::_,::testing::_))
+                .Times(testing::AtLeast(1))
+                .WillRepeatedly(::testing::Return(true));
+
+            EXPECT_CALL(*p_runcMock, destroy(::testing::_,::testing::_,::testing::_))
+                .Times(testing::AtLeast(1))
+                .WillRepeatedly(::testing::Return(true));
+
+            EXPECT_CALL(*p_rdkPluginManagerMock, getContainerLogger())
+                .Times(testing::AtLeast(1))
+                .WillRepeatedly(::testing::Return(std::make_shared<IDobbyRdkLoggingPluginMock>()));
+
+            EXPECT_CALL(*p_loggerMock, DumpBuffer(::testing::_,::testing::_,::testing::_))
+                .Times(testing::AtLeast(1))
+                .WillRepeatedly(::testing::Return(true));
+
+            EXPECT_CALL(*p_streamMock, getMemFd())
+                .Times(testing::AtLeast(1))
+                .WillRepeatedly(::testing::Return(123));
+
+        }
+
+        void expect_cleanupContainersShutdown()
+        {
+            expect_stopContainerOnCleanup();
+            expect_handleContainerTerminate();
+        }
+
+        void expect_stopContainerSuccess(int32_t containerState)
+        {
+            if (containerState == CONTAINER_STATE_PAUSED)
+            {
+                EXPECT_CALL(*p_runcMock,resume(::testing::_))
+                    .Times(1)
+                    .WillOnce(::testing::Invoke(
+                        [](const ContainerId &id){
+                            return true;
+                    }));
+
+                EXPECT_CALL(*p_runcMock, killCont(::testing::_,::testing::_,::testing::_))
+                    .Times(1)
+                    .WillOnce(::testing::Invoke(
+                        [](const ContainerId &id, int signal, bool all) {
+                            return true;
+                    }));
+            }
+            else if (containerState == CONTAINER_STATE_RUNNING)
+            {
+                EXPECT_CALL(*p_runcMock, killCont(::testing::_,::testing::_,::testing::_))
+                    .Times(1)
+                    .WillOnce(::testing::Invoke(
+                        [](const ContainerId &id, int signal, bool all) {
+                            return true;
+                    }));
+            }
+            else if (containerState == CONTAINER_STATE_INVALID)
+            {
+                return;
+            }
+        }
+
+        void expect_stopContainerFailedToResumeFromPausedState()
+        {
+            EXPECT_CALL(*p_runcMock,resume(::testing::_))
+                .Times(1)
+                .WillOnce(::testing::Invoke(
+                    [](const ContainerId &id){
+                        return false;
+                }));
+        }
+
+        void expect_stopContainerFailedToKillContainer()
+        {
+            EXPECT_CALL(*p_runcMock, killCont(::testing::_,::testing::_,::testing::_))
+                .Times(1)
+                .WillOnce(::testing::Invoke(
+                    [](const ContainerId &id, int signal, bool all) {
+                        return false;
+                }));
+        }
+
+        void expect_pauseContainerSuccess()
+        {
+            ContainerId id = ContainerId::create("container1");
+            EXPECT_CALL(*p_runcMock,pause(id))
+                .Times(1)
+                .WillOnce(::testing::Invoke(
+                [](const ContainerId &id){
+                    return true;
+                }));
+        }
+
+        void expect_pauseContainerFailed()
+        {
+            ContainerId id = ContainerId::create("container1");
+            EXPECT_CALL(*p_runcMock,pause(id))
+                .Times(1)
+                .WillOnce(::testing::Invoke(
+                [](const ContainerId &id){
+                    return false;
+                }));
+        }
+
+        void expect_resumeContainer_sucess(ContainerId &id)
+        {
+            EXPECT_CALL(*p_runcMock,resume(id))
+                .Times(1)
+                .WillOnce(::testing::Invoke(
+                [](const ContainerId &id){
+                     return true;
+                }));
+        }
+
+        void expect_resumeContainer_failed(ContainerId &id)
+        {
+            EXPECT_CALL(*p_runcMock,resume(id))
+                .Times(1)
+                .WillOnce(::testing::Invoke(
+                [](const ContainerId &id){
+                    return false;
+                }));
+        }
+};
 
         void DaemonDobbyManagerTest::onContainerStarted(int32_t cd, const ContainerId& id) {
             std::unique_lock<std::mutex> lock(m_mutex);
@@ -878,6 +1038,8 @@ protected:
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_ValidInputs)
 {
+    expect_invalidContainerCleanupTask();
+
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
         .WillOnce(::testing::Return(true));
@@ -1083,6 +1245,8 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_ValidInputs)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_SuccessWithoutRdkPlugins)
 {
+    expect_invalidContainerCleanupTask();
+
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
             .WillOnce(::testing::Return(true));
@@ -1239,6 +1403,8 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_SuccessWithoutRdkPlugins)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_InvalidBundleCreation)
 {
+    expect_invalidContainerCleanupTask();
+
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
             .WillOnce(::testing::Return(false));
@@ -1267,6 +1433,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_InvalidBundleCreation)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_InvalidConfigObject)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
@@ -1300,6 +1467,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_InvalidConfigObject)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_InvalidRootfsCreation)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
@@ -1337,6 +1505,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_InvalidRootfsCreation)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_InvalidStartStateObject)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
@@ -1378,6 +1547,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_InvalidStartStateObject)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_onPostConstructionHookFailure)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
@@ -1403,6 +1573,11 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_onPostConstructionHookFail
     EXPECT_CALL(*p_specConfigMock, rdkPlugins())
         .Times(1)
             .WillOnce(::testing::ReturnRef(sampleData));
+
+    int32_t cd = 123;
+    EXPECT_CALL(*p_containerMock, allocDescriptor())
+        .Times(1)
+            .WillOnce(::testing::Return(cd));
 
     const std::string validPath = "/unit_tests/L1_testing/tests/";
 
@@ -1470,6 +1645,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_onPostConstructionHookFail
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_WriteConfigJsonFailure)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
@@ -1497,6 +1673,11 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_WriteConfigJsonFailure)
             .WillOnce(::testing::ReturnRef(sampleData));
 
     const std::string validPath = "/unit_tests/L1_testing/tests/";
+
+    int32_t cd = 123;
+    EXPECT_CALL(*p_containerMock, allocDescriptor())
+        .Times(1)
+            .WillOnce(::testing::Return(cd));
 
 // Set the expectation to return the valid path
     EXPECT_CALL(*p_rootfsMock, path())
@@ -1589,8 +1770,10 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_WriteConfigJsonFailure)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_FailedAsContainerAlreadyRunning)
 {
+    expect_invalidContainerCleanupTask();
 
-    expect_startContainerFromBundle(123);
+    ContainerId id1 = ContainerId::create("container_123");
+    expect_startContainerFromBundle(123,id1);
 
     ContainerId id = ContainerId::create("container_123");
     std::string jsonSpec = "{\"key\": \"value\", \"number\": 42}";
@@ -1615,6 +1798,8 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_FailedAsContainerAlreadyRu
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_CreateAndStartContainerFailure)
 {
+    expect_invalidContainerCleanupTask();
+
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
             .WillOnce(::testing::Return(true));
@@ -1641,6 +1826,11 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_CreateAndStartContainerFai
             .WillOnce(::testing::ReturnRef(sampleData))
 
             .WillOnce(::testing::ReturnRef(sampleData));
+
+    int32_t cd = 123;
+    EXPECT_CALL(*p_containerMock, allocDescriptor())
+        .Times(1)
+            .WillOnce(::testing::Return(cd));
 
     const std::string validPath = "/unit_tests/L1_testing/tests/";
 
@@ -1749,6 +1939,10 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_CreateAndStartContainerFai
                 return false;
     }));
 
+    EXPECT_CALL(*p_runcMock, destroy(::testing::_,::testing::_,::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(true));
+
     ContainerId id = ContainerId::create("container_123");
     std::string jsonSpec = "{\"key\": \"value\", \"number\": 42}";
     std::list<int> files = {1, 2, 3};//file descriptors
@@ -1792,6 +1986,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromSpec_CreateAndStartContainerFai
 
 TEST_F(DaemonDobbyManagerTest, createBundle_Success)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
@@ -1845,6 +2040,8 @@ TEST_F(DaemonDobbyManagerTest, createBundle_Success)
 
 TEST_F(DaemonDobbyManagerTest, createBundle_BundleFailure)
 {
+    expect_invalidContainerCleanupTask();
+
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
             .WillOnce(::testing::Return(false));
@@ -1865,6 +2062,7 @@ TEST_F(DaemonDobbyManagerTest, createBundle_BundleFailure)
 
 TEST_F(DaemonDobbyManagerTest, createBundle_CreateConfigObjectFailure)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
@@ -1890,6 +2088,7 @@ TEST_F(DaemonDobbyManagerTest, createBundle_CreateConfigObjectFailure)
 
 TEST_F(DaemonDobbyManagerTest, createBundle_RootfsCreationFailure)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleMock, isValid())
         .Times(1)
@@ -1913,7 +2112,6 @@ TEST_F(DaemonDobbyManagerTest, createBundle_RootfsCreationFailure)
 }
 
 #endif //defined(LEGACY_COMPONENTS)
-
 
 /*Test cases for createBundle ends here*/
 
@@ -1946,6 +2144,7 @@ TEST_F(DaemonDobbyManagerTest, createBundle_RootfsCreationFailure)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_CreateConfigObjectFailure)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleConfigMock, isValid())
         .Times(1)
@@ -1975,6 +2174,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_CreateConfigObjectFailur
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_DobbyBundleFailure)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleConfigMock, isValid())
         .Times(1)
@@ -2008,6 +2208,8 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_DobbyBundleFailure)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_RootfsCreationFailure)
 {
+    expect_invalidContainerCleanupTask();
+
     EXPECT_CALL(*p_bundleConfigMock, isValid())
         .Times(1)
             .WillOnce(::testing::Return(true));
@@ -2044,6 +2246,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_RootfsCreationFailure)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_StartStateObjectFailure)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleConfigMock, isValid())
         .Times(1)
@@ -2085,6 +2288,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_StartStateObjectFailure)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_onPostConstructionHookFailure)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleConfigMock, isValid())
         .Times(1)
@@ -2110,6 +2314,11 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_onPostConstructionHookFa
     EXPECT_CALL(*p_bundleConfigMock, rdkPlugins())
         .Times(1)
             .WillOnce(::testing::ReturnRef(sampleData));
+
+    int32_t cd = 123;
+    EXPECT_CALL(*p_containerMock, allocDescriptor())
+        .Times(1)
+            .WillOnce(::testing::Return(cd));
 
     const std::string validPath = "/unit_tests/L1_testing/tests/";
 
@@ -2178,6 +2387,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_onPostConstructionHookFa
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_ConfigJsonFileCreationFailure)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleConfigMock, isValid())
         .Times(1)
@@ -2203,6 +2413,11 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_ConfigJsonFileCreationFa
     EXPECT_CALL(*p_bundleConfigMock, rdkPlugins())
         .Times(1)
             .WillOnce(::testing::ReturnRef(sampleData));
+
+    int32_t cd = 123;
+    EXPECT_CALL(*p_containerMock, allocDescriptor())
+        .Times(1)
+            .WillOnce(::testing::Return(cd));
 
     const std::string validPath = "/unit_tests/L1_testing/tests/";
 
@@ -2296,8 +2511,12 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_ConfigJsonFileCreationFa
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_ValidInputs)
 {
+    expect_invalidContainerCleanupTask();
 
-    expect_startContainerFromBundle(123);
+    ContainerId id = ContainerId::create("container1");
+    expect_startContainerFromBundle(123,id);
+
+    expect_cleanupContainersShutdown();
 }
 
 
@@ -2309,8 +2528,10 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_ValidInputs)
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_FailedAsContainerAlreadyRunning)
 {
+    expect_invalidContainerCleanupTask();
 
-    expect_startContainerFromBundle(123);
+    ContainerId id1 = ContainerId::create("container_123");
+    expect_startContainerFromBundle(123,id1);
 
     const ContainerId id = ContainerId::create("container_123");
     const std::string bundlePath = "/path/to/bundle";
@@ -2336,7 +2557,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_FailedAsContainerAlready
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_SuccessWithoutRdkPlugins)
 {
-//system("touch ./config-0.json");
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleConfigMock, isValid())
         .Times(1)
@@ -2490,6 +2711,7 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_SuccessWithoutRdkPlugins
 
 TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_CreateAndStartContainerFailure)
 {
+    expect_invalidContainerCleanupTask();
 
     EXPECT_CALL(*p_bundleConfigMock, isValid())
         .Times(1)
@@ -2516,6 +2738,11 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_CreateAndStartContainerF
         .Times(2)
             .WillOnce(::testing::ReturnRef(sampleData))
             .WillOnce(::testing::ReturnRef(sampleData));
+
+    int32_t cd = 123;
+    EXPECT_CALL(*p_containerMock, allocDescriptor())
+        .Times(1)
+            .WillOnce(::testing::Return(cd));
 
     const std::string validPath = "/unit_tests/L1_testing/tests/";
 
@@ -2623,6 +2850,9 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_CreateAndStartContainerF
                  return true;
         }));
 
+    EXPECT_CALL(*p_runcMock, destroy(::testing::_,::testing::_,::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(true));
 
     const ContainerId id = ContainerId::create("container_123");
     const std::string bundlePath = "/path/to/bundle";
@@ -2638,6 +2868,620 @@ TEST_F(DaemonDobbyManagerTest, startContainerFromBundle_CreateAndStartContainerF
 
     EXPECT_EQ(result, DobbyErrorValue);
 
+}
+
+/* -----------------------------------------------------------------------------
+ *  @brief Stops a running container
+ *
+ *  If withPrejudice is not specified (the default) then we send the init
+ *  process within the container a SIGTERM.
+ *
+ *  If the withPrejudice is true then we use the SIGKILL signal.
+ *
+ *  This call is asynchronous, i.e. it is a request to stop rather than a
+ *  blocking call that ensures the container is stopped before returning.
+ *
+ *  The @a mContainerStoppedCb callback will be called when the container
+ *  has actually been torn down.
+ *
+ *  @param[in]  cd              The descriptor of the container to stop.
+ *  @param[in]  withPrejudice   If true the container process is killed with
+ *                              SIGKILL, otherwise SIGTERM is used.
+ *
+ *  @return true if a container with a matching id was found and a signal
+ *  sent successfully to it.
+ *
+ * Use case coverage:
+ *                @Success :3
+ *                @Failure :4
+ *  -----------------------------------------------------------------------------
+*/
+
+/**
+ * @brief Test stopContainer.
+ * Check the stopContainer method failed to find the invalid descriptor Id
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, stopContainer_FailedToFindTheContainer)
+{
+    expect_invalidContainerCleanupTask();
+
+    ContainerId id = ContainerId::create("container1");
+    expect_startContainerFromBundle(3456,id);
+
+    /* set stop container with unknow descriptor value */
+    int return_value = dobbyManager_test->stopContainer(1234,true);
+    EXPECT_EQ(return_value,false);
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test stopContainer.
+ * Check the stopContainer method find the valid descriptor Id from containers list and stop the container.
+ *
+ * @return true.
+ */
+TEST_F(DaemonDobbyManagerTest, stopContainer_SuccessWithMultipleContainers)
+{
+    ContainerId id = ContainerId::create("container1");
+    ContainerId id1 = ContainerId::create("container2");
+    ContainerId id2 = ContainerId::create("container3");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(1234,id);
+    expect_startContainerFromBundle(2345,id1);
+    expect_startContainerFromBundle(3456,id2);
+
+    expect_stopContainerSuccess(dobbyManager_test->stateOfContainer(2345));
+    int return_value = dobbyManager_test->stopContainer(2345,true);
+    EXPECT_EQ(return_value,true);
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test stopContainer.
+ * Check the stopContainer method find the valid descriptor Id and stop the container.
+ *
+ * @return true.
+ */
+TEST_F(DaemonDobbyManagerTest, stopContainer_SuccessWithOneContainer)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    /* stopContainer is called from the cleanup shutdown */
+    expect_stopContainerSuccess(dobbyManager_test->stateOfContainer(cd));
+    int return_value = dobbyManager_test->stopContainer(cd,true);
+    EXPECT_EQ(return_value,true);
+
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test stopContainer.
+ * Check the stopContainer method find the valid descriptor Id and stop the unknown state container.
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, stopContainer_UnknownContainerState)
+{
+    int32_t cd = 1234;
+    int32_t stop_cd = 4444;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_startContainerFromBundle(cd,id);
+
+    /* stopContainer is called from the cleanup shutdown */
+    expect_stopContainerSuccess(dobbyManager_test->stateOfContainer(stop_cd));
+    int return_value = dobbyManager_test->stopContainer(stop_cd,true);
+    EXPECT_EQ(return_value,false);
+
+    expect_invalidContainerCleanupTask();
+
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test stopContainer.
+ * Check the stopContainer method find the valid descriptor Id and stop the paused container .
+ *
+ * @return true.
+ */
+TEST_F(DaemonDobbyManagerTest, stopContainer_ContainerStatePaused)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    expect_pauseContainerSuccess();
+
+    int return_value = dobbyManager_test->pauseContainer(cd);
+    EXPECT_EQ(return_value,true);
+
+    expect_stopContainerSuccess(dobbyManager_test->stateOfContainer(cd));
+    return_value = dobbyManager_test->stopContainer(cd,true);
+    EXPECT_EQ(return_value,true);
+}
+
+/**
+ * @brief Test stopContainer.
+ * Check the stopContainer method find the valid descriptor Id and failed to resume and stop the paused container.
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, stopContainer_FailedToResumeFromPausedState)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    expect_pauseContainerSuccess();
+
+    int return_value = dobbyManager_test->pauseContainer(cd);
+    EXPECT_EQ(return_value,true);
+
+    expect_stopContainerFailedToResumeFromPausedState();
+    return_value = dobbyManager_test->stopContainer(cd,true);
+    EXPECT_EQ(return_value,false);
+
+    expect_resumeContainer_sucess(id);
+    return_value = dobbyManager_test->resumeContainer(cd);
+    EXPECT_EQ(return_value,true);
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test stopContainer.
+ * Check the stopContainer method find the valid descriptor Id and failed to stop on killContainer call.
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, stopContainer_FailedToSendSignal)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    expect_stopContainerFailedToKillContainer();
+    int return_value = dobbyManager_test->stopContainer(cd,false);
+    EXPECT_EQ(return_value,false);
+
+    expect_cleanupContainersShutdown();
+}
+
+/* -----------------------------------------------------------------------------
+ *  @brief Gets the stats for the container
+ *
+ *  This is primarily a debugging method, used to get statistics on the
+ *  container and roughly correlates to the 'runc events --stats <id>' call.
+ *
+ *  The reply is a json formatted string containing some info, it's form may
+ *  change over time.
+ *
+ *      {
+ *          "id": "blah",
+ *          "state": "running",
+ *          "timestamp": 348134887768,
+ *          "pids": [ 1234, 1245 ],
+ *          "cpu": {
+ *              "usage": {
+ *                  "total":734236982,
+ *                  "percpu":[348134887,386102095]
+ *              }
+ *          },
+ *          "memory":{
+ *              "user": {
+ *                  "limit":41943040,
+ *                  "usage":356352,
+ *                  "max":524288,
+ *                  "failcnt":0
+ *              }
+ *          }
+ *          "gpu":{
+ *              "memory": {
+ *                  "limit":41943040,
+ *                  "usage":356352,
+ *                  "max":524288,
+ *                  "failcnt":0
+ *              }
+ *          }
+ *          ...
+ *      }
+ *
+ *  @param[in]  cd      The container descriptor
+ *
+ *  @return Json formatted string with the info for the container, on failure an
+ *  empty string.
+ *
+ * Use case coverage:
+ *                @Success :2
+ *                @Failure :1
+ * -----------------------------------------------------------------------------
+ */
+
+/**
+ * @brief Test statsOfContainer.
+ * Check the statsOfContainer method find state after startContainer without failure.
+ *
+ * @return DobbyContainer state.
+ */
+TEST_F(DaemonDobbyManagerTest, statsOfContainer_Success)
+{
+    std::string expected_string("{\n \"id\" : \"container1\",\n \"state\" : \"running\"\n}");
+    int32_t cd = 1234;
+    Json::Value jsonStats;
+
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+    expect_startContainerFromBundle(cd,id);
+
+    EXPECT_CALL(*p_statsMock,stats())
+        .Times(1)
+        .WillOnce(::testing::ReturnRef(jsonStats));
+
+    std::string actual_string= dobbyManager_test->statsOfContainer(cd);
+    EXPECT_EQ(actual_string,expected_string);
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test statsOfContainer.
+ * Check the statsOfContainer method find state of unknown container without failure.
+ *
+ * @return DobbyContainer state.
+ */
+TEST_F(DaemonDobbyManagerTest, statsOfContainer_EmptyString)
+{
+    std::string expected_string("{\n \"id\" : \"UnknownContainer\",\n \"state\" : \"unknown\"\n}");
+    int32_t cd = 4444;
+    Json::Value jsonStats;
+
+    EXPECT_CALL(*p_statsMock,stats())
+        .Times(1)
+        .WillOnce(::testing::ReturnRef(jsonStats));
+
+    std::string actual_string= dobbyManager_test->statsOfContainer(cd);
+    EXPECT_EQ(actual_string,expected_string);
+
+    expect_invalidContainerCleanupTask();
+
+}
+
+/**
+ * @brief Test statsOfContainer.
+ * Check the statsOfContainer method find state after Paused Container without failure.
+ *
+ * @return DobbyContainer state.
+ */
+TEST_F(DaemonDobbyManagerTest, statsOfContainer_FailedToFindContainer)
+{
+    std::string expected_string;
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+    Json::Value jsonStats;
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    std::string actual_string= dobbyManager_test->statsOfContainer(2345);
+    EXPECT_EQ(actual_string,expected_string);
+    expect_cleanupContainersShutdown();
+}
+
+/* -----------------------------------------------------------------------------
+ *  @brief Returns the state of a given container
+ *
+ *
+ *
+ *  @param[in]  cd      The descriptor of the container to get the state of.
+ *
+ *  @return one of the possible state values.
+ * Use case coverage:
+ *                @Success :2
+ *                @Failure :1
+ * -----------------------------------------------------------------------------
+ */
+
+/**
+ * @brief Test stateOfContainer.
+ * Check the stateOfContainer method find state after startContainer without failure.
+ *
+ * @return DobbyContainer state.
+ */
+TEST_F(DaemonDobbyManagerTest, stateOfContainer_SuccessWhenContainerRunning)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    int return_value = dobbyManager_test->stateOfContainer(cd);
+    EXPECT_EQ(return_value,CONTAINER_STATE_RUNNING);
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test stateOfContainer.
+ * Check the stateOfContainer method find state after pausedContainer without failure.
+ *
+ * @return DobbyContainer state.
+ */
+TEST_F(DaemonDobbyManagerTest, stateOfContainer_SuccessWhenContainerPaused)
+{
+    int32_t cd = 1234;
+    int return_value;
+
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    expect_pauseContainerSuccess();
+    return_value = dobbyManager_test->pauseContainer(cd);
+    EXPECT_EQ(return_value,true);
+
+    return_value = dobbyManager_test->stateOfContainer(cd);
+    EXPECT_EQ(return_value,CONTAINER_STATE_PAUSED);
+}
+
+/**
+ * @brief Test statsOfContainer.
+ * Check the statsOfContainer method failed to find container Id.
+ *
+ * @return DobbyContainer state.
+ */
+TEST_F(DaemonDobbyManagerTest, stateOfContainer_FailedToFindContainer)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    int return_value = dobbyManager_test->stateOfContainer(2345);
+
+    EXPECT_EQ(return_value,CONTAINER_STATE_INVALID);
+    expect_cleanupContainersShutdown();
+}
+
+/* -----------------------------------------------------------------------------
+ *  @brief Freezes a running container
+ *
+ *  Currently we have no use case for pause/resume containers so the method
+ *  hasn't been implemented, however when testing manually I've discovered it
+ *  actually works quite well.
+ *
+ *  If wanting to have a play you can run the following on the command line
+ *
+ *      runc --root /var/run/runc pause <id>
+ *
+ *  @param[in]  cd      The descriptor of the container to pause.
+ *
+ *  @return true if a container with a matching descriptor was found and it was
+ *  frozen.
+ * Use case coverage:
+ *                @Success :1
+ *                @Failure :3
+ * -----------------------------------------------------------------------------
+ */
+
+/**
+ * @brief Test pauseContainer with valid arguments.
+ * Check if pauseContainer method handles the case with valid,
+ *
+ * @return true.
+ */
+TEST_F(DaemonDobbyManagerTest, pauseContainer_ValidInput)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    expect_pauseContainerSuccess();
+    int return_value = dobbyManager_test->pauseContainer(cd);
+    EXPECT_EQ(return_value,true);
+
+    expect_resumeContainer_sucess(id);
+    return_value = dobbyManager_test->resumeContainer(cd);
+    EXPECT_EQ(return_value,true);
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test pauseContainer with invalid container Id.
+ * Check if pauseContainer method failed to find the containter Id, then It will return false,
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, pauseContainer_FailedToFindContainer)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    int return_value = dobbyManager_test->pauseContainer(2345);
+    EXPECT_EQ(return_value,false);
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test pauseContainer with valid arguments.
+ * Check if pauseContainer method handles the case with valid arguments and failed to pause the container.
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, pauseContainer_FailedToPauseContainer)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    expect_pauseContainerFailed();
+    int return_value = dobbyManager_test->pauseContainer(cd);
+    EXPECT_EQ(return_value,false);
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test pauseContainer with valid arguments.
+ * Check if pauseContainer method verify the container already paused, then It will avoid the pause call.
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, pauseContainer_FailedAsAlreadyPaused)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    /* Freezes a running container and set the container state to puased */
+    expect_pauseContainerSuccess();
+    int return_value = dobbyManager_test->pauseContainer(cd);
+    EXPECT_EQ(return_value,true);
+
+    /* Freezes a puased container, and it will failed */
+    return_value = dobbyManager_test->pauseContainer(cd);
+    EXPECT_EQ(return_value,false);
+
+    /* Resume a puased container, before stop container we should resume the container */
+    expect_resumeContainer_sucess(id);
+    return_value = dobbyManager_test->resumeContainer(cd);
+    EXPECT_EQ(return_value,true);
+    expect_cleanupContainersShutdown();
+}
+
+
+/* -----------------------------------------------------------------------------
+ *  @brief Thaws a frozen container
+ *
+ *  @param[in]  cd      The descriptor of the container to resume.
+ *
+ *  @return true if a container with a matching descriptor was found and it was
+ *  resumed.
+ * Use case coverage:
+ *                @Success :1
+ *                @Failure :3
+ *-----------------------------------------------------------------------------
+ */
+
+/**
+ * @brief Test resumeContainer with valid arguments.
+ * Check if resumeContainer method resume the paused container for descriptor Id from input argument,
+ *
+ * @return true.
+ */
+TEST_F(DaemonDobbyManagerTest, resumeContainer_Success)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    expect_pauseContainerSuccess();
+    int return_value = dobbyManager_test->pauseContainer(cd);
+    EXPECT_EQ(return_value,true);
+
+    expect_resumeContainer_sucess(id);
+    return_value = dobbyManager_test->resumeContainer(cd);
+    EXPECT_EQ(return_value,true);
+    expect_cleanupContainersShutdown();
+}
+
+/**
+ * @brief Test resumeContainer with invalid container Id.
+ * Check if resumeContainer method failed to find the containter Id, then It will return false,
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, resumeContainer_FailedToFindContainer)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    int return_value = dobbyManager_test->resumeContainer(2345);
+    EXPECT_EQ(return_value,false);
+    expect_cleanupContainersShutdown();
+}
+
+
+/**
+ * @brief Test resumeContainer with valid arguments.
+ * Check if resumeContainer method resume the paused container and failed to resume the container.
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, resumeContainer_FailedToResume)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    expect_pauseContainerSuccess();
+    int return_value = dobbyManager_test->pauseContainer(cd);
+    EXPECT_EQ(return_value,true);
+
+    expect_resumeContainer_failed(id);
+    return_value = dobbyManager_test->resumeContainer(cd);
+    EXPECT_EQ(return_value,false);
+}
+
+/**
+ * @brief Test resumeContainer with valid arguments.
+ * Check the resumeContainer method not resume, if the container is not paused
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, resumeContainer_FailureAsNotInPausedState)
+{
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    /* We can only resume a container that's currently paused */
+    int return_value = dobbyManager_test->resumeContainer(cd);
+    EXPECT_EQ(return_value,false);
+    expect_cleanupContainersShutdown();
 }
 
 /*Test cases for startContainerFromBundle ends here*/
@@ -2666,10 +3510,13 @@ TEST_F(DaemonDobbyManagerTest, ociConfigOfContainer_Success)
     std::string expect_string("{\n \"id\" : \"container1\",\n \"state\" : \"running\"\n}");
     int32_t cd = 1234;
 
+    expect_invalidContainerCleanupTask();
+
 #ifdef LEGACY_COMPONENTS
-        expect_startContainerFromSpec(cd);
+    expect_startContainerFromSpec(cd);
 #else
-        expect_startContainerFromBundle(cd);
+    ContainerId id = ContainerId::create("container1");
+    expect_startContainerFromBundle(cd,id);
 #endif /* LEGACY_COMPONENTS */
 
     EXPECT_CALL(*p_configMock, configJson())
@@ -2693,10 +3540,13 @@ TEST_F(DaemonDobbyManagerTest, ociConfigOfContainer_FailedToFindContainer)
     std::string expect_string("");
     int32_t cd = 1234;
 
+    expect_invalidContainerCleanupTask();
+
 #ifdef LEGACY_COMPONENTS
-        expect_startContainerFromSpec(cd);
+    expect_startContainerFromSpec(cd);
 #else
-        expect_startContainerFromBundle(cd);
+    ContainerId id = ContainerId::create("container1");
+    expect_startContainerFromBundle(cd,id);
 #endif /* LEGACY_COMPONENTS */
 
     std::string result = dobbyManager_test->ociConfigOfContainer(2345);
@@ -2716,10 +3566,13 @@ TEST_F(DaemonDobbyManagerTest, ociConfigOfContainer_EmptyOCIConfigJsonSpec)
     std::string empty_string("{}");
     int32_t cd = 123;
 
+    expect_invalidContainerCleanupTask();
+
 #ifdef LEGACY_COMPONENTS
-        expect_startContainerFromSpec(cd);
+    expect_startContainerFromSpec(cd);
 #else
-        expect_startContainerFromBundle(cd);
+    ContainerId id = ContainerId::create("container1");
+    expect_startContainerFromBundle(cd,id);
 #endif /* LEGACY_COMPONENTS */
 
     EXPECT_CALL(*p_configMock, configJson())
@@ -2759,6 +3612,7 @@ TEST_F(DaemonDobbyManagerTest, specOfContainer_FailedToFindContainer)
 
     std::string expected_string("");
     int32_t cd = 1234;
+    expect_invalidContainerCleanupTask();
 
     expect_startContainerFromSpec(cd);
 
@@ -2782,6 +3636,7 @@ TEST_F(DaemonDobbyManagerTest, specOfContainer_SuccessWhenStarting)
 
     std::string expected_string("{\n \"id\" : \"container1\",\n \"state\" : \"running\"\n}");
     int32_t cd = 1234;
+    expect_invalidContainerCleanupTask();
 
     expect_startContainerFromSpec(1234);
 
@@ -2801,6 +3656,7 @@ TEST_F(DaemonDobbyManagerTest, specOfContainer_EmptyJsonSpec)
 
     std::string empty_string("{}");
     int32_t cd = 123;
+    expect_invalidContainerCleanupTask();
 
     expect_startContainerFromSpec(123);
 
@@ -2816,3 +3672,214 @@ TEST_F(DaemonDobbyManagerTest, specOfContainer_EmptyJsonSpec)
 
 /*specOfContainer usecases ends here*/
 
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Executes a command in a running container
+ *
+ *  @param[in]  cd          The descriptor of the container to execute the command in.
+ *  @param[in]  command     Command to be executed.
+ *  @param[in]  options     Options to execute the command with.
+ *
+ *  @return true if a container with a matching descriptor was found and the command was run
+ *
+ * Use case coverage:
+ *                @Success :1
+ *                @Failure :3
+ *-----------------------------------------------------------------------------
+ */
+/* Test the exec running container success and return non zero pid */
+TEST_F(DaemonDobbyManagerTest, execInContainer_Success)
+{
+    pid_t pid1 = 1234;
+    pid_t pid2 = 5678;
+    std::string options = "--tty";
+    std::string command = "fork exec";
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+    expect_startContainerFromBundle(cd,id);
+
+    EXPECT_CALL(*p_runcMock,exec(::testing::_,::testing::_,::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(std::make_pair(pid1, pid2)));
+
+    EXPECT_CALL(*p_rdkPluginManagerMock, getContainerLogger())
+        .Times(1)
+        .WillOnce(::testing::Return(std::make_shared<IDobbyRdkLoggingPluginMock>()));
+
+    EXPECT_CALL(*p_loggerMock, StartContainerLogging(::testing::_,::testing::_,::testing::_,::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(true));
+
+    bool return_value = dobbyManager_test->execInContainer(cd, options, command);
+    EXPECT_EQ(return_value,true);
+
+}
+
+/* Test the exec failed to get valid container */
+TEST_F(DaemonDobbyManagerTest, execInContainer_FailedToFindContainer)
+{
+    std::string options = "--tty";
+    std::string command = "fork exec";
+    int32_t cd = 1234;
+    int32_t expect_cd = 2345;
+
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    bool return_value = dobbyManager_test->execInContainer(expect_cd, options, command);
+    EXPECT_EQ(return_value,false);
+
+}
+
+/* Test the exec command and return a pid is zero */
+TEST_F(DaemonDobbyManagerTest, execInContainer_FailedToExecuteCommand)
+{
+    pid_t pid1 = 1234;
+    pid_t pid2 = 0;
+    std::string options = "--tty";
+    std::string command = "fork exec";
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    EXPECT_CALL(*p_runcMock,exec(::testing::_,::testing::_,::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(std::make_pair(pid1, pid2)));
+
+    bool return_value = dobbyManager_test->execInContainer(cd, options, command);
+    EXPECT_EQ(return_value,false);
+
+}
+
+/* Test the exec command failed to excecute paused container, exec command process the running container only */
+TEST_F(DaemonDobbyManagerTest, execInContainer_FailureAsContainerNotRunning)
+{
+    bool return_value;
+    pid_t pid1 = 1234;
+    pid_t pid2 = 0;
+    std::string options = "--tty";
+    std::string command = "fork exec";
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    expect_pauseContainerSuccess();
+
+    /* Container move to paused state */
+    return_value = dobbyManager_test->pauseContainer(cd);
+    EXPECT_EQ(return_value,true);
+
+    /*No expect call, if the container not in running state */
+    return_value = dobbyManager_test->execInContainer(cd, options, command);
+    EXPECT_EQ(return_value,false);
+
+}
+/*execInContainer usecases ends here*/
+
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Returns a list of all the containers
+ *
+ *  The returned list contains the id of all the containers we know about in
+ *  their various states.  Just because a container id is in the list it
+ *  doesn't necessarily mean it's actually running, it could be in either
+ *  the starting or stopping phase.
+ *
+ *  @see DobbyManager::stateOfContainer for a way to retrieve the
+ *  status of the container.
+ *
+ *  @return a list of all the containers.
+ *
+ * Use case coverage:
+ *                @Success :3
+ *                @Failure :0
+ *-----------------------------------------------------------------------------
+
+ */
+/* Test the listContainers success, returns the valid containers list */
+TEST_F(DaemonDobbyManagerTest, listContainers)
+{
+    std::vector<int32_t> cds = { 1234, 2345,3456};
+    std::vector<ContainerId>ids(3);
+    ids[0] = ContainerId::create("container1");
+    ids[1] = ContainerId::create("container2");
+    ids[2] = ContainerId::create("container3");
+
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cds[0],ids[0]);
+    expect_startContainerFromBundle(cds[1],ids[1]);
+    expect_startContainerFromBundle(cds[2],ids[2]);
+
+    std::list<std::pair<int32_t, ContainerId>> containers = dobbyManager_test->listContainers();
+
+    size_t n = 0;
+    for (const std::pair<int32_t, ContainerId>& details : containers)
+    {
+        EXPECT_EQ(details.first,cds[n]);
+        EXPECT_EQ(details.second.mId,ids[n].mId);
+        n++;
+    }
+    expect_cleanupContainersShutdown();
+}
+
+/* Test the listContainers without start container, returns the empty containers list */
+TEST_F(DaemonDobbyManagerTest, listContainers_WhenListIsEmpty)
+{
+    EXPECT_CALL(*p_runcMock, destroy(::testing::_,::testing::_,::testing::_))
+        .Times(testing::AtLeast(1))
+        .WillRepeatedly(::testing::Return(true));
+
+    /* Removed UnknownContainer and no containers added */
+    Test_invalidContainerCleanupTask();
+    Test_invalidContainerCleanupTask = nullptr;
+
+    std::list<std::pair<int32_t, ContainerId>> containers = dobbyManager_test->listContainers();
+
+    /* expect the containers list is count */
+    EXPECT_EQ(containers.size(),0);
+}
+
+/* Test the listContainers to get huge start containers, returns the valid containers list. Verifies the all containers data */
+TEST_F(DaemonDobbyManagerTest, listContainers_WhenListIsHuge)
+{
+    std::vector<int32_t> cds(LIST_CONTAINERS_HUGE_COUNT);
+    std::vector<ContainerId>ids(LIST_CONTAINERS_HUGE_COUNT);
+    std::string s[LIST_CONTAINERS_HUGE_COUNT];
+
+    expect_invalidContainerCleanupTask();
+
+    for (size_t i = 0; i < LIST_CONTAINERS_HUGE_COUNT; i++)
+    {
+        s[i] = "container" + std::to_string(i + 1);
+        ids[i] = ContainerId::create(s[i]);
+        cds[i] = i+1;
+
+        expect_startContainerFromBundle(cds[i],ids[i]);
+    }
+
+    std::list<std::pair<int32_t, ContainerId>> containers = dobbyManager_test->listContainers();
+
+    EXPECT_EQ(containers.size(),LIST_CONTAINERS_HUGE_COUNT);
+
+    size_t n = 0;
+    for (const std::pair<int32_t, ContainerId>& details : containers)
+    {
+        EXPECT_EQ(details.first,cds[n]);
+        EXPECT_EQ(details.second.mId,ids[n].mId);
+        n++;
+    }
+    expect_cleanupContainersShutdown();
+}
+/* listContainers usecases ends here*/


### PR DESCRIPTION
These are the completed use cases API list
[RDK-44357] - API list 2
DobbyManager::stopContainer()
DobbyManager::pauseContainer()
DobbyManager::resumeContainer()
DobbyManager::stateOfContainer()
DobbyManager::statsOfContainer()
[RDK-44358] - API list 3
DobbyManager::execInContainer()
DobbyManager::listContainers()

[RDK-45574] Enhancing the L1 Unit Test for Dobby.h - Added a few use cases in Dobby
Dobby::run()
Dobby::setDefaultAIDbusAddresses()

### Type of Change
- [ ] New feature (non-breaking change which adds functionality)

### Requires Bitbake Recipe changes?
- [ ] None