### PR TITLE
RDK-45937-Add valgrind to check the memory leak

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: install-dependencies
         run: |
           sudo apt-get update -y -q
-          sudo apt-get install -q -y automake libtool autotools-dev software-properties-common build-essential cmake libsystemd-dev libctemplate-dev libjsoncpp-dev libdbus-1-dev libnl-3-dev libnl-route-3-dev libsystemd-dev libyajl-dev libcap-dev libboost-dev lcov clang
+          sudo apt-get install -q -y automake libtool autotools-dev software-properties-common build-essential cmake libsystemd-dev libctemplate-dev libjsoncpp-dev libdbus-1-dev libnl-3-dev libnl-route-3-dev libsystemd-dev libyajl-dev libcap-dev libboost-dev lcov clang valgrind
 
       - name: Set clang toolchain
         if: ${{ matrix.compiler == 'clang' }}
@@ -47,7 +47,7 @@ jobs:
       - name: Install gmock
         run: |
          cd $GITHUB_WORKSPACE
-         git clone https://github.com/google/googletest.git
+         git clone https://github.com/google/googletest.git -b release-1.11.0
          cd googletest
          mkdir build
          cd build
@@ -71,9 +71,9 @@ jobs:
       - name: run unit-tests
         if: ${{ matrix.extra_flags == 'RUN_TESTS' && matrix.build_type == 'Debug' }}
         run: |
-          sudo $GITHUB_WORKSPACE/build/unit_tests/L1_testing/tests/DobbyTest/DobbyL1Test
+          sudo valgrind --tool=memcheck --leak-check=yes --show-reachable=yes --track-fds=yes --fair-sched=try $GITHUB_WORKSPACE/build/unit_tests/L1_testing/tests/DobbyTest/DobbyL1Test
           sudo $GITHUB_WORKSPACE/build/unit_tests/L1_testing/tests/DobbyUtilsTest/DobbyUtilsL1Test
-          sudo $GITHUB_WORKSPACE/build/unit_tests/L1_testing/tests/DobbyManagerTest/DobbyManagerL1Test
+          sudo valgrind --tool=memcheck --leak-check=yes --show-reachable=yes --track-fds=yes --fair-sched=try $GITHUB_WORKSPACE/build/unit_tests/L1_testing/tests/DobbyManagerTest/DobbyManagerL1Test
 
       - name: Generate coverage
         if: ${{ matrix.coverage == 'with-coverage' && matrix.extra_flags == 'RUN_TESTS' && matrix.build_type == 'Debug' }}

--- a/unit_tests/L1_testing/mocks/ContainerId.h
+++ b/unit_tests/L1_testing/mocks/ContainerId.h
@@ -46,7 +46,6 @@ public:
     ~ContainerId() = default;
 
     static void setImpl(ContainerIdImpl* newImpl);
-    static ContainerId* getInstance();
     bool isValid() const;
     const std::string& str() const;
     const char* c_str() const;

--- a/unit_tests/L1_testing/mocks/ContainerIdMock.cpp
+++ b/unit_tests/L1_testing/mocks/ContainerIdMock.cpp
@@ -20,17 +20,9 @@
 
 void ContainerId::setImpl(ContainerIdImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-ContainerId* ContainerId::getInstance()
-{
-    static ContainerId* instance = nullptr;
-    if(nullptr == instance)
-    {
-       instance = new ContainerId();
-    }
-    return instance;
 }
 
 bool ContainerId::isValid() const

--- a/unit_tests/L1_testing/mocks/DobbyBundle.h
+++ b/unit_tests/L1_testing/mocks/DobbyBundle.h
@@ -28,6 +28,7 @@ class IDobbyEnv;
 class DobbyBundleImpl {
 
 public:
+    virtual ~DobbyBundleImpl() = default;
 
     virtual void setPersistence(bool persist) = 0;
     virtual bool isValid() const = 0;
@@ -56,7 +57,6 @@ public:
 
 
     static void setImpl(DobbyBundleImpl* newImpl);
-    static DobbyBundle* getInstance();
     void setPersistence(bool persist);
     bool isValid() const;
 };

--- a/unit_tests/L1_testing/mocks/DobbyBundleConfig.h
+++ b/unit_tests/L1_testing/mocks/DobbyBundleConfig.h
@@ -26,6 +26,7 @@
 class DobbyBundleConfigImpl {
 
 public:
+    virtual ~DobbyBundleConfigImpl() = default;
 
     virtual std::shared_ptr<rt_dobby_schema> config() const =0;
     virtual bool restartOnCrash() const =0;
@@ -54,7 +55,6 @@ public:
 #endif /* LEGACY_COMPONENTS */
     const std::map<std::string, Json::Value>& rdkPlugins() const ;
     static void setImpl(DobbyBundleConfigImpl* newImpl);
-    static DobbyBundleConfig* getInstance();
     std::shared_ptr<rt_dobby_schema> config();
     bool restartOnCrash() const;
 };

--- a/unit_tests/L1_testing/mocks/DobbyBundleConfigMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyBundleConfigMock.cpp
@@ -33,17 +33,9 @@ DobbyBundleConfig::~DobbyBundleConfig()
 
 void DobbyBundleConfig::setImpl(DobbyBundleConfigImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyBundleConfig* DobbyBundleConfig::getInstance()
-{
-    static DobbyBundleConfig* instance = nullptr;
-    if (nullptr == instance)
-    {
-        instance = new DobbyBundleConfig();
-    }
-    return instance;
 }
 
 std::shared_ptr<rt_dobby_schema> DobbyBundleConfig::config()

--- a/unit_tests/L1_testing/mocks/DobbyBundleMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyBundleMock.cpp
@@ -21,17 +21,9 @@
 
 void DobbyBundle::setImpl(DobbyBundleImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyBundle* DobbyBundle::getInstance()
-{
-    static DobbyBundle* instance = nullptr;
-    if (nullptr == instance)
-    {
-       instance = new DobbyBundle();
-    }
-    return instance;
 }
 
 void DobbyBundle::setPersistence(bool persist)

--- a/unit_tests/L1_testing/mocks/DobbyConfigMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyConfigMock.cpp
@@ -23,6 +23,8 @@
 
 void DobbyConfig::setImpl(DobbyConfigImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
 }
 

--- a/unit_tests/L1_testing/mocks/DobbyContainer.h
+++ b/unit_tests/L1_testing/mocks/DobbyContainer.h
@@ -74,7 +74,6 @@ public:
     std::string customConfigFilePath;
 
     static void setImpl(DobbyContainerImpl* newImpl);
-    static DobbyContainer* getInstance();
     void setRestartOnCrash(const std::list<int>& files);
     void clearRestartOnCrash();
     const std::list<int>& files() const;

--- a/unit_tests/L1_testing/mocks/DobbyContainerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyContainerMock.cpp
@@ -65,17 +65,9 @@ bool DobbyContainer::shouldRestart(int statusCode)
 
 void DobbyContainer::setImpl(DobbyContainerImpl* newImpl)
 {
+     // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+     EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
      impl = newImpl;
-}
-
-DobbyContainer* DobbyContainer::getInstance()
-{
-    static DobbyContainer* instance = nullptr;
-    if (nullptr == instance)
-    {
-        instance = new DobbyContainer();
-    }
-    return instance;
 }
 
 void DobbyContainer::setRestartOnCrash(const std::list<int>& files)

--- a/unit_tests/L1_testing/mocks/DobbyEnv.h
+++ b/unit_tests/L1_testing/mocks/DobbyEnv.h
@@ -48,7 +48,6 @@ public:
     ~DobbyEnv();
     DobbyEnv(const std::shared_ptr<const IDobbySettings>& settings);
     static void setImpl(DobbyEnvImpl* newImpl);
-    static DobbyEnv* getInstance();
     std::string workspaceMountPath() const override;
     std::string flashMountPath() const override;
     std::string pluginsWorkspacePath() const override;

--- a/unit_tests/L1_testing/mocks/DobbyEnvMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyEnvMock.cpp
@@ -34,17 +34,9 @@ DobbyEnv::DobbyEnv(const std::shared_ptr<const IDobbySettings>& settings)
 
 void DobbyEnv::setImpl(DobbyEnvImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyEnv* DobbyEnv::getInstance()
-{
-    static DobbyEnv* instance = nullptr;
-    if(nullptr == instance)
-    {
-       instance = new DobbyEnv();
-    }
-    return instance;
 }
 
 std::string DobbyEnv::workspaceMountPath() const

--- a/unit_tests/L1_testing/mocks/DobbyFileAccessFixer.h
+++ b/unit_tests/L1_testing/mocks/DobbyFileAccessFixer.h
@@ -48,6 +48,8 @@
 class DobbyFileAccessFixerImpl
 {
 public:
+   virtual ~DobbyFileAccessFixerImpl() = default;
+
     virtual bool fixIt() const = 0;
 };
 
@@ -59,7 +61,6 @@ protected:
 public:
     DobbyFileAccessFixer();
     ~DobbyFileAccessFixer();
-    static DobbyFileAccessFixer* getInstance();
     static void setImpl(DobbyFileAccessFixerImpl* newImpl);
 
 public:

--- a/unit_tests/L1_testing/mocks/DobbyFileAccessFixerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyFileAccessFixerMock.cpp
@@ -27,18 +27,10 @@ DobbyFileAccessFixer::~DobbyFileAccessFixer()
 {
 }
 
-DobbyFileAccessFixer* DobbyFileAccessFixer::getInstance()
-{
-    static DobbyFileAccessFixer* instance = nullptr;
-    if (nullptr == instance)
-    {
-        instance = new DobbyFileAccessFixer();
-    }
-    return instance;
-}
-
 void DobbyFileAccessFixer::setImpl(DobbyFileAccessFixerImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
 }
 

--- a/unit_tests/L1_testing/mocks/DobbyIPCUtils.h
+++ b/unit_tests/L1_testing/mocks/DobbyIPCUtils.h
@@ -29,6 +29,7 @@
 class DobbyIPCUtilsImpl
 {
     public:
+    virtual ~DobbyIPCUtilsImpl() = default;
     virtual bool setAIDbusAddress(bool privateBus, const std::string &address) = 0;
     virtual std::shared_ptr<AI_IPC::IAsyncReplyGetter> ipcInvokeMethod(const IDobbyIPCUtils::BusType &bus,const AI_IPC::Method &method,const AI_IPC::VariantList &args,int timeoutMs) const = 0;
     virtual bool ipcInvokeMethod(const IDobbyIPCUtils::BusType &bus,const AI_IPC::Method &method,const AI_IPC::VariantList &args,AI_IPC::VariantList &replyArgs) const = 0;
@@ -55,7 +56,6 @@ public:
     ~DobbyIPCUtils();
 
     static void setImpl(DobbyIPCUtilsImpl* newImpl);
-    static DobbyIPCUtils* getInstance();
     bool setAIDbusAddress(bool privateBus, const std::string &address);
     std::shared_ptr<AI_IPC::IAsyncReplyGetter> ipcInvokeMethod(const BusType &bus,const AI_IPC::Method &method,const AI_IPC::VariantList &args,int timeoutMs) const override;
     bool ipcInvokeMethod(const BusType &bus,const AI_IPC::Method &method,const AI_IPC::VariantList &args,AI_IPC::VariantList &replyArgs) const override;

--- a/unit_tests/L1_testing/mocks/DobbyIPCUtilsMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyIPCUtilsMock.cpp
@@ -33,17 +33,9 @@ DobbyIPCUtils::~DobbyIPCUtils()
 
 void DobbyIPCUtils::setImpl(DobbyIPCUtilsImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyIPCUtils* DobbyIPCUtils::getInstance()
-{
-    static DobbyIPCUtils* instance = nullptr;
-    if(nullptr == instance)
-    {
-        instance = new DobbyIPCUtils();
-    }
-    return instance;
 }
 
 bool DobbyIPCUtils::setAIDbusAddress(bool privateBus, const std::string &address)

--- a/unit_tests/L1_testing/mocks/DobbyIPCUtilsMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyIPCUtilsMock.h
@@ -22,6 +22,8 @@
 
 class DobbyIPCUtilsMock : public DobbyIPCUtilsImpl {
 public:
+    virtual ~DobbyIPCUtilsMock() = default;
+
     MOCK_METHOD(bool, setAIDbusAddress,(bool privateBus, const std::string& address), (override));
     MOCK_METHOD(std::shared_ptr<AI_IPC::IAsyncReplyGetter>, ipcInvokeMethod,(const IDobbyIPCUtils::BusType &bus,const AI_IPC::Method &method,const AI_IPC::VariantList &args,int timeoutMs), (const,override));
     MOCK_METHOD(bool, ipcInvokeMethod,(const IDobbyIPCUtils::BusType &bus,const AI_IPC::Method &method,const AI_IPC::VariantList &args,AI_IPC::VariantList &replyArgs), (const,override));

--- a/unit_tests/L1_testing/mocks/DobbyLegacyPluginManager.h
+++ b/unit_tests/L1_testing/mocks/DobbyLegacyPluginManager.h
@@ -102,7 +102,6 @@ public:
     ~DobbyLegacyPluginManager();
 
 public:
-    static DobbyLegacyPluginManager* getInstance();
     static void setImpl(DobbyLegacyPluginManagerImpl* newImpl);
     void refreshPlugins(const std::string& path = std::string(DEFAULT_PLUGIN_PATH));
     bool executePostConstructionHooks(const std::map<std::string, Json::Value>& plugins,

--- a/unit_tests/L1_testing/mocks/DobbyLegacyPluginManagerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyLegacyPluginManagerMock.cpp
@@ -90,18 +90,10 @@ bool DobbyLegacyPluginManager::executePreDestructionHooks(const std::map<std::st
     return impl->executePreDestructionHooks(plugins,id,rootfsPath);
 }
 
-DobbyLegacyPluginManager* DobbyLegacyPluginManager::getInstance()
-{
-    static DobbyLegacyPluginManager* instance = nullptr;
-    if (nullptr == instance)
-    {
-        instance = new DobbyLegacyPluginManager();
-    }
-    return instance;
-}
-
 void DobbyLegacyPluginManager::setImpl(DobbyLegacyPluginManagerImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
 }
 

--- a/unit_tests/L1_testing/mocks/DobbyLogger.h
+++ b/unit_tests/L1_testing/mocks/DobbyLogger.h
@@ -51,7 +51,6 @@ public:
     ~DobbyLogger();
 
     static void setImpl(DobbyLoggerImpl* newImpl);
-    static DobbyLogger* getInstance();
     bool StartContainerLogging(std::string containerId,pid_t runtimePid,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin);
     bool DumpBuffer(int bufferMemFd,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin);
 };

--- a/unit_tests/L1_testing/mocks/DobbyLoggerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyLoggerMock.cpp
@@ -32,17 +32,9 @@ DobbyLogger::~DobbyLogger()
 
 void DobbyLogger::setImpl(DobbyLoggerImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyLogger* DobbyLogger::getInstance()
-{
-    static DobbyLogger* instance = nullptr;
-    if (nullptr == instance)
-    {
-       instance = new DobbyLogger();
-    }
-    return instance;
 }
 
 bool DobbyLogger::StartContainerLogging(std::string containerId,pid_t runtimePid,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin)

--- a/unit_tests/L1_testing/mocks/DobbyManagerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyManagerMock.cpp
@@ -42,17 +42,9 @@ DobbyManager::~DobbyManager()
 
 void DobbyManager::setImpl(DobbyManagerImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyManager* DobbyManager::getInstance()
-{
-    static DobbyManager* instance = nullptr;
-    if(nullptr == instance)
-    {
-        instance = new DobbyManager();
-    }
-    return instance;
 }
 
 #if defined(LEGACY_COMPONENTS)

--- a/unit_tests/L1_testing/mocks/DobbyManagerMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyManagerMock.h
@@ -24,6 +24,7 @@
 class  DobbyManagerMock : public DobbyManagerImpl {
 
 public:
+    virtual ~DobbyManagerMock() = default;
 
 #if defined(LEGACY_COMPONENTS)
 

--- a/unit_tests/L1_testing/mocks/DobbyRdkPluginManager.h
+++ b/unit_tests/L1_testing/mocks/DobbyRdkPluginManager.h
@@ -29,7 +29,7 @@ class DobbyRdkPluginUtils;
 class DobbyRdkPluginManagerImpl {
 
 public:
-
+    virtual ~DobbyRdkPluginManagerImpl() = default;
     virtual bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint,const uint timeoutMs ) const = 0;
     virtual bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint) const = 0;
     virtual void setExitStatus(int status) = 0;
@@ -50,7 +50,6 @@ public:
     ~DobbyRdkPluginManager();
 
     static void setImpl(DobbyRdkPluginManagerImpl* newImpl);
-    static DobbyRdkPluginManager* getInstance();
     bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint,const uint timeoutMs ) const;
     bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint) const;
     void setExitStatus(int status) const;

--- a/unit_tests/L1_testing/mocks/DobbyRdkPluginManagerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyRdkPluginManagerMock.cpp
@@ -33,17 +33,9 @@ DobbyRdkPluginManager::~DobbyRdkPluginManager()
 
 void DobbyRdkPluginManager::setImpl(DobbyRdkPluginManagerImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyRdkPluginManager* DobbyRdkPluginManager::getInstance()
-{
-    static DobbyRdkPluginManager* instance = nullptr;
-    if (nullptr == instance)
-    {
-       instance = new DobbyRdkPluginManager();
-    }
-    return instance;
 }
 
 bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint,const uint timeoutMs ) const

--- a/unit_tests/L1_testing/mocks/DobbyRdkPluginUtils.h
+++ b/unit_tests/L1_testing/mocks/DobbyRdkPluginUtils.h
@@ -61,6 +61,7 @@ typedef struct ContainerNetworkInfo
 
 class DobbyRdkPluginUtilsImpl {
 public:
+    virtual ~DobbyRdkPluginUtilsImpl() = default;
 
     virtual bool callInNamespaceImpl(pid_t pid, int nsType,const std::function<bool()>& func) const =0;
     virtual void nsThread(int newNsFd, int nsType, bool* success,std::function<bool()>& func) const = 0;
@@ -103,7 +104,6 @@ public:
     ~DobbyRdkPluginUtils();
 
     static void setImpl(DobbyRdkPluginUtilsImpl* newImpl);
-    static DobbyRdkPluginUtils* getInstance();
     bool callInNamespaceImpl(pid_t pid, int nsType,const std::function<bool()>& func) const;
     void nsThread(int newNsFd, int nsType, bool* success,std::function<bool()>& func) const;
     pid_t getContainerPid() const;

--- a/unit_tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.cpp
@@ -53,17 +53,9 @@ DobbyRdkPluginUtils::~DobbyRdkPluginUtils()
 
 void DobbyRdkPluginUtils::setImpl(DobbyRdkPluginUtilsImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyRdkPluginUtils* DobbyRdkPluginUtils::getInstance()
-{
-    static DobbyRdkPluginUtils* instance = nullptr;
-    if (nullptr == instance)
-    {
-       instance = new DobbyRdkPluginUtils();
-    }
-    return instance;
 }
 
 bool DobbyRdkPluginUtils::callInNamespaceImpl(pid_t pid, int nsType,const std::function<bool()>& func) const

--- a/unit_tests/L1_testing/mocks/DobbyRootfs.h
+++ b/unit_tests/L1_testing/mocks/DobbyRootfs.h
@@ -33,6 +33,7 @@ class DobbyBundle;
 
 class DobbyRootfsImpl {
 public:
+    virtual ~DobbyRootfsImpl() = default;
 
     virtual void setPersistence(bool persist) = 0;
 
@@ -58,7 +59,6 @@ public:
     ~DobbyRootfs();
 
     static void setImpl(DobbyRootfsImpl* newImpl);
-    static DobbyRootfs* getInstance();
     void setPersistence(bool persist);
     const std::string& path() const;
     bool isValid() const;

--- a/unit_tests/L1_testing/mocks/DobbyRootfsMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyRootfsMock.cpp
@@ -38,17 +38,9 @@ DobbyRootfs::~DobbyRootfs()
 
 void DobbyRootfs::setImpl(DobbyRootfsImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyRootfs* DobbyRootfs::getInstance()
-{
-    static DobbyRootfs* instance = nullptr;
-    if (nullptr == instance)
-    {
-       instance = new DobbyRootfs();
-    }
-    return instance;
 }
 
 void DobbyRootfs::setPersistence(bool persist)

--- a/unit_tests/L1_testing/mocks/DobbyRunC.h
+++ b/unit_tests/L1_testing/mocks/DobbyRunC.h
@@ -70,7 +70,6 @@ struct ContainerListItem
 public:
     DobbyRunC();
     static void setImpl(DobbyRunCImpl* newImpl);
-    static DobbyRunC* getInstance();
 
     std::pair<pid_t, pid_t> create(const ContainerId &id,
                                    const std::shared_ptr<const DobbyBundle> &bundle,
@@ -93,6 +92,8 @@ public:
 class DobbyRunCImpl
 {
 public:
+    virtual ~DobbyRunCImpl() = default;
+
     virtual std::pair<pid_t, pid_t> create(const ContainerId &id,
                                    const std::shared_ptr<const DobbyBundle> &bundle,
                                    const std::shared_ptr<const IDobbyStream> &console,

--- a/unit_tests/L1_testing/mocks/DobbyRunCMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyRunCMock.cpp
@@ -108,18 +108,10 @@ DobbyRunC::~DobbyRunC()
 {
 }
 
-DobbyRunC* DobbyRunC::getInstance()
-{
-    static DobbyRunC* instance = nullptr;
-    if (nullptr == instance)
-    {
-        instance = new DobbyRunC();
-    }
-    return instance;
-}
-
 void DobbyRunC::setImpl(DobbyRunCImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
 }
 

--- a/unit_tests/L1_testing/mocks/DobbySettingsMock.h
+++ b/unit_tests/L1_testing/mocks/DobbySettingsMock.h
@@ -23,6 +23,8 @@
 
 class DobbySettingsMock : public IDobbySettings {
     public:
+    virtual ~DobbySettingsMock() = default;
+
     MOCK_METHOD(std::string, workspaceDir, (), (const, override));
     MOCK_METHOD(std::string, persistentDir, (), (const, override));
     MOCK_METHOD((std::map<std::string, std::string>), extraEnvVariables, (), (const, override));

--- a/unit_tests/L1_testing/mocks/DobbySpecConfig.h
+++ b/unit_tests/L1_testing/mocks/DobbySpecConfig.h
@@ -59,7 +59,6 @@ public:
     ~DobbySpecConfig();
 
     static void setImpl(DobbySpecConfigImpl* newImpl);
-    static DobbySpecConfig* getInstance();
     bool isValid() const;
 
 #if defined(LEGACY_COMPONENTS)

--- a/unit_tests/L1_testing/mocks/DobbySpecConfigMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbySpecConfigMock.cpp
@@ -36,17 +36,9 @@ DobbySpecConfig::~DobbySpecConfig()
 
 void DobbySpecConfig::setImpl(DobbySpecConfigImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbySpecConfig* DobbySpecConfig::getInstance()
-{
-    static DobbySpecConfig* instance = nullptr;
-    if (nullptr == instance)
-    {
-       instance = new DobbySpecConfig();
-    }
-    return instance;
 }
 
 bool DobbySpecConfig::isValid() const

--- a/unit_tests/L1_testing/mocks/DobbyStartState.h
+++ b/unit_tests/L1_testing/mocks/DobbyStartState.h
@@ -48,7 +48,6 @@ public:
     DobbyStartState(const std::shared_ptr<DobbyConfig>& config,const std::list<int>& files);
     ~DobbyStartState();
     static void setImpl(DobbyStartStateImpl* newImpl);
-    static DobbyStartState* getInstance();
     bool isValid() const;
     std::list<int> files() const;
 

--- a/unit_tests/L1_testing/mocks/DobbyStartStateMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyStartStateMock.cpp
@@ -41,17 +41,9 @@ DobbyStartState::~DobbyStartState()
 
 void DobbyStartState::setImpl(DobbyStartStateImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyStartState* DobbyStartState::getInstance()
-{
-    static DobbyStartState* instance = nullptr;
-    if (nullptr == instance)
-    {
-       instance = new DobbyStartState();
-    }
-    return instance;
 }
 
 std::list<int> DobbyStartState::files() const

--- a/unit_tests/L1_testing/mocks/DobbyStartStateMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyStartStateMock.h
@@ -25,6 +25,7 @@
 
 class DobbyStartStateMock : public DobbyStartStateImpl{
 public:
+    virtual ~DobbyStartStateMock() = default;
 
     MOCK_METHOD(std::list<int>, files, (), (const,override));
     MOCK_METHOD(bool, isValid, (), (const,override));

--- a/unit_tests/L1_testing/mocks/DobbyStats.h
+++ b/unit_tests/L1_testing/mocks/DobbyStats.h
@@ -58,7 +58,6 @@ public:
     ~DobbyStats();
 
     static void setImpl(DobbyStatsImpl* newImpl);
-    static DobbyStats* getInstance();
     const Json::Value & stats() const;
 };
 

--- a/unit_tests/L1_testing/mocks/DobbyStatsMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyStatsMock.cpp
@@ -32,17 +32,9 @@ DobbyStats::~DobbyStats()
 
 void DobbyStats::setImpl(DobbyStatsImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyStats* DobbyStats::getInstance()
-{
-    static DobbyStats* instance = nullptr;
-    if (nullptr == instance)
-    {
-       instance = new DobbyStats();
-    }
-    return instance;
 }
 
 const Json::Value & DobbyStats::stats() const

--- a/unit_tests/L1_testing/mocks/DobbyStream.h
+++ b/unit_tests/L1_testing/mocks/DobbyStream.h
@@ -88,7 +88,6 @@ public:
     int dupWriteFD(int newFd, bool closeExec) const;
 public:
     static void setImpl(DobbyBufferStreamImpl* newImpl);
-    static DobbyBufferStream* getInstance();
     std::vector<char> getBuffer() const;
     int getMemFd() const;
 

--- a/unit_tests/L1_testing/mocks/DobbyStreamMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyStreamMock.cpp
@@ -33,17 +33,9 @@ int DobbyBufferStream::dupWriteFD(int newFd, bool closeExec) const
 
 void DobbyBufferStream::setImpl(DobbyBufferStreamImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyBufferStream* DobbyBufferStream::getInstance()
-{
-    static DobbyBufferStream* instance = nullptr;
-    if(nullptr == instance)
-    {
-        instance = new DobbyBufferStream();
-    }
-    return instance;
 }
 
 std::vector<char> DobbyBufferStream::getBuffer() const

--- a/unit_tests/L1_testing/mocks/DobbyTemplate.h
+++ b/unit_tests/L1_testing/mocks/DobbyTemplate.h
@@ -19,13 +19,7 @@
 #ifndef DOBBYTEMPLATE_H
 #define DOBBYTEMPLATE_H
 
-#pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wshadow"
-#  include <ctemplate/template.h>
-#pragma GCC diagnostic pop
-
 #include <pthread.h>
-
 #include <memory>
 #include <string>
 #include <list>
@@ -35,8 +29,6 @@ public:
 
     virtual ~DobbyTemplateImpl() = default;
     virtual void setSettings(const std::shared_ptr<const IDobbySettings>& settings) const = 0;
-    virtual std::string apply(const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint) = 0;
-    virtual bool applyAt(int dirFd, const std::string& fileName, const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint) = 0;
 };
 
 class DobbyTemplate {
@@ -49,10 +41,6 @@ public:
 
     DobbyTemplate();
     static void setImpl(DobbyTemplateImpl* newImpl);
-    static DobbyTemplate* getInstance();
     static void setSettings(const std::shared_ptr<const IDobbySettings>& settings);
-    static std::string apply(const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint);
-    static bool applyAt(int dirFd, const std::string& fileName, const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint);
-
   };
 #endif // !defined(DOBBYTEMPLATE_H)

--- a/unit_tests/L1_testing/mocks/DobbyTemplateMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyTemplateMock.cpp
@@ -25,17 +25,9 @@ DobbyTemplate::DobbyTemplate()
 
 void DobbyTemplate::setImpl(DobbyTemplateImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyTemplate* DobbyTemplate::getInstance()
-{
-    static DobbyTemplate* instance = nullptr;
-    if(nullptr == instance)
-    {
-       instance = new DobbyTemplate();
-    }
-    return instance;
 }
 
 void DobbyTemplate::setSettings(const std::shared_ptr<const IDobbySettings>& settings)
@@ -45,16 +37,3 @@ void DobbyTemplate::setSettings(const std::shared_ptr<const IDobbySettings>& set
     return impl->setSettings(settings);
 }
 
-std::string DobbyTemplate::apply(const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint)
-{
-   EXPECT_NE(impl, nullptr);
-
-    return impl->apply(dictionary, prettyPrint);
-}
-
-bool DobbyTemplate::applyAt(int dirFd, const std::string& fileName, const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint)
-{
-   EXPECT_NE(impl, nullptr);
-
-    return impl->applyAt(dirFd, fileName, dictionary, prettyPrint);
-}

--- a/unit_tests/L1_testing/mocks/DobbyTemplateMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyTemplateMock.h
@@ -27,6 +27,4 @@ public:
      virtual ~DobbyTemplateMock() = default;
 
      MOCK_METHOD(void, setSettings, (const std::shared_ptr<const IDobbySettings>& settings), (const,override));
-     MOCK_METHOD(std::string, apply, (const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint), (override));
-     MOCK_METHOD(bool, applyAt, (int dirFd, const std::string& fileName, const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint), (override));
 };

--- a/unit_tests/L1_testing/mocks/DobbyUtils.h
+++ b/unit_tests/L1_testing/mocks/DobbyUtils.h
@@ -80,7 +80,6 @@ public:
     ~DobbyUtils();
 
     static void setImpl(DobbyUtilsImpl* newImpl);
-    static DobbyUtils* getInstance();
     bool cancelTimer(int timerId) const override;
     int loopDeviceAssociate(int fileFd, std::string* loopDevPath) const override;
     bool checkExtImageFile(int dirFd, const std::string& imageFileName,bool repair) const override;

--- a/unit_tests/L1_testing/mocks/DobbyUtilsMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyUtilsMock.cpp
@@ -28,17 +28,9 @@ DobbyUtils::~DobbyUtils()
 
 void DobbyUtils::setImpl(DobbyUtilsImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-DobbyUtils* DobbyUtils::getInstance()
-{
-    static DobbyUtils* instance = nullptr;
-    if(nullptr == instance)
-    {
-        instance = new DobbyUtils();
-    }
-    return instance;
 }
 
 bool DobbyUtils::cancelTimer(int timerId) const

--- a/unit_tests/L1_testing/mocks/DobbyWorkQueue.h
+++ b/unit_tests/L1_testing/mocks/DobbyWorkQueue.h
@@ -40,7 +40,6 @@ protected:
 public:
 
     static void setImpl(DobbyWorkQueueImpl* newImpl);
-    static DobbyWorkQueue* getInstance();
     bool runFor(const std::chrono::milliseconds &msecs);
     void exit();
     bool postWork(WorkFunc &&work);

--- a/unit_tests/L1_testing/mocks/DobbyWorkQueueMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyWorkQueueMock.cpp
@@ -20,19 +20,10 @@
 
 void DobbyWorkQueue::setImpl(DobbyWorkQueueImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
 }
-
-DobbyWorkQueue* DobbyWorkQueue::getInstance()
-{
-    static DobbyWorkQueue* instance = nullptr;
-    if(nullptr == instance)
-    {
-        instance =  new DobbyWorkQueue();
-    }
-    return instance;
-}
-
 
 bool DobbyWorkQueue::runFor(const std::chrono::milliseconds &msecs)
 {

--- a/unit_tests/L1_testing/mocks/IIpcServiceMock.cpp
+++ b/unit_tests/L1_testing/mocks/IIpcServiceMock.cpp
@@ -20,6 +20,8 @@
 
 void AI_IPC::IIpcService::setImpl(IIpcServiceImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
 }
 

--- a/unit_tests/L1_testing/mocks/IpcCommon.h
+++ b/unit_tests/L1_testing/mocks/IpcCommon.h
@@ -48,6 +48,8 @@ public:
 
     static void setImpl(IAsyncReplySenderApiImpl* newImpl)
     {
+        // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+        EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
         impl = newImpl;
     }
 
@@ -65,15 +67,6 @@ public:
         return impl->getMethodCallArguments();
     }
 
-    static IAsyncReplySender* getInstance()
-    {
-        static IAsyncReplySender* instance = nullptr;
-        if(nullptr == instance)
-        {
-            instance = new IAsyncReplySender();
-        }
-        return instance;
-    }
 };
 
 

--- a/unit_tests/L1_testing/mocks/IpcFileDescriptor.h
+++ b/unit_tests/L1_testing/mocks/IpcFileDescriptor.h
@@ -45,7 +45,6 @@ public:
     ~IpcFileDescriptor();
 
     static void setImpl(IpcFileDescriptorApiImpl* newImpl);
-    static IpcFileDescriptor* getInstance();
     bool isValid() const;
     int fd() const;
 

--- a/unit_tests/L1_testing/mocks/IpcFileDescriptorMock.cpp
+++ b/unit_tests/L1_testing/mocks/IpcFileDescriptorMock.cpp
@@ -48,17 +48,9 @@ IpcFileDescriptor::~IpcFileDescriptor()
 
 void IpcFileDescriptor::setImpl(IpcFileDescriptorApiImpl* newImpl)
 {
+    // Handles both resetting 'impl' to nullptr and assigning a new value to 'impl'
+    EXPECT_TRUE ((nullptr == impl) || (nullptr == newImpl));
     impl = newImpl;
-}
-
-IpcFileDescriptor* IpcFileDescriptor::getInstance()
-{
-    static IpcFileDescriptor* instance = nullptr;
-    if(nullptr == instance)
-    {
-        instance = new IpcFileDescriptor();
-    }
-    return instance;
 }
 
 bool IpcFileDescriptor::isValid() const

--- a/unit_tests/L1_testing/mocks/dobbymanager/DobbyManager.h
+++ b/unit_tests/L1_testing/mocks/dobbymanager/DobbyManager.h
@@ -125,7 +125,6 @@ public:
     ~DobbyManager();
 
     static void setImpl(DobbyManagerImpl* newImpl);
-    static DobbyManager* getInstance();
 
 #if defined(LEGACY_COMPONENTS)
 

--- a/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -147,20 +147,9 @@ protected:
         DobbyIPCUtilsMock*  p_ipcutilsMock = nullptr;
         DobbyUtilsMock*  p_utilsMock = nullptr;
 
-        DobbyContainer *p_dobbyContainer = nullptr;
-        DobbyRdkPluginManager *p_rdkPluginManager = nullptr;
-        DobbyRootfs *p_rootfs = nullptr;
-        #if defined(LEGACY_COMPONENTS)
-        DobbySpecConfig *p_specConfig = nullptr;
-        #endif //defined(LEGACY_COMPONENTS)
-        DobbyStartState *p_startState = nullptr;
         DobbyBundle *p_bundle = nullptr;
         DobbyBundleConfig *p_bundleConfig = nullptr;
-        DobbyRdkPluginUtils *p_rdkPluginUtils = nullptr;
-        AI_IPC::IAsyncReplySender *p_iasyncReplySender = nullptr;
-        ContainerId *p_containerId = nullptr;
         DobbyFileAccessFixer *p_fileAccessFixer = nullptr;
-        DobbyRunC *p_runc = nullptr;
         DobbyBufferStream *p_stream = nullptr;
         DobbyLegacyPluginManager *p_legacyPluginManager = nullptr;
         DobbyStats *p_stats = nullptr;
@@ -197,27 +186,27 @@ protected:
             p_ipcutilsMock = new NiceMock <DobbyIPCUtilsMock>;
             p_utilsMock = new NiceMock <DobbyUtilsMock>;
 
-            p_dobbyContainer->setImpl(p_containerMock);
-            p_rdkPluginManager->setImpl(p_rdkPluginManagerMock);
-            p_rootfs->setImpl(p_rootfsMock);
-            p_startState->setImpl(p_startStateMock);
+            DobbyContainer::setImpl(p_containerMock);
+            DobbyRdkPluginManager::setImpl(p_rdkPluginManagerMock);
+            DobbyRootfs::setImpl(p_rootfsMock);
+            DobbyStartState::setImpl(p_startStateMock);
 
             #if defined(LEGACY_COMPONENTS)
-            p_specConfig->setImpl(p_specConfigMock);
+            DobbySpecConfig::setImpl(p_specConfigMock);
             #endif //defined(LEGACY_COMPONENTS)
 
-            p_bundle->setImpl(p_bundleMock);
+            DobbyBundle::setImpl(p_bundleMock);
             DobbyConfig::setImpl(p_configMock);
-            p_bundleConfig->setImpl(p_bundleConfigMock);
-            p_rdkPluginUtils->setImpl(p_rdkPluginUtilsMock);
-            p_iasyncReplySender->setImpl(p_asyncReplySenderMock);
-            p_containerId->setImpl(p_containerIdMock);
-            p_fileAccessFixer->setImpl(p_fileAccessFixerMock);
-            p_logger->setImpl(p_loggerMock);
-            p_runc->setImpl(p_runcMock);
-            p_stream->setImpl(p_streamMock);
-            p_legacyPluginManager->setImpl(p_legacyPluginManagerMock);
-            p_stats->setImpl(p_statsMock);
+            DobbyBundleConfig::setImpl(p_bundleConfigMock);
+            DobbyRdkPluginUtils::setImpl(p_rdkPluginUtilsMock);
+            AI_IPC::IAsyncReplySender::setImpl(p_asyncReplySenderMock);
+            ContainerId::setImpl(p_containerIdMock);
+            DobbyFileAccessFixer::setImpl(p_fileAccessFixerMock);
+            DobbyLogger::setImpl(p_loggerMock);
+            DobbyRunC::setImpl(p_runcMock);
+            DobbyBufferStream::setImpl(p_streamMock);
+            DobbyLegacyPluginManager::setImpl(p_legacyPluginManagerMock);
+            DobbyStats::setImpl(p_statsMock);
             DobbyEnv::setImpl(p_envMock);
             DobbyIPCUtils::setImpl(p_ipcutilsMock);
             DobbyUtils::setImpl(p_utilsMock);
@@ -248,31 +237,32 @@ protected:
         {
             dobbyManager_test.reset();
 
-            p_dobbyContainer->setImpl(nullptr);
-            p_rdkPluginManager->setImpl(nullptr);
-            p_rootfs->setImpl(nullptr);
-            p_startState->setImpl(nullptr);
+            DobbyContainer::setImpl(nullptr);
+            DobbyRdkPluginManager::setImpl(nullptr);
+            DobbyRootfs::setImpl(nullptr);
+            DobbyStartState::setImpl(nullptr);
 
             #if defined(LEGACY_COMPONENTS)
-            p_specConfig->setImpl(nullptr);
+            DobbySpecConfig::setImpl(nullptr);
             #endif //defined(LEGACY_COMPONENTS)
 
-            p_bundle->setImpl(nullptr);
+            DobbyBundle::setImpl(nullptr);
             DobbyConfig::setImpl(nullptr);
-            p_bundleConfig->setImpl(nullptr);
-            p_rdkPluginUtils->setImpl(nullptr);
-            p_iasyncReplySender->setImpl(nullptr);
-            p_containerId->setImpl(nullptr);
-            p_fileAccessFixer->setImpl(nullptr);
-            p_logger->setImpl(nullptr);
-            p_runc->setImpl(nullptr);
-            p_stream->setImpl(nullptr);
-            p_legacyPluginManager->setImpl(nullptr);
-            p_stats->setImpl(nullptr);
+            DobbyBundleConfig::setImpl(nullptr);
+            DobbyRdkPluginUtils::setImpl(nullptr);
+            AI_IPC::IAsyncReplySender::setImpl(nullptr);
+            ContainerId::setImpl(nullptr);
+            DobbyFileAccessFixer::setImpl(nullptr);
+            DobbyLogger::setImpl(nullptr);
+            DobbyRunC::setImpl(nullptr);
+            DobbyBufferStream::setImpl(nullptr);
+            DobbyLegacyPluginManager::setImpl(nullptr);
+            DobbyStats::setImpl(nullptr);
             DobbyEnv::setImpl(nullptr);
             DobbyIPCUtils::setImpl(nullptr);
             DobbyUtils::setImpl(nullptr);
 
+            p_dobbysettingsMock.reset();
 
             if( p_rdkPluginManagerMock != nullptr)
             {

--- a/unit_tests/L1_testing/tests/DobbyTest/DaemonDobbyTests.cpp
+++ b/unit_tests/L1_testing/tests/DobbyTest/DaemonDobbyTests.cpp
@@ -27,13 +27,14 @@
 #include "IpcFileDescriptorMock.h"
 #include "DobbySettingsMock.h"
 #include "IIpcServiceMock.h"
+#if defined(LEGACY_COMPONENTS)
 #include "DobbyTemplateMock.h"
+#endif /* LEGACY_COMPONENTS */
 #include "DobbyEnvMock.h"
 #include "DobbyManagerMock.h"
 #include "DobbyIPCUtilsMock.h"
 #include "DobbyUtilsMock.h"
 #include "ContainerIdMock.h"
-
 #include "DobbyProtocol.h"
 
 #include <cstdlib>
@@ -42,7 +43,9 @@
 DobbyWorkQueueImpl* DobbyWorkQueue::impl = nullptr;
 DobbyManagerImpl*   DobbyManager::impl = nullptr;
 DobbyIPCUtilsImpl*  DobbyIPCUtils::impl = nullptr;
+#if defined(LEGACY_COMPONENTS)
 DobbyTemplateImpl*  DobbyTemplate::impl = nullptr;
+#endif /* LEGACY_COMPONENTS */
 DobbyUtilsImpl*  DobbyUtils::impl = nullptr;
 ContainerIdImpl*  ContainerId::impl = nullptr;
 AI_IPC::IIpcServiceImpl* AI_IPC::IIpcService::impl = nullptr;
@@ -56,14 +59,18 @@ protected:
     AI_IPC::IAsyncReplySenderMock* p_asyncReplySenderMock = nullptr;
     AI_IPC::IpcFileDescriptorMock*  p_ipcFileDescriptorMock = nullptr;
     DobbyWorkQueueMock*  p_workQueueMock = nullptr;
+#if defined(LEGACY_COMPONENTS)
     DobbyTemplateMock*  p_templateMock = nullptr;
+#endif /* LEGACY_COMPONENTS */
     DobbyUtilsMock*  p_utilsMock = nullptr;
     DobbyIPCUtilsMock*  p_IPCUtilsMock = nullptr;
     DobbyManagerMock*  p_dobbyManagerMock = nullptr ;
     AI_IPC::IpcServiceMock*  p_ipcServiceMock = nullptr ;
     ContainerIdMock*  p_containerIdMock  = nullptr;
-
+#if defined(LEGACY_COMPONENTS)
     DobbyTemplate *p_dobbyTemplate = nullptr;
+#endif //defined(LEGACY_COMPONENTS)
+
     DobbyManager *p_dobbyManager = nullptr;
     AI_IPC::IIpcService *p_ipcService = nullptr;
     DobbyWorkQueue *p_workQueue = nullptr;
@@ -81,37 +88,26 @@ protected:
         p_asyncReplySenderMock = new NiceMock<AI_IPC::IAsyncReplySenderMock>;
         p_ipcFileDescriptorMock = new NiceMock<AI_IPC::IpcFileDescriptorMock>;
         p_workQueueMock =new NiceMock <DobbyWorkQueueMock>;
+#if defined(LEGACY_COMPONENTS)
         p_templateMock = new NiceMock <DobbyTemplateMock>;
+#endif /* LEGACY_COMPONENTS */
         p_utilsMock =  new NiceMock <DobbyUtilsMock>;
         p_IPCUtilsMock = new NiceMock <DobbyIPCUtilsMock>;
         p_dobbyManagerMock = new NiceMock <DobbyManagerMock>;
         p_ipcServiceMock  = new NiceMock <AI_IPC::IpcServiceMock>;
         p_containerIdMock = new NiceMock  <ContainerIdMock>;
 
-        p_dobbyTemplate =  DobbyTemplate::getInstance();
-        EXPECT_NE(p_dobbyTemplate, nullptr);
-        p_dobbyManager =  DobbyManager::getInstance();
-        EXPECT_NE(p_dobbyManager, nullptr);
-        p_workQueue = DobbyWorkQueue::getInstance();
-        EXPECT_NE(p_workQueue, nullptr);
-        p_dobbyUtils = DobbyUtils::getInstance();
-        EXPECT_NE(p_dobbyUtils, nullptr);
-        p_dobbyIPCUtils = DobbyIPCUtils::getInstance();
-        EXPECT_NE(p_dobbyIPCUtils, nullptr);
-        p_containerId =  ContainerId::getInstance();
-        EXPECT_NE(p_containerId, nullptr);
-        p_iIpcFileDescriptor = AI_IPC::IpcFileDescriptor::getInstance();
-        EXPECT_NE(p_iIpcFileDescriptor, nullptr);
-
-        p_iasyncReplySender->setImpl(p_asyncReplySenderMock);
-        p_iIpcFileDescriptor->setImpl(p_ipcFileDescriptorMock);
-        p_ipcService->setImpl(p_ipcServiceMock);
-        p_workQueue->setImpl(p_workQueueMock);
-        p_dobbyTemplate->setImpl(p_templateMock);
-        p_dobbyUtils->setImpl(p_utilsMock);
-        p_dobbyIPCUtils->setImpl(p_IPCUtilsMock);
-        p_dobbyManager->setImpl(p_dobbyManagerMock);
-        p_containerId->setImpl(p_containerIdMock);
+        AI_IPC::IAsyncReplySender::setImpl(p_asyncReplySenderMock);
+        AI_IPC::IpcFileDescriptor::setImpl(p_ipcFileDescriptorMock);
+        AI_IPC::IIpcService::setImpl(p_ipcServiceMock);
+        DobbyWorkQueue::setImpl(p_workQueueMock);
+#if defined(LEGACY_COMPONENTS)
+        DobbyTemplate::setImpl(p_templateMock);
+#endif /* LEGACY_COMPONENTS */
+        DobbyUtils::setImpl(p_utilsMock);
+        DobbyIPCUtils::setImpl(p_IPCUtilsMock);
+        DobbyManager::setImpl(p_dobbyManagerMock);
+        ContainerId::setImpl(p_containerIdMock);
 
         p_settingsMock =  std::make_shared<NiceMock<DobbySettingsMock>>();
         std::string dbusAddress = "unix:path=/some/socket";
@@ -130,19 +126,22 @@ protected:
 
     virtual void TearDown()
     {
-
         ON_CALL(*p_ipcServiceMock, unregisterHandler(::testing::_))
         .WillByDefault(::testing::Return(true));
 
         dobby_test.reset();
-        p_workQueue->setImpl(nullptr);
-        p_iasyncReplySender->setImpl(nullptr);
-        p_iIpcFileDescriptor->setImpl(nullptr);
-        p_dobbyTemplate->setImpl(nullptr);
-        p_ipcService->setImpl(nullptr);
-        p_dobbyManager->setImpl(nullptr);
-        p_dobbyIPCUtils->setImpl(nullptr);
-        p_containerId->setImpl(nullptr);
+        dobby_test = nullptr;
+        DobbyWorkQueue::setImpl(nullptr);
+        AI_IPC::IAsyncReplySender::setImpl(nullptr);
+        AI_IPC::IpcFileDescriptor::setImpl(nullptr);
+#if defined(LEGACY_COMPONENTS)
+        DobbyTemplate::setImpl(nullptr);
+#endif //defined(LEGACY_COMPONENTS)
+        AI_IPC::IIpcService::setImpl(nullptr);
+        DobbyManager::setImpl(nullptr);
+        DobbyIPCUtils::setImpl(nullptr);
+        ContainerId::setImpl(nullptr);
+        DobbyUtils::setImpl(nullptr);
 
         if( p_asyncReplySenderMock != nullptr)
         {
@@ -161,11 +160,13 @@ protected:
             p_workQueueMock = nullptr;
         }
 
+#if defined(LEGACY_COMPONENTS)
         if ( p_templateMock != nullptr)
         {
             delete  p_templateMock;
             p_templateMock = nullptr;
         }
+#endif //defined(LEGACY_COMPONENTS)
 
         if (p_utilsMock != nullptr)
         {
@@ -196,6 +197,9 @@ protected:
             delete  p_containerIdMock;
             p_containerIdMock = nullptr;
         }
+
+        p_settingsMock.reset();
+        p_settingsMock = nullptr;
     }
 };
 
@@ -1636,8 +1640,8 @@ TEST_F(DaemonDobbyTest, stopSuccess_validArg_postWorkSuccess)
     EXPECT_CALL(*p_dobbyManagerMock, stopContainer(::testing::_,::testing::_,::testing::_))
         .WillOnce(::testing::Invoke(
                  [&](int32_t cd, bool withPrejudice, const std::function<void(int32_t cd, const ContainerId& id,  int32_t status)> containnerStopCb) {
-                     ContainerId *p_containerId = ContainerId::getInstance();;
-                     containnerStopCb(cd, *p_containerId, 2/*DobbyContainer::State:Stopping*/);
+                     ContainerId containerId;
+                     containnerStopCb(cd, containerId, 2/*DobbyContainer::State:Stopping*/);
                      return cd;
                  }));
 
@@ -2747,6 +2751,7 @@ TEST_F(DaemonDobbyTest, list_postWorkSuccess_SendReplySuccess)
             }));
 
     dobby_test->list((std::shared_ptr<AI_IPC::IAsyncReplySender>)p_iasyncReplySender);
+    containers.clear();
 }
 
 /*Test cases for startFromBundle ends here*/
@@ -2807,6 +2812,8 @@ TEST_F(DaemonDobbyTest, list_postWorkFailed_SendReplySuccess)
             }));
 
     dobby_test->list((std::shared_ptr<AI_IPC::IAsyncReplySender>)p_iasyncReplySender);
+
+    containers.clear();
 }
 
 /**
@@ -2868,6 +2875,7 @@ TEST_F(DaemonDobbyTest, list_postWorkSuccess_sendReplyFailed)
             }));
 
     dobby_test->list((std::shared_ptr<AI_IPC::IAsyncReplySender>)p_iasyncReplySender);
+    containers.clear();
 }
 
 /**


### PR DESCRIPTION
### Description
Changes Done:
1. Installing valgrind tool
2. Run the DobbyL1Test and DobbyManagerL1Test test with valgrind, valgrind logs it will comes with console log
3. Removed the getInstance() from the mock and setting impl directly from the test
4. Changing release-1.11.0 gtest verion as latest verion has gmock memory leak issue

### Test Procedure
In github workflow L1 test is running and passing

### Type of Change
- Enhancing Dobby L1 test

### Requires Bitbake Recipe changes?
- Not required