### PR TITLE
RDKTV-26826: Unmount the dynamic mounts instead of removing

### DIFF
--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -211,7 +211,7 @@ bool DynamicMountDetails::onPostStop() const
 
     if (stat(targetPath.c_str(), &buffer) == 0)
     {
-        if (remove(targetPath.c_str()) == 0)
+        if (umount(targetPath.c_str()) == 0)
         {
             success = true;
         }


### PR DESCRIPTION
### Description
If two HtmlApp's are running in container mode (i.e)HtmlApp-0 and HtmlApp-1 and whenever the HtmlApp-0 is closed, in the postStop hook we are removing the files that are dynamically mounted, thus removing the files even for HtmlApp-1. So, unmounting the dynamic mounts in the postStop instead of removing it.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)