### PR TITLE
[RDK-47795] - L1/L2 test - Create json output file with test result d…

### DIFF
--- a/tests/L2_testing/dobby_specs/wget-private.json
+++ b/tests/L2_testing/dobby_specs/wget-private.json
@@ -3,7 +3,7 @@
     "cwd": "/",
     "args": [
         "wget",
-        "--timeout=5",
+        "--timeout=4",
         "example.com"
     ],
     "env": [


### PR DESCRIPTION
…etails

### Description
wget-private test has failed intermittently
wget command timeout value and the test completion time is 5 seconds. 
before wget command execution, the test verifies the test result, and the expected log is not uploaded. 
without the expected log the test has failed.
Now the timeout value is changed and this issue is fixed.


### Test Procedure
Run the L2 test in GitHub and vagrant VM

### Type of Change
- [ ] wget-private test failure is fixed

### Requires Bitbake Recipe changes?
- [ ] NA