### PR TITLE
RDK-45706: Support for hibernate and wakeup Phase 1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     env:
       # For CI, build all optional plugins. Newly developed plugins should be added to this list
       optional_plugins: "-DPLUGIN_TESTPLUGIN=ON -DPLUGIN_GPU=ON -DPLUGIN_LOCALTIME=ON -DPLUGIN_RTSCHEDULING=ON -DPLUGIN_HTTPPROXY=ON -DPLUGIN_APPSERVICES=ON -DPLUGIN_IONMEMORY=ON -DPLUGIN_DEVICEMAPPER=ON -DPLUGIN_OOMCRASH=ON"
-      optional_flags: "-DLEGACY_COMPONENTS=ON -DRDK=ON -DUSE_SYSTEMD=ON"
+      optional_flags: "-DLEGACY_COMPONENTS=ON -DRDK=ON -DUSE_SYSTEMD=ON -DDOBBY_HIBERNATE_MEMCR_IMPL=ON"
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +25,7 @@ jobs:
         # If adding a RUN_TESTS cmake option, it will build with enabling optional_flags and run the unit tests
         # matrix runs both versions
         build_type: ["Release", "Debug"]
-        extra_flags: [ "RUN_TESTS", "-DLEGACY_COMPONENTS=ON", "-DLEGACY_COMPONENTS=OFF", "-DUSE_SYSTEMD=ON", "-DUSE_SYSTEMD=OFF"]
+        extra_flags: [ "RUN_TESTS", "-DLEGACY_COMPONENTS=ON", "-DLEGACY_COMPONENTS=OFF", "-DUSE_SYSTEMD=ON", "-DUSE_SYSTEMD=OFF", "-DDOBBY_HIBERNATE_MEMCR_IMPL=ON", "-DDOBBY_HIBERNATE_MEMCR_IMPL=OFF"]
     name: Build in ${{ matrix.build_type }} Mode (${{ matrix.extra_flags }})
     steps:
       - name: checkout

--- a/AppInfrastructure/Public/Dobby/IDobbyProxy.h
+++ b/AppInfrastructure/Public/Dobby/IDobbyProxy.h
@@ -64,6 +64,9 @@ public:
         Stopping = 3,
         Paused = 4,
         Stopped = 5,
+        Hibernating = 6,
+        Hibernated = 7,
+        Awakening = 8
     };
 
 public:
@@ -140,6 +143,10 @@ public:
     virtual bool pauseContainer(int32_t descriptor) const = 0;
 
     virtual bool resumeContainer(int32_t descriptor) const = 0;
+
+    virtual bool hibernateContainer(int32_t descriptor, const std::string& options) const = 0;
+
+    virtual bool wakeupContainer(int32_t descriptor) const = 0;
 
     virtual bool execInContainer(int32_t cd,
                                  const std::string& options,

--- a/client/lib/include/DobbyProxy.h
+++ b/client/lib/include/DobbyProxy.h
@@ -99,6 +99,10 @@ public:
 
     bool resumeContainer(int32_t cd) const override;
 
+    bool hibernateContainer(int32_t descriptor, const std::string& options) const override;
+
+    bool wakeupContainer(int32_t descriptor) const override;
+
     bool execInContainer(int32_t cd,
                          const std::string& options,
                          const std::string& command) const override;
@@ -136,6 +140,8 @@ public:
 private:
     void onContainerStartedEvent(const AI_IPC::VariantList& args);
     void onContainerStoppedEvent(const AI_IPC::VariantList& args);
+    void onContainerHibernatedEvent(const AI_IPC::VariantList& args);
+    void onContainerAwokenEvent(const AI_IPC::VariantList& args);
 
 private:
     bool invokeMethod(const char *interface_, const char *method_,
@@ -160,7 +166,7 @@ private:
 
     struct StateChangeEvent
     {
-        enum Type { Terminate, ContainerStarted, ContainerStopped };
+        enum Type { Terminate, ContainerStarted, ContainerStopped, ContainerHibernated, ContainerAwoken };
 
         explicit StateChangeEvent(Type type_)
             : type(type_), descriptor(-1)

--- a/daemon/lib/CMakeLists.txt
+++ b/daemon/lib/CMakeLists.txt
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+option(DOBBY_HIBERNATE_MEMCR_IMPL "Hibernate containers using Memcr tool" OFF)
+
 if (LEGACY_COMPONENTS)
         list(APPEND ADDITIONAL_SOURCES
                 "source/DobbyLegacyPluginManager.cpp"
@@ -37,6 +39,7 @@ add_library( DobbyDaemonLib
         source/DobbyWorkQueue.cpp
         source/DobbyLogger.cpp
         source/DobbyLogRelay.cpp
+        source/DobbyHibernate.cpp
 
         ${ADDITIONAL_SOURCES}
         )
@@ -93,6 +96,10 @@ if( BUILDING_WITH_RDK_SDK )
             JsonCpp::JsonCpp
             CTemplate::libctemplate )
 
+endif()
+
+if(DOBBY_HIBERNATE_MEMCR_IMPL)
+    add_definitions( -DDOBBY_HIBERNATE_MEMCR_IMPL=1 )
 endif()
 
 # Install public headers for external use

--- a/daemon/lib/include/Dobby.h
+++ b/daemon/lib/include/Dobby.h
@@ -89,6 +89,8 @@ private:
     DOBBY_DBUS_METHOD(stop);
     DOBBY_DBUS_METHOD(pause);
     DOBBY_DBUS_METHOD(resume);
+    DOBBY_DBUS_METHOD(hibernate);
+    DOBBY_DBUS_METHOD(wakeup);
     DOBBY_DBUS_METHOD(exec);
     DOBBY_DBUS_METHOD(list);
     DOBBY_DBUS_METHOD(getState);
@@ -122,6 +124,8 @@ private:
 private:
     void onContainerStarted(int32_t cd, const ContainerId& id);
     void onContainerStopped(int32_t cd, const ContainerId& id, int status);
+    void onContainerHibernated(int32_t cd, const ContainerId& id);
+    void onContainerAwoken(int32_t cd, const ContainerId& id);
 
 private:
     void runWorkQueue() const;

--- a/daemon/lib/source/DobbyHibernate.cpp
+++ b/daemon/lib/source/DobbyHibernate.cpp
@@ -1,0 +1,240 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2016 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File:   DobbyHibernate.cpp
+ *
+ */
+
+
+#include "DobbyHibernate.h"
+#include <Logging.h>
+
+#ifdef DOBBY_HIBERNATE_MEMCR_IMPL
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+typedef enum {
+    MEMCR_CHECKPOINT = 100,
+    MEMCR_RESTORE
+} ServerRequestCode;
+
+typedef enum {
+    MEMCR_OK = 0,
+    MEMCR_ERROR = -1,
+    MEMCR_INVALID_PID = -2
+} ServerResponseCode;
+
+typedef struct {
+    ServerRequestCode reqCode;
+    pid_t pid;
+} __attribute__((packed)) ServerRequest;
+
+typedef struct {
+    ServerResponseCode respCode;
+} __attribute__((packed)) ServerResponse;
+
+const char* DobbyHibernate::DFL_LOCATOR = "/tmp/memcrcom";
+const uint32_t DobbyHibernate::DFL_TIMEOUTE_MS = 20000;
+
+
+static int Connect(const char* serverLocator, uint32_t timeoutMs)
+{
+    AI_LOG_FN_ENTRY();
+    int cd = -1;
+    struct sockaddr_in addrIn = { 0 };
+    struct sockaddr_un addrUn = { 0 };
+    struct sockaddr* addr = NULL;
+    size_t addrSize = 0;
+    char host[64] = { 0 };
+    char* port = NULL;
+    struct timeval rcvTimeout = { 0 };
+
+    rcvTimeout.tv_sec = timeoutMs / 1000;
+    rcvTimeout.tv_usec = (timeoutMs % 1000) * 1000;
+
+    // check if we have unix or tcp socket
+    if (strlen(serverLocator) == 0) {
+        AI_LOG_ERROR("Locator empty");
+        AI_LOG_FN_EXIT();
+        return -1;
+    }
+
+    if (serverLocator[0] == '/') {
+        // try to configure unix socket
+        cd = socket(PF_UNIX, SOCK_STREAM, 0);
+        if (cd < 0) {
+            AI_LOG_ERROR("Unix Socket create failed: %d", cd);
+            AI_LOG_FN_EXIT();
+            return false;
+        }
+
+        addrUn.sun_family = PF_UNIX;
+        strncpy(addrUn.sun_path, serverLocator, sizeof(addrUn.sun_path));
+        addr = (struct sockaddr*)&addrUn;
+        addrSize = sizeof(struct sockaddr_un);
+    } else {
+        // go on with inet socket
+        cd = socket(AF_INET, SOCK_STREAM, 0);
+        if (cd < 0) {
+            AI_LOG_ERROR("Inet Socket create failed");
+            AI_LOG_FN_EXIT();
+            return -1;
+        }
+
+        strncpy(host, serverLocator, 64);
+        port = strstr(host, ":");
+        if (port == NULL) {
+            AI_LOG_ERROR("Invalid Server Ip Address: %s", host);
+            AI_LOG_FN_EXIT();
+            return false;
+        }
+
+        // Add NULL delimer between host and port
+        *port = 0;
+        port++;
+
+        addrIn.sin_family = AF_INET;
+        addrIn.sin_addr.s_addr = inet_addr(host);
+        addrIn.sin_port = htons(atoi(port));
+
+        addr = (struct sockaddr*)&addrIn;
+        addrSize = sizeof(struct sockaddr_in);
+    }
+
+    setsockopt(cd, SOL_SOCKET, SO_RCVTIMEO, &rcvTimeout, sizeof(rcvTimeout));
+
+    int ret = connect(cd, addr, addrSize);
+    if (ret < 0) {
+        AI_LOG_ERROR("Socket connect failed: %d with %s", ret, serverLocator);
+        close(cd);
+        AI_LOG_FN_EXIT();
+        return -1;
+    }
+
+    AI_LOG_FN_EXIT();
+    return cd;
+}
+
+static bool SendRcvCmd(const ServerRequest* cmd, ServerResponse* resp, uint32_t timeoutMs, const char* serverLocator)
+{
+    AI_LOG_FN_ENTRY();
+    int cd;
+    int ret;
+    struct sockaddr_in addr = { 0 };
+    resp->respCode = MEMCR_ERROR;
+
+    cd = Connect(serverLocator, timeoutMs);
+    if (cd < 0) {
+        AI_LOG_ERROR("Unnable to connect to %s", serverLocator);
+        AI_LOG_FN_EXIT();
+        return false;
+    }
+
+    ret = write(cd, cmd, sizeof(ServerRequest));
+    if (ret != sizeof(ServerRequest)) {
+        AI_LOG_ERROR("Socket write failed: ret %d", ret);
+        close(cd);
+        AI_LOG_FN_EXIT();
+        return false;
+    }
+
+    ret = read(cd, resp, sizeof(ServerResponse));
+    if (ret != sizeof(ServerResponse)) {
+        AI_LOG_ERROR("Socket read failed: ret %d", ret);
+        close(cd);
+        AI_LOG_FN_EXIT();
+        return false;
+    }
+
+    close(cd);
+
+    AI_LOG_FN_EXIT();
+    return (resp->respCode == MEMCR_OK);
+}
+
+DobbyHibernate::Error DobbyHibernate::HibernateProcess(const pid_t pid, const uint32_t timeout,  const char* locator,
+    const char* dumpDirPath, CompressionAlg compression)
+{
+    AI_LOG_FN_ENTRY();
+    ServerRequest req = {
+        .reqCode = MEMCR_CHECKPOINT,
+        .pid = pid
+    };
+    ServerResponse resp;
+
+    if (SendRcvCmd(&req, &resp, timeout, locator)) {
+        AI_LOG_INFO("Hibernate process PID %d success", pid);
+        AI_LOG_FN_EXIT();
+        return DobbyHibernate::Error::ErrorNone;
+    } else {
+        AI_LOG_WARN("Error Hibernate process PID %d ret %d", pid, resp.respCode);
+        AI_LOG_FN_EXIT();
+        return DobbyHibernate::Error::ErrorGeneral;
+    }
+}
+
+DobbyHibernate::Error DobbyHibernate::WakeupProcess(const pid_t pid, const uint32_t timeout, const char* locator)
+{
+    AI_LOG_FN_ENTRY();
+    ServerRequest req = {
+        .reqCode = MEMCR_RESTORE,
+        .pid = pid
+    };
+    ServerResponse resp;
+
+    if (SendRcvCmd(&req, &resp, timeout, locator)) {
+        AI_LOG_INFO("Wakeup process PID %d success", pid);
+        AI_LOG_FN_EXIT();
+        return DobbyHibernate::Error::ErrorNone;
+    } else if (resp.respCode == MEMCR_INVALID_PID) {
+        AI_LOG_WARN("Wakeup process PID %d ret %d - INVALID PID, nothing to wakeup", pid, resp.respCode);
+        AI_LOG_FN_EXIT();
+        return DobbyHibernate::Error::ErrorNone;
+    }
+
+    AI_LOG_WARN("Error Wakeup process PID %d ret %d", pid, resp.respCode);
+    AI_LOG_FN_EXIT();
+    return DobbyHibernate::Error::ErrorGeneral;
+}
+
+#else
+
+const char* DobbyHibernate::DFL_LOCATOR = "";
+const uint32_t DobbyHibernate::DFL_TIMEOUTE_MS = 0;
+
+DobbyHibernate::Error DobbyHibernate::HibernateProcess(const pid_t pid, const uint32_t timeout,  const char* locator,
+    const char* dumpDirPath, CompressionAlg compression)
+{
+    AI_LOG_ERROR("DobbyHibernate Implementation not enabled");
+    return DobbyHibernate::Error::ErrorGeneral;
+}
+
+DobbyHibernate::Error DobbyHibernate::WakeupProcess(const pid_t pid, const uint32_t timeout, const char* locator)
+{
+    AI_LOG_ERROR("DobbyHibernate Implementation not enabled");
+    return DobbyHibernate::Error::ErrorGeneral;
+}
+
+#endif

--- a/daemon/lib/source/DobbyHibernate.h
+++ b/daemon/lib/source/DobbyHibernate.h
@@ -1,0 +1,52 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2016 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File:   DobbyHibernate.h
+ *
+ */
+#pragma once
+
+#include <sys/types.h>
+#include <stdint.h>
+
+class DobbyHibernate
+{
+    public:
+
+    enum Error
+    {
+        ErrorNone = 0,
+        ErrorGeneral = 1
+    };
+
+    enum CompressionAlg
+    {
+        AlgNone = 0,
+        AlgLz4 = 1,
+        AlgZstd = 2
+    };
+
+    static const char* DFL_LOCATOR;
+    static const uint32_t DFL_TIMEOUTE_MS;
+
+    static Error HibernateProcess(const pid_t pid, const uint32_t timeout = DFL_TIMEOUTE_MS,
+        const char* locator = DFL_LOCATOR, const char* dumpDirPath = nullptr, CompressionAlg compression = AlgLz4);
+
+    static Error WakeupProcess(const pid_t pid, const uint32_t timeout = DFL_TIMEOUTE_MS, const char* locator = DFL_LOCATOR);
+};

--- a/daemon/lib/source/include/DobbyContainer.h
+++ b/daemon/lib/source/include/DobbyContainer.h
@@ -86,7 +86,7 @@ public:
 public:
     pid_t containerPid;
     bool hasCurseOfDeath;
-    enum class State { Starting, Running, Stopping, Paused, Unknown } state;
+    enum class State { Starting, Running, Stopping, Paused, Hibernating, Hibernated, Awakening, Unknown } state;
     std::string customConfigFilePath;
 
 public:

--- a/daemon/lib/source/include/DobbyManager.h
+++ b/daemon/lib/source/include/DobbyManager.h
@@ -78,6 +78,7 @@ class DobbyManager
 public:
     typedef std::function<void(int32_t cd, const ContainerId& id)> ContainerStartedFunc;
     typedef std::function<void(int32_t cd, const ContainerId& id, int32_t status)> ContainerStoppedFunc;
+    typedef std::function<void(int32_t cd, const ContainerId& id)> ContainerHibernatedFunc;
 
 public:
     DobbyManager(const std::shared_ptr<IDobbyEnv>& env,
@@ -85,7 +86,9 @@ public:
                  const std::shared_ptr<IDobbyIPCUtils>& ipcUtils,
                  const std::shared_ptr<const IDobbySettings>& settings,
                  const ContainerStartedFunc& containerStartedCb,
-                 const ContainerStoppedFunc& containerStoppedCb);
+                 const ContainerStoppedFunc& containerStoppedCb,
+                 const ContainerHibernatedFunc& containerHibernatedCb,
+                 const ContainerHibernatedFunc& containerAwokenCb);
     ~DobbyManager();
 
 private:
@@ -116,6 +119,8 @@ public:
 
     bool pauseContainer(int32_t cd);
     bool resumeContainer(int32_t cd);
+    bool hibernateContainer(int32_t cd, const std::string& options);
+    bool wakeupContainer(int32_t cd);
 
     bool execInContainer(int32_t cd,
                          const std::string& options,
@@ -163,6 +168,8 @@ private:
 private:
     ContainerStartedFunc mContainerStartedCb;
     ContainerStoppedFunc mContainerStoppedCb;
+    ContainerHibernatedFunc mContainerHibernatedCb;
+    ContainerHibernatedFunc mContainerAwokenCb;
 
 private:
     mutable std::mutex mLock;

--- a/protocol/include/DobbyProtocol.h
+++ b/protocol/include/DobbyProtocol.h
@@ -52,6 +52,8 @@
 #define DOBBY_CTRL_METHOD_STOP                      "Stop"
 #define DOBBY_CTRL_METHOD_PAUSE                     "Pause"
 #define DOBBY_CTRL_METHOD_RESUME                    "Resume"
+#define DOBBY_CTRL_METHOD_HIBERNATE                 "Hibernate"
+#define DOBBY_CTRL_METHOD_WAKEUP                    "Wakeup"
 #define DOBBY_CTRL_METHOD_EXEC                      "Exec"
 #define DOBBY_CTRL_METHOD_GETSTATE                  "GetState"
 #define DOBBY_CTRL_METHOD_GETINFO                   "GetInfo"
@@ -59,6 +61,8 @@
 #define DOBBY_CTRL_EVENT_STARTED                    "Started"
 #define DOBBY_CTRL_EVENT_STOPPED                    "Stopped"
 #define DOBBY_CTRL_EVENT_STOPPED_WITH_STATUS        "StoppedWithStatus"
+#define DOBBY_CTRL_EVENT_HIBERNATED                 "Hibernated"
+#define DOBBY_CTRL_EVENT_AWOKEN                     "Awoken"
 
 #define DOBBY_DEBUG_INTERFACE                   DOBBY_SERVICE ".debug1"
 #define DOBBY_DEBUG_METHOD_CREATE_BUNDLE            "CreateBundle"
@@ -72,6 +76,9 @@
 #define CONTAINER_STATE_RUNNING                 2
 #define CONTAINER_STATE_STOPPING                3
 #define CONTAINER_STATE_PAUSED                  4
+#define CONTAINER_STATE_HIBERNATING             5
+#define CONTAINER_STATE_HIBERNATED              6
+#define CONTAINER_STATE_AWAKENING               7
 
 #define DOBBY_LOG_NULL                          0
 #define DOBBY_LOG_SYSLOG                        1

--- a/unit_tests/L1_testing/mocks/DobbyContainer.h
+++ b/unit_tests/L1_testing/mocks/DobbyContainer.h
@@ -54,7 +54,7 @@ public:
     DobbyContainer(DobbyContainer&&) = delete;
     friend class DobbyManager;
 
-    enum class State { Starting, Running, Stopping, Paused, Unknown } state;
+    enum class State { Starting, Running, Stopping, Paused, Hibernating, Hibernated, Awakening, Unknown } state;
     pid_t containerPid;
     const int32_t descriptor;
     const std::shared_ptr<const DobbyRdkPluginManager> rdkPluginManager;

--- a/unit_tests/L1_testing/mocks/DobbyManagerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyManagerMock.cpp
@@ -30,7 +30,9 @@ DobbyManager::DobbyManager(std::shared_ptr<DobbyEnv>&,
                                                     std::shared_ptr<DobbyIPCUtils>&,
                                                     const std::shared_ptr<const IDobbySettings>&,
                                                     std::function<void(int, const ContainerId&)>& StartedFunc,
-                                                    std::function<void(int, const ContainerId&, int)>& StoppedFunc)
+                                                    std::function<void(int, const ContainerId&, int)>& StoppedFunc,
+                                                    std::function<void(int32_t cd, const ContainerId& id)>&,
+                                                    std::function<void(int32_t cd, const ContainerId& id)>&)
 : mContainerStartedCb(StartedFunc)
 , mContainerStoppedCb(StoppedFunc)
 {
@@ -107,6 +109,20 @@ bool DobbyManager::resumeContainer(int32_t cd)
    EXPECT_NE(impl, nullptr);
 
     return impl->resumeContainer(cd);
+}
+
+bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return true;
+}
+
+bool DobbyManager::wakeupContainer(int32_t cd)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return true;
 }
 
 bool DobbyManager::execInContainer(int32_t cd,

--- a/unit_tests/L1_testing/mocks/DobbyManagerMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyManagerMock.h
@@ -56,6 +56,10 @@ public:
 
     MOCK_METHOD(bool, resumeContainer, (int32_t cd), (override));
 
+    MOCK_METHOD(bool, hibernateContainer, (int32_t cd, const std::string& options), (override));
+
+    MOCK_METHOD(bool, wakeupContainer, (int32_t cd), (override));
+
     MOCK_METHOD(bool, execInContainer, (int32_t cd,
                                    const std::string& options,
                                    const std::string& command), (override));

--- a/unit_tests/L1_testing/mocks/dobbymanager/DobbyManager.h
+++ b/unit_tests/L1_testing/mocks/dobbymanager/DobbyManager.h
@@ -91,6 +91,10 @@ public:
 
     virtual bool resumeContainer(int32_t cd) = 0;
 
+    virtual bool hibernateContainer(int32_t cd, const std::string& options) = 0;
+
+    virtual bool wakeupContainer(int32_t cd) = 0;
+
     virtual bool execInContainer(int32_t cd,
                              const std::string& options,
                              const std::string& command) = 0;
@@ -115,13 +119,17 @@ protected:
 public:
     typedef std::function<void(int32_t cd, const ContainerId& id)> ContainerStartedFunc;
     typedef std::function<void(int32_t cd, const ContainerId& id, int32_t status)> ContainerStoppedFunc;
+    typedef std::function<void(int32_t cd, const ContainerId& id)> ContainerHibernatedFunc;
+
     DobbyManager();
     DobbyManager(std::shared_ptr<DobbyEnv>&,
                                   std::shared_ptr<DobbyUtils>&,
                                   std::shared_ptr<DobbyIPCUtils>&,
                                   const std::shared_ptr<const IDobbySettings>&,
                                   std::function<void(int, const ContainerId&)>& StartedFunc,
-                                  std::function<void(int, const ContainerId&, int)>& StoppedFunc);
+                                  std::function<void(int, const ContainerId&, int)>& StoppedFunc,
+                                  std::function<void(int32_t cd, const ContainerId& id)>& containerHibernatedCb,
+                                  std::function<void(int32_t cd, const ContainerId& id)>& containerAwokenCb);
     ~DobbyManager();
 
     static void setImpl(DobbyManagerImpl* newImpl);
@@ -147,6 +155,8 @@ public:
     bool stopContainer(int32_t cd, bool withPrejudice);
     bool pauseContainer(int32_t cd);
     bool resumeContainer(int32_t cd);
+    bool hibernateContainer(int32_t cd, const std::string& options);
+    bool wakeupContainer(int32_t cd);
     bool execInContainer(int32_t cd,
                                 const std::string& options,
                                 const std::string& command);
@@ -157,6 +167,7 @@ public:
 
     ContainerStartedFunc mContainerStartedCb;
     ContainerStoppedFunc mContainerStoppedCb;
+
 };
 
 #endif // !defined(DOBBYMANAGER_H)

--- a/unit_tests/L1_testing/tests/DobbyManagerTest/CMakeLists.txt
+++ b/unit_tests/L1_testing/tests/DobbyManagerTest/CMakeLists.txt
@@ -28,6 +28,7 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 add_library(DaemonDobbyManagerTest SHARED STATIC
             ../../../../daemon/lib/source/DobbyManager.cpp
+            ../../../../daemon/lib/source/DobbyHibernate.cpp
             ../../../../AppInfrastructure/Logging/source/Logging.cpp
             ../../mocks/DobbyBundleConfigMock.cpp
             ../../mocks/DobbyRunCMock.cpp

--- a/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -103,12 +103,17 @@ protected:
 
     void onContainerStopped(int32_t cd, const ContainerId& id, int status);
 
+    void onContainerHibernated(int32_t cd, const ContainerId& id);
+
+    void onContainerAwoken(int32_t cd, const ContainerId& id);
+
     bool waitForContainerStarted(int32_t timeout_ms);
 
     bool waitForContainerStopped(int32_t timeout_ms);
 
     typedef std::function<void(int32_t cd, const ContainerId& id)> ContainerStartedFunc;
     typedef std::function<void(int32_t cd, const ContainerId& id, int32_t status)> ContainerStoppedFunc;
+    typedef std::function<void(int32_t cd, const ContainerId& id)> ContainerHibernatedFunc;
     std::function<bool()> Test_invalidContainerCleanupTask;
 
     ContainerStartedFunc startcb =
@@ -118,6 +123,14 @@ protected:
     ContainerStoppedFunc stopcb =
         std::bind(&DaemonDobbyManagerTest::onContainerStopped, this,
                   std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+
+    ContainerHibernatedFunc hibernatedCb  =
+        std::bind(&DaemonDobbyManagerTest::onContainerHibernated, this,
+                  std::placeholders::_1, std::placeholders::_2);
+
+    ContainerHibernatedFunc awokenCb  =
+        std::bind(&DaemonDobbyManagerTest::onContainerAwoken, this,
+                  std::placeholders::_1, std::placeholders::_2);
 
     public:
         std::mutex m_mutex;
@@ -251,7 +264,7 @@ protected:
            return 123456;
            }));
 
-           dobbyManager_test = std::make_shared<NiceMock<DobbyManager>>(p_env,p_utils,p_ipcutils,p_dobbysettingsMock,startcb,stopcb);
+           dobbyManager_test = std::make_shared<NiceMock<DobbyManager>>(p_env,p_utils,p_ipcutils,p_dobbysettingsMock,startcb,stopcb,hibernatedCb,awokenCb);
         }
 
         virtual void TearDown()
@@ -991,6 +1004,12 @@ protected:
                 }
             }
             return true;
+        }
+
+        void DaemonDobbyManagerTest::onContainerHibernated(int32_t cd, const ContainerId& id) {
+        }
+
+        void DaemonDobbyManagerTest::onContainerAwoken(int32_t cd, const ContainerId& id) {
         }
 
 #if defined(LEGACY_COMPONENTS)


### PR DESCRIPTION
### Description
Add support for container hibernation and wakeup using Memcr tool as a backend

### Test Procedure
Call:
DobbyTool hibernate <container_id>
DobbyTool wakeup <container_id>

### Type of Change
- [ ] New feature (non-breaking change which adds functionality)


### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)
- [ ] CMake flag has to be set to enable Memcr backend interface implementation: DOBBY_HIBERNATE_MEMCR_IMPL=ON