### PR TITLE
RDK-45299: startContainerFromSpec fix

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -842,6 +842,18 @@ int32_t DobbyManager::startContainerFromSpec(const ContainerId &id,
         return -1;
     }
 
+    // Set Apparmor profile
+    if (mSettings->apparmorSettings().enabled)
+    {
+        config->setApparmorProfile(mSettings->apparmorSettings().profileName);
+    }
+
+    // Set pids limit
+    if (mSettings->pidsSettings().enabled)
+    {
+        config->setPidsLimit(mSettings->pidsSettings().limit);
+    }
+
     // Load the RDK plugins from disk (if necessary)
     std::map<std::string, Json::Value> rdkPlugins = config->rdkPlugins();
     AI_LOG_DEBUG("There are %zd rdk plugins to run", rdkPlugins.size());


### PR DESCRIPTION
### Description
Fixed setting apparmor profile and pids cgroup limit for containers started using spec files.

### Test Procedure
Check apps are using dobby_default apparmor profile.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [x] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)