### PR TITLE
Add missing container hibernate callback call

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1650,6 +1650,10 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
             if (ret == DobbyHibernate::Error::ErrorNone)
             {
                 mContainers[id]->state = DobbyContainer::State::Hibernated;
+                if (mContainerHibernatedCb)
+                {
+                    mContainerHibernatedCb(cd, id);
+                }
             }
             else
             {


### PR DESCRIPTION
### Description
Add missing container hibernate callback call.

### Test Procedure
Run sleepy container, hibernate it using 'DobbyTool hibernate sleepy'.
Check Dobby logs, there should be:
MIL: < M:Dobby.cpp F:onContainerHibernated L:2029 > container 'sleepy'(734) hibernated

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)