### PR TITLE
HBBTV-67: Increased default pids limit

### DIFF
--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -403,7 +403,7 @@ void Settings::setDefaults()
     mApparmorSettings.enabled = true;
     mApparmorSettings.profileName = "dobby_default";
     mPidsSettings.enabled = true;
-    mPidsSettings.limit = 128;
+    mPidsSettings.limit = 256;
 #else
     mWorkspaceDir = getPathFromEnv("AI_WORKSPACE_PATH", "/tmp/ai-workspace-fallback");
     mPersistentDir = getPathFromEnv("AI_PERSISTENT_PATH", "/tmp/ai-flash-fallback");


### PR DESCRIPTION
### Description
Increased default pids limit to 256.

### Test Procedure
Run container, check pids limit in /sys/fs/cgroup/pids/<container_name>/pids.max

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)