### PR TITLE
RDK-50163 Support for running Android containers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ option(PLUGIN_STORAGE "Include Storage plugin" ON)
 option(PLUGIN_MINIDUMP "Include Minidump plugin" ON)
 option(PLUGIN_THUNDER "Include Thunder plugin" ON)
 option(PLUGIN_OOMCRASH "Include OOMCrash plugin" ON)
+option(PLUGIN_ANDROIDRUNTIME "Include Android plugin" ON)
 
 # Optional RDK plugins
 option(PLUGIN_TESTPLUGIN "Include TestPlugin plugin" OFF)
@@ -377,6 +378,10 @@ endif()
 
 if(PLUGIN_GAMEPAD)
 	add_subdirectory(rdkPlugins/Gamepad)
+endif()
+
+if(PLUGIN_ANDROIDRUNTIME)
+    add_subdirectory(rdkPlugins/AndroidRuntime)
 endif()
 
 # Export targets in Dobby package

--- a/bundle/lib/include/DobbyRootfs.h
+++ b/bundle/lib/include/DobbyRootfs.h
@@ -100,6 +100,7 @@ private:
     std::string mPath;
     int mDirFd;
     bool mPersist;
+    bool androidRootfs;
 };
 
 

--- a/bundle/lib/include/DobbySpecConfig.h
+++ b/bundle/lib/include/DobbySpecConfig.h
@@ -110,6 +110,9 @@ public:
     std::vector<MountPoint> mountPoints() const;
 
 public:
+    bool androidEnabled() const;
+
+public:
     const std::string& rootfsPath() const override;
 
 private:
@@ -143,6 +146,7 @@ private:
     JSON_FIELD_PROCESSOR(processDevices);
     JSON_FIELD_PROCESSOR(processCapabilities);
     JSON_FIELD_PROCESSOR(processSeccomp);
+    JSON_FIELD_PROCESSOR(processAndroid);
 
     #undef JSON_FIELD_PROCESSOR
 
@@ -180,6 +184,7 @@ private:
     const std::shared_ptr<IDobbyUtils> mUtilities;
     const std::shared_ptr<const IDobbySettings::HardwareAccessSettings> mGpuSettings;
     const std::shared_ptr<const IDobbySettings::HardwareAccessSettings> mVpuSettings;
+    const std::shared_ptr<const IDobbySettings::AndroidAccessSettings> mAndroidSettings;
     const std::vector<std::string> mDefaultPlugins;
     const Json::Value mRdkPluginsData;
 
@@ -229,6 +234,9 @@ private:
     std::string mEtcPasswd;
     std::string mEtcGroup;
     std::string mEtcLdSoPreload;
+
+private:
+    bool mAndroidEnabled;
 
 private:
     static int mNumCores;

--- a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
@@ -575,7 +575,11 @@ static const char* ociJsonTemplate = R"JSON(
             "/sys/devices/virtual/misc/vndbinder",
             "/sys/firmware/devicetree/base/emmc@ffe07000",
             "/sys/module/mmcblk",
-            "/sys/power"
+            "/sys/power",
+            "/sys/devices/platform/rdb/84b1000.sdhci",
+            "/sys/devices/virtual/devlink/brcm_scmi@0--84b1000.sdhci",
+            "/sys/firmware/devicetree/base/rdb/sdhci@84b1000",
+            "/sys/firmware/devicetree/base/rdb/sdhci@84b0000"
         ],
         "rootfsPropagation": "rshared"
         {{/ANDROID_ENABLED}}

--- a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
@@ -27,8 +27,21 @@ static const char* ociJsonTemplate = R"JSON(
         "arch": "arm"
     },
 
-    "process": {
+    {{#ANDROID_ENABLED}}
+    "annotations": {
+        "run.oci.hooks.stderr": "/dev/stderr",
+        "run.oci.hooks.stdout": "/dev/stdout"
+    },
+    {{/ANDROID_ENABLED}}
+
+
+   "process": {
+        {{#ANDROID_DISABLED}}
         "terminal": false,
+        {{/ANDROID_DISABLED}}
+        {{#ANDROID_ENABLED}}
+        "terminal": true,
+        {{/ANDROID_ENABLED}}
         "user": {
             {{#USERNS_DISABLED}}
             "uid": {{USER_ID}},
@@ -41,16 +54,122 @@ static const char* ociJsonTemplate = R"JSON(
             "additionalGids": [ {{#ADDITIONAL_GIDS}} {{ADDITIONAL_GID}}{{#ADDITIONAL_GIDS_separator}},{{/ADDITIONAL_GIDS_separator}} {{/ADDITIONAL_GIDS}} ]
         },
         "args": [
+        {{#ANDROID_DISABLED}}
             "/usr/libexec/DobbyInit",
             {{#ARGS_VAR_SECTION}}"{{ARGS_VAR_VALUE:json_escape}}"{{#ARGS_VAR_SECTION_separator}},{{/ARGS_VAR_SECTION_separator}} {{/ARGS_VAR_SECTION}}
         ],
+        {{/ANDROID_DISABLED}}
+        {{#ANDROID_ENABLED}}
+            {{#ARGS_VAR_SECTION}}"{{ARGS_VAR_VALUE:json_escape}}"{{#ARGS_VAR_SECTION_separator}},{{/ARGS_VAR_SECTION_separator}} {{/ARGS_VAR_SECTION}}
+        ],
+        {{/ANDROID_ENABLED}}
         "cwd": "{{WORKING_DIRECTORY}}",
+        {{#ANDROID_DISABLED}}
         "env": [
             {{#ENV_VAR_SECTION}}"{{ENV_VAR_VALUE:json_escape}}", {{/ENV_VAR_SECTION}}
             {{EXTRA_ENV_VARS}}
             "HOME=/home/private",
             "PATH=/usr/sbin:/usr/bin:/sbin:/bin"
         ],
+        {{/ANDROID_DISABLED}}
+        {{#ANDROID_ENABLED}}
+        "env": [
+            {{#ENV_VAR_SECTION}}"{{ENV_VAR_VALUE:json_escape}}", {{/ENV_VAR_SECTION}}
+            {{EXTRA_ENV_VARS}}
+            "PATH=/system/bin:/"
+        ],
+        {{/ANDROID_ENABLED}}
+        {{#ANDROID_ENABLED}}
+        "capabilities": {
+            "bounding": [
+                "CAP_AUDIT_CONTROL",
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_FOWNER",
+                "CAP_KILL",
+                "CAP_MKNOD",
+                "CAP_NET_ADMIN",
+                "CAP_SETGID",
+                "CAP_SETPCAP",
+                "CAP_SETUID",
+                "CAP_SYSLOG",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_RESOURCE"
+                {{#EXTRA_CAPS_SECTION}},"{{EXTRA_CAPS_VALUE}}"{{/EXTRA_CAPS_SECTION}}
+            ],
+            "effective": [
+                "CAP_AUDIT_CONTROL",
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_FOWNER",
+                "CAP_KILL",
+                "CAP_MKNOD",
+                "CAP_NET_ADMIN",
+                "CAP_SETGID",
+                "CAP_SETPCAP",
+                "CAP_SETUID",
+                "CAP_SYSLOG",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_RESOURCE"
+            ],
+            "inheritable": [
+                "CAP_AUDIT_CONTROL",
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_FOWNER",
+                "CAP_KILL",
+                "CAP_MKNOD",
+                "CAP_NET_ADMIN",
+                "CAP_SETGID",
+                "CAP_SETPCAP",
+                "CAP_SETUID",
+                "CAP_SYSLOG",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_RESOURCE"
+            ],
+            "permitted": [
+                "CAP_AUDIT_CONTROL",
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_FOWNER",
+                "CAP_KILL",
+                "CAP_MKNOD",
+                "CAP_NET_ADMIN",
+                "CAP_SETGID",
+                "CAP_SETPCAP",
+                "CAP_SETUID",
+                "CAP_SYSLOG",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_RESOURCE"
+            ],
+            "ambient": [
+                "CAP_AUDIT_CONTROL",
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_DAC_READ_SEARCH",
+                "CAP_FOWNER",
+                "CAP_KILL",
+                "CAP_MKNOD",
+                "CAP_NET_ADMIN",
+                "CAP_SETGID",
+                "CAP_SETPCAP",
+                "CAP_SETUID",
+                "CAP_SYSLOG",
+                "CAP_SYS_ADMIN",
+                "CAP_SYS_PTRACE",
+                "CAP_SYS_RESOURCE"
+            ]
+        },
+        {{/ANDROID_ENABLED}}
+        {{#ANDROID_DISABLED}}
         "capabilities": {
             "bounding": [
                 "CAP_AUDIT_WRITE",
@@ -79,6 +198,8 @@ static const char* ociJsonTemplate = R"JSON(
                 "CAP_NET_BIND_SERVICE"
             ]
         },
+        {{/ANDROID_DISABLED}}
+        {{#ANDROID_DISABLED}}
         "rlimits": [
             {
                 "type": "RLIMIT_NOFILE",
@@ -97,13 +218,22 @@ static const char* ociJsonTemplate = R"JSON(
                 "soft": {{RLIMIT_RTPRIO}}
             }{{/RTLIMIT_ENABLED}}
         ],
+        {{/ANDROID_DISABLED}}
         "noNewPrivileges": {{NO_NEW_PRIVS}}
     },
 
+    {{#ANDROID_DISABLED}}
     "root": {
         "path": "rootfs",
         "readonly": true
     },
+    {{/ANDROID_DISABLED}}
+    {{#ANDROID_ENABLED}}
+    "root": {
+        "path": "rootfs",
+        "readonly": false
+    },
+    {{/ANDROID_ENABLED}}
 
     "hostname": "dobby",
 
@@ -113,11 +243,16 @@ static const char* ociJsonTemplate = R"JSON(
             "type": "tmpfs",
             "source": "tmpfs",
             "options": [
+                {{#ANDROID_DISABLED}}
                 "nosuid",
                 "noexec",
                 "nodev",
                 "size=65536k",
                 "nr_inodes=8k"
+                {{/ANDROID_DISABLED}}
+                {{#ANDROID_ENABLED}}
+                "mode=0755"
+                {{/ANDROID_ENABLED}}
             ]
         },
         {
@@ -125,24 +260,18 @@ static const char* ociJsonTemplate = R"JSON(
             "type": "tmpfs",
             "source": "tmpfs",
             "options": [
+                {{#ANDROID_DISABLED}}
                 "nosuid",
                 "noexec",
                 "strictatime",
                 "mode=755",
                 "size=65536k"
-            ]
-        },
-        {
-            "destination": "/dev/pts",
-            "type": "devpts",
-            "source": "devpts",
-            "options": [
-                "nosuid",
+                {{/ANDROID_DISABLED}}
+                {{#ANDROID_ENABLED}}
                 "noexec",
-                "newinstance",
-                "ptmxmode=0666",
-                "mode=0620",
-                "gid=5"
+                "strictatime",
+                "mode=755"
+                {{/ANDROID_ENABLED}}
             ]
         },
         {
@@ -164,8 +293,10 @@ static const char* ociJsonTemplate = R"JSON(
             "options": [
                 "nosuid",
                 "noexec",
-                "nodev",
-                "ro"
+                {{#ANDROID_DISABLED}}
+                "ro",
+                {{/ANDROID_DISABLED}}
+                "nodev"
             ]
         },
         {
@@ -175,10 +306,18 @@ static const char* ociJsonTemplate = R"JSON(
             "options": [
                 "nosuid",
                 "noexec",
+                {{#ANDROID_DISABLED}}
                 "nodev",
                 "relatime"
+                {{/ANDROID_DISABLED}}
+                {{#ANDROID_ENABLED}}
+                "none",
+                "name=",
+                "strictatime"
+                {{/ANDROID_ENABLED}}
             ]
         },
+        {{#ANDROID_DISABLED}}
         {
             "destination": "/lib",
             "type": "bind",
@@ -223,6 +362,26 @@ static const char* ociJsonTemplate = R"JSON(
                 "ro"
             ]
         },
+        {{/ANDROID_DISABLED}}
+        {{#ANDROID_DISABLED}}
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {{/ANDROID_DISABLED}}
+        {{#ANDROID_ENABLED}} {{! /proc before MOUNT_SECTION so we can override /proc/cmdline for Android }}
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc"
+        },
+        {{/ANDROID_ENABLED}}
         {{#SYSLOG_SECTION}}{
             "destination": "/dev/log",
             "type": "bind",
@@ -242,13 +401,16 @@ static const char* ociJsonTemplate = R"JSON(
             ]
         },{{/MOUNT_SECTION}}
         {
-            "destination": "/proc",
-            "type": "proc",
-            "source": "proc",
+            "destination": "/dev/pts",
+            "type": "devpts",
+            "source": "devpts",
             "options": [
                 "nosuid",
                 "noexec",
-                "nodev"
+                "newinstance",
+                "ptmxmode=0666",
+                "mode=0620",
+                "gid=5"
             ]
         }
     ],
@@ -304,6 +466,7 @@ static const char* ociJsonTemplate = R"JSON(
             {{/ADDITIONAL_DEVICE_NODES}}
         ],
         "resources": {
+            {{#ANDROID_DISABLED}}
             "devices": [
                 {
                     "allow": false,
@@ -328,9 +491,22 @@ static const char* ociJsonTemplate = R"JSON(
                 }
                 {{/DEV_WHITELIST_SECTION}}
             ],
+            {{/ANDROID_DISABLED}}
+            {{#ANDROID_DISABLED}}
             "memory": {
                 "limit": {{MEM_LIMIT}}
             },
+            {{/ANDROID_DISABLED}}
+            {{#ANDROID_ENABLED}}
+            "memory": {
+                "kernel": -1,
+                "kernelTCP": -1,
+                "limit": {{MEM_LIMIT}},
+                "swap": 1073741824,
+                "swappiness": 0,
+                "disableOOMKiller": false
+            },
+            {{/ANDROID_ENABLED}}
             "cpu": {
                 {{#CPU_SHARES_ENABLED}}
                 "shares": {{CPU_SHARES_VALUE}},
@@ -343,6 +519,10 @@ static const char* ociJsonTemplate = R"JSON(
             }
         },
         "namespaces": [
+            {{#ANDROID_ENABLED}}
+            {
+                "type": "cgroup"
+            },{{/ANDROID_ENABLED}}
             {
                 "type": "pid"
             },{{#NETNS_ENABLED}}
@@ -362,6 +542,7 @@ static const char* ociJsonTemplate = R"JSON(
                 "type": "mount"
             }
         ],
+        {{#ANDROID_DISABLED}}
         "maskedPaths": [
             "/proc/kcore",
             "/proc/latency_stats",
@@ -377,6 +558,27 @@ static const char* ociJsonTemplate = R"JSON(
             "/proc/sysrq-trigger"
         ],
         "rootfsPropagation": "slave"
+        {{/ANDROID_DISABLED}}
+        {{#ANDROID_ENABLED}}
+        "maskedPaths": [
+            "/sys/block",
+            "/sys/bus/mmc",
+            "/sys/class/block",
+            "/sys/class/misc/binder",
+            "/sys/class/misc/hwbinder",
+            "/sys/class/misc/vndbinder",
+            "/sys/class/mmc_host",
+            "/sys/devices/platform/ffe05000.sdio",
+            "/sys/devices/platform/ffe07000.emmc",
+            "/sys/devices/virtual/misc/binder",
+            "/sys/devices/virtual/misc/hwbinder",
+            "/sys/devices/virtual/misc/vndbinder",
+            "/sys/firmware/devicetree/base/emmc@ffe07000",
+            "/sys/module/mmcblk",
+            "/sys/power"
+        ],
+        "rootfsPropagation": "rshared"
+        {{/ANDROID_ENABLED}}
     },
     {{#ENABLE_LEGACY_PLUGINS}}
     "legacyPlugins": {

--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -680,6 +680,40 @@
                 }
             }
         },
+        "AndroidRuntime": {
+            "type": "object",
+            "required": [
+                "required"
+            ],
+            "properties": {
+                "required": {
+                    "type": "boolean"
+                },
+                "dependsOn": {
+                    "$ref": "defs.json#/definitions/ArrayOfStrings"
+                },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "systemPath": {
+                            "type": "string"
+                        },
+                        "vendorPath": {
+                            "type": "string"
+                        },
+                        "dataPath": {
+                            "type": "string"
+                        },
+                        "cachePath": {
+                            "type": "string"
+                        },
+                        "cmdlinePath": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "LegacyPlugins": {
             "type": "object",
             "properties": {
@@ -741,6 +775,9 @@
                 },
                 "gamepad": {
                     "$ref": "#/definitions/Gamepad"
+                },
+                "androidruntime": {
+                    "$ref": "#/definitions/AndroidRuntime"
                 }
             }
         }

--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -706,9 +706,6 @@
                         },
                         "cachePath": {
                             "type": "string"
-                        },
-                        "cmdlinePath": {
-                            "type": "string"
                         }
                     }
                 }

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -975,7 +975,7 @@ void Dobby::startFromSpec(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
     std::vector<std::string> envVars;
 
     // The command argument might not be sent at all (e.g. from AI) so we should
-    // be able to withstand receiving 3 or 6 arguments
+    // be able to withstand receiving 3, 4 or 6 arguments
     bool parseArgsSuccess = false;
     if (replySender->getMethodCallArguments().size() == 3)
     {

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -860,7 +860,14 @@ int32_t DobbyManager::startContainerFromSpec(const ContainerId &id,
     // Set Apparmor profile
     if (mSettings->apparmorSettings().enabled)
     {
-        config->setApparmorProfile(mSettings->apparmorSettings().profileName);
+        if (config->androidEnabled() && !mSettings->androidAccessSettings()->appArmorProfile.empty())
+        {
+            config->setApparmorProfile(mSettings->androidAccessSettings()->appArmorProfile);
+        }
+        else
+        {
+            config->setApparmorProfile(mSettings->apparmorSettings().profileName);
+        }
     }
 
     // Set pids limit

--- a/rdkPlugins/AndroidRuntime/CMakeLists.txt
+++ b/rdkPlugins/AndroidRuntime/CMakeLists.txt
@@ -20,6 +20,7 @@
 # Project name should match the name of the plugin
 # CMake will prefix this with "lib"
 project(AndroidRuntimePlugin)
+set(CMAKE_CXX_STANDARD 17)
 
 add_library( ${PROJECT_NAME}
         SHARED

--- a/rdkPlugins/AndroidRuntime/CMakeLists.txt
+++ b/rdkPlugins/AndroidRuntime/CMakeLists.txt
@@ -1,0 +1,45 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 Sky UK
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reference CMake file for the simplest Dobby RDK Plugin
+
+# Project name should match the name of the plugin
+# CMake will prefix this with "lib"
+project(AndroidRuntimePlugin)
+
+add_library( ${PROJECT_NAME}
+        SHARED
+        source/AndroidRuntimePlugin.cpp
+        source/AndroidHelper.cpp
+        )
+
+target_include_directories(${PROJECT_NAME}
+        PRIVATE
+        $<TARGET_PROPERTY:DobbyDaemonLib,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+install(
+        TARGETS ${PROJECT_NAME}
+        LIBRARY DESTINATION lib/plugins/dobby
+        NAMELINK_SKIP
+        )
+
+target_link_libraries(${PROJECT_NAME}
+        DobbyRdkPluginCommonLib
+)
+
+set_target_properties( ${PROJECT_NAME} PROPERTIES SOVERSION 1 )

--- a/rdkPlugins/AndroidRuntime/source/AndroidHelper.cpp
+++ b/rdkPlugins/AndroidRuntime/source/AndroidHelper.cpp
@@ -18,22 +18,17 @@
 */
 
 #include "AndroidHelper.h"
-#include "DobbyRdkPluginUtils.h"
 
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <strings.h>
 #include <unistd.h>
-#include <list>
-#include <map>
 #include <sys/mount.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
-#include <sstream>
-#include <fstream>
 #include <dirent.h>
-#include <string.h>
 #include <sys/sysmacros.h>
 
 #if defined(__linux__)

--- a/rdkPlugins/AndroidRuntime/source/AndroidHelper.cpp
+++ b/rdkPlugins/AndroidRuntime/source/AndroidHelper.cpp
@@ -1,0 +1,553 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2020 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "AndroidHelper.h"
+#include "DobbyRdkPluginUtils.h"
+
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <list>
+#include <map>
+#include <sys/mount.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sstream>
+#include <fstream>
+#include <dirent.h>
+#include <string.h>
+#include <sys/sysmacros.h>
+
+#if defined(__linux__)
+#include <linux/loop.h>
+#endif
+
+// The major number of the loop back devices
+#define LOOP_DEV_MAJOR_NUM          7
+
+// Storage helper methods (doesn't require state to work)
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Attempts to open an available loop device
+ *
+ *  WARNING this method requires sudo
+ *
+ *  @param[out]  loopDevice         Loop device name
+ *
+ *  @return on success a positive file descriptor corresponding to a free
+ *  loop device, -1 on error.
+ */
+int AndroidHelper::openLoopDevice(std::string* loopDevice)
+{
+    AI_LOG_FN_ENTRY();
+
+    // This is the part which require sudo!!
+    int devCtlFd = open("/dev/loop-control", O_RDWR | O_CLOEXEC);
+    if (devCtlFd < 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "failed to open '/dev/loop-control'");
+        return -1;
+    }
+
+    int devFd = -1;
+    for (unsigned attempts = 0; (attempts < 5) && (devFd < 0); attempts++)
+    {
+        int devNum = ioctl(devCtlFd, LOOP_CTL_GET_FREE);
+        if (devNum < 0)
+        {
+            AI_LOG_SYS_ERROR_EXIT(errno, "failed to get free device from loop control");
+            close(devCtlFd);
+            return -1;
+        }
+
+        AI_LOG_DEBUG("found free loop device number %d", devNum);
+
+        char loopDevPath[32];
+        sprintf(loopDevPath, "/dev/loop%d", devNum);
+
+        devFd = open(loopDevPath, O_RDWR | O_CLOEXEC);
+        if (devFd < 0)
+        {
+            // check if we failed because the devnode didn't exist, if this
+            // happens then we should go create the dev node ourselves, at this
+            // point we're racing against udev which may also be trying to
+            // create the dev node ... we don't care who wins as long as there
+            // is a dev node there when we try and open it
+            if (errno == ENOENT)
+            {
+                if (mknod(loopDevPath, (S_IFBLK | 0660),
+                          makedev(LOOP_DEV_MAJOR_NUM, devNum)) != 0)
+                {
+                    if (errno != EEXIST)
+                        AI_LOG_SYS_ERROR(errno, "failed to mknod '%s'", loopDevPath);
+                }
+            }
+
+            // try and open the devnode once again
+            devFd = open(loopDevPath, O_RDWR | O_CLOEXEC);
+        }
+
+        // check again if managed to open the file
+        if (devFd < 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to open '%s'", loopDevPath);
+
+            // try and release the loop device we created (but failed to
+            // connect to)
+            if (ioctl(devCtlFd, LOOP_CTL_REMOVE, devNum) != 0)
+                AI_LOG_SYS_ERROR(errno, "failed to free device from loop control");
+        }
+        else if (loopDevice != nullptr)
+        {
+            loopDevice->assign(loopDevPath);
+        }
+    }
+
+    if (close(devCtlFd) != 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "failed to close '/dev/loop-control'");
+    }
+
+    AI_LOG_FN_EXIT();
+    return devFd;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Attempts to attach the file to the loop device
+ *
+ *  @param[in] loopFd           An open file descriptor to the loop device
+ *  @param[in] fileFd           An open file descriptor that should be associate
+ *                              with the loop device.
+ *
+ *  @return on success a positive file desccriptor corresponding to a free
+ *  loop device, -1 on error.
+ */
+bool AndroidHelper::attachFileToLoopDevice(int loopFd, int fileFd)
+{
+    AI_LOG_FN_ENTRY();
+
+    if (ioctl(loopFd, LOOP_SET_FD, fileFd) < 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "failed to attach to file to loop device");
+        return false;
+    }
+
+    struct loop_info64 loopInfo;
+    bzero(&loopInfo, sizeof(loopInfo));
+    loopInfo.lo_flags = LO_FLAGS_AUTOCLEAR;
+
+    if (ioctl(loopFd, LOOP_SET_STATUS64, &loopInfo) < 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "failed to set the autoclear flag");
+
+        if (ioctl(loopFd, LOOP_CLR_FD, 0) < 0)
+        {
+            AI_LOG_SYS_WARN(errno, "failed to detach from loop device");
+        }
+
+        AI_LOG_FN_EXIT();
+        return false;
+    }
+
+    AI_LOG_DEBUG("attached file to loop device");
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Associates a give file descriptor with a loop device
+ *
+ *  First the function attempts to get a free loop device, if that succeeds it
+ *  attaches the supplied file descriptor to it and returns an fd to the loop
+ *  device and (optionally) writes the path to the loop device in the
+ *  @a loopDevPath string.
+ *
+ *  @param[in]  fileFd          An open file descriptor to associate with
+ *                              the loop device.
+ *  @param[out] loopDevPath     If not null, the method will write the path
+ *                              to the loop device dev node into the string
+ *
+ *  @return on success returns the open file descriptor to the loop device
+ *  associated with the file, on failure -1.
+ */
+int AndroidHelper::loopDeviceAssociate(int fileFd, std::string* loopDevPath /*= nullptr*/)
+{
+    AI_LOG_FN_ENTRY();
+
+    int loopDevFd = openLoopDevice(loopDevPath);
+    if (loopDevFd < 0)
+    {
+        AI_LOG_ERROR_EXIT("failed to open loop device");
+        return -1;
+    }
+
+    if (!attachFileToLoopDevice(loopDevFd, fileFd))
+    {
+        AI_LOG_ERROR_EXIT("failed to attach file to loop device");
+        close(loopDevFd);
+        return -1;
+    }
+
+    AI_LOG_FN_EXIT();
+    return loopDevFd;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Attaches the given file to an available loop device
+ *
+ *  @param[in]  sourceFile  The path to the image file.
+ *  @param[out] loopDevice  The path to the loop device that was attached.
+ *
+ *  @return the file descriptor to the loop device if attached, otherwise -1.
+ */
+int AndroidHelper::attachLoopDevice(const std::string& sourceFile,
+                                       std::string* loopDevice)
+{
+    AI_LOG_FN_ENTRY();
+
+    // check we managed to open the file
+    int fd = open(sourceFile.c_str(), O_CLOEXEC | O_RDWR);
+    if (fd < 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "failed to open file @ '%s'",
+                              sourceFile.c_str());
+        return -1;
+    }
+
+    // associate the fd with a free loop device
+    int loopDevFd = loopDeviceAssociate(fd, loopDevice);
+
+    // no longer need the backing file, can close
+    if (close(fd) != 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "failed to close file");
+    }
+
+    AI_LOG_INFO("Attached sourcefile '%s' to loopdevice '%s' with file description %d",
+                sourceFile.c_str(),
+                loopDevice->c_str(),
+                loopDevFd);
+
+    AI_LOG_FN_EXIT();
+    return loopDevFd;
+}
+
+// -------------------------------------------------------------------------
+/**
+ *  @brief Removes a directory and all it's contents.
+ *
+ *  This is equivalent to the 'rm -rf' command.
+ *
+ *  If the pathname given in pathname is relative, then it is interpreted
+ *  relative to the directory referred to by the file descriptor dirFd, if
+ *  dirFd is not supplied then it's relative to the cwd.
+ *
+ *  @warning This function only supports deleting directories with contents
+ *  that are less than 128 levels deep, this is to avoid running out of
+ *  file descriptors.
+ *
+ *  @param[in]  dirFd           If specified the path should be relative to
+ *                              to this directory.
+ *  @param[in]  path            The path to the directory to create.
+ *
+ *  @return true on success, false on failure.
+ */
+bool AndroidHelper::rmdirRecursive(int dirFd, const std::string& path)
+{
+    AI_LOG_FN_ENTRY();
+
+    // remove the directory contents first
+    bool success = rmdirContents(dirFd, path);
+    if (success)
+    {
+        // then delete the directory itself
+        if (unlinkat(dirFd, path.c_str(), AT_REMOVEDIR) != 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to remove dir at '%s", path.c_str());
+            success = false;
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+    return success;
+}
+
+// -------------------------------------------------------------------------
+/**
+ *  @brief Removes the contents of a directory but leave the actual
+ *  directory in place.
+ *
+ *  This is equivalent to the 'cd <dir>; rm -rf *' command.
+ *
+ *  If the pathname given in @a path is relative, then it is interpreted
+ *  relative to the directory referred to by the file descriptor @a dirFd, if
+ *  @a dirFd is not supplied then it's relative to the cwd.
+ *
+ *  @warning This function only supports deleting directories with contents
+ *  that are less than 128 levels deep, this is to avoid running out of
+ *  file descriptors.
+ *
+ *  @param[in]  dirFd           If specified the path should be relative to
+ *                              to this directory.
+ *  @param[in]  path            The path to the directory to create.
+ *
+ *  @return true on success, false on failure.
+ */
+bool AndroidHelper::rmdirContents(int dirFd, const std::string& path)
+{
+    AI_LOG_FN_ENTRY();
+
+    // get the fd of the directory to delete
+    int toDeleteFd = openat(dirFd, path.c_str(), O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+    if (toDeleteFd < 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "failed to open dir @ '%s'", path.c_str());
+        return false;
+    }
+
+    // recursively walks the directory deleting all the files and directories
+    // within it, this will also close the file descriptor
+    bool success = deleteRecursive(toDeleteFd, 128);
+
+    AI_LOG_FN_EXIT();
+    return success;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Recursive function that deletes everything within the supplied
+ *  directory (as a descriptor).
+ *
+ *  @param[in]  dirFd           If specified the path should be relative to
+ *                              to this directory.
+ *  @param[in]  availDepth      Maximal depth of recursion
+ *
+ *  @return true on success, false on failure.
+ *
+ *
+ */
+bool AndroidHelper::deleteRecursive(int dirfd, int availDepth)
+{
+    DIR* dir = fdopendir(dirfd);
+    if (!dir)
+    {
+        AI_LOG_SYS_ERROR(errno, "fdopendir failed");
+
+        // to maintain consistency we should close the fd in case of failure
+        if (close(dirfd) != 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to close dirfd");
+        }
+
+        return false;
+    }
+
+    bool success = true;
+
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != nullptr)
+    {
+        // skip the '.' and '..' entries
+        if ((entry->d_name[0] == '.') && ((entry->d_name[1] == '\0') ||
+                                          ((entry->d_name[1] == '.') && (entry->d_name[2] == '\0'))))
+        {
+            continue;
+        }
+
+        // if a directory then recurse into it
+        if (entry->d_type == DT_DIR)
+        {
+            // check we're not going to deep
+            if (--availDepth <= 0)
+            {
+                AI_LOG_ERROR("recursing to deep, aborting");
+                success = false;
+                break;
+            }
+
+            // try and open the dir
+            int fd = openat(dirfd, entry->d_name, O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+            if (fd < 0)
+            {
+                AI_LOG_SYS_ERROR(errno, "failed to open directory '%s'",
+                                 entry->d_name);
+                success = false;
+                break;
+            }
+            else
+            {
+                // recurse into the directory deleting it's contents, the
+                // function assumes ownership of the fd and will free (closedir)
+                if (!deleteRecursive(fd, availDepth))
+                {
+                    success = false;
+                    break;
+                }
+            }
+        }
+
+        int flags = (entry->d_type == DT_DIR) ? AT_REMOVEDIR : 0;
+
+        // try unlinking the file / directory / symlink / whatever
+        if (unlinkat(dirfd, entry->d_name, flags) != 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "failed to remove '%s'", entry->d_name);
+            success = false;
+            break;
+        }
+    }
+
+    closedir(dir);
+
+    return success;
+}
+
+// Tests Storage helpers
+#ifdef ENABLE_TESTS
+// cppcheck-suppress unusedFunction
+bool AndroidHelper::Test_mkdirRecursive(const std::string& rootfsPath)
+{
+    std::string tmp = "/home/private/";
+    tmp = rootfsPath + tmp;
+
+    tmp.append(".temp");
+
+    AI_LOG_INFO("temp path = '%s'", tmp.c_str());
+
+    // step 1 - create a directory within the rootfs
+    if (DobbyRdkPluginUtils::mkdirRecursive(tmp, 0700))
+    {
+        AI_LOG_INFO("Success");
+        return true;
+    }
+    else
+    {
+        AI_LOG_INFO("Fail");
+        return false;
+    }
+}
+
+// cppcheck-suppress unusedFunction
+bool AndroidHelper::Test_openLoopDevice()
+{
+    std::string loopDevPath;
+
+    int loopDevFd = openLoopDevice(&loopDevPath);
+    if (loopDevFd < 0)
+    {
+        AI_LOG_ERROR_EXIT("failed to open loop device");
+        return false;
+    }
+    else
+    {
+        AI_LOG_INFO("Opened loop mount =%s", loopDevPath.c_str());
+    }
+
+    if (close(loopDevFd) != 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "failed to close file");
+        return false;
+    }
+    return true;
+}
+
+// cppcheck-suppress unusedFunction
+bool AndroidHelper::Test_attachLoopDevice(std::string& imagePath)
+{
+    std::string loopDevice;
+
+    createFileIfNeeded(imagePath, 1024*10*12, 123, "ext4");
+
+    int loopDevFd = attachLoopDevice(imagePath, &loopDevice);
+    if ((loopDevFd < 0) || (loopDevice.empty()))
+    {
+        AI_LOG_ERROR("failed to attach file to loop device");
+        return false;
+    }
+    else if (close(loopDevFd) != 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "failed to close file");
+        return false;
+    }
+    else
+    {
+        AI_LOG_INFO("Successfully attached loop device =%s", loopDevice.c_str());
+    }
+
+    return true;
+}
+
+// cppcheck-suppress unusedFunction
+bool AndroidHelper::Test_cleanMountLostAndFound(const std::string& rootfsPath)
+{
+    std::string tmp = "/lost+found/some/long/path/file.xyz";
+    tmp = rootfsPath + tmp;
+
+    createFileIfNeeded(tmp, 1024*12*12, 123, "ext4");
+
+    cleanMountLostAndFound(rootfsPath, std::string("0"));
+}
+
+// cppcheck-suppress unusedFunction
+bool AndroidHelper::Test_checkWriteReadMount(const std::string& tmpPath)
+{
+    //Test
+    ssize_t nrd;
+    const char text[] = "Storage was runned\n";
+    const unsigned int BUFFER_SIZE = 100;
+
+    //std::string tmpPath = "/home/private/test.txt";
+    AI_LOG_INFO("path = '%s'", tmpPath.c_str());
+
+    int fd = open(tmpPath.c_str(), O_RDWR | O_CREAT | O_APPEND, 0777);
+    if (fd < 0)
+        AI_LOG_SYS_ERROR(errno, "failed to open");
+    else
+    {
+        AI_LOG_INFO("write fd = %d", fd);
+
+        nrd = write(fd,text, sizeof(text));
+        AI_LOG_INFO("write nrd = %d", nrd);
+        close(fd);
+    }
+
+    fd = open(tmpPath.c_str(), O_RDONLY, 0777);
+    if (fd < 0)
+        AI_LOG_SYS_ERROR(errno, "failed to open");
+    else
+    {
+        char buffer[BUFFER_SIZE] = "";
+        nrd = read(fd,buffer,BUFFER_SIZE);
+        if (nrd > 0) {
+            AI_LOG_INFO("Test file content '%s'", buffer);
+        }
+
+        AI_LOG_INFO("read nrd = %d", nrd);
+        close(fd);
+    }
+}
+#endif // ENABLE_TESTS

--- a/rdkPlugins/AndroidRuntime/source/AndroidHelper.h
+++ b/rdkPlugins/AndroidRuntime/source/AndroidHelper.h
@@ -1,0 +1,111 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File: AnroidHelper.h
+ *
+ */
+#ifndef ANDROID_HELPER_H
+#define ANDROID_HELPER_H
+
+#include <Logging.h>
+
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <string>
+#include <memory>
+#include <map>
+#include <mutex>
+#include <list>
+
+//#define ENABLE_TESTS 1
+
+/**
+ *  @brief Help functions for Storage related things
+ *
+ *  All low level help functions that doesn't rely on current state
+ */
+class AndroidHelper
+{
+public:
+    static int loopDeviceAssociate(int fileFd, std::string* loopDevPath);
+    static int openLoopDevice(std::string* loopDevice);
+    static bool attachFileToLoopDevice(int loopFd, int fileFd);
+    static int attachLoopDevice(const std::string& sourceFile,
+                                std::string* loopDevice);
+    static int getMountOptions(const std::list<std::string> &mountOptions);
+
+    // -------------------------------------------------------------------------
+    /**
+     *  @brief Removes a directory and all it's contents.
+     *
+     *  This is equivalent to the 'rm -rf <dir>' command.
+     *
+     *  If the pathname given in pathname is relative, then it is interpreted
+     *  relative to the directory referred to by the file descriptor dirFd, if
+     *  dirFd is not supplied then it's relative to the cwd.
+     *
+     *  @warning This function only supports deleting directories with contents
+     *  that are less than 128 levels deep, this is to avoid running out of
+     *  file descriptors.
+     *
+     *  @param[in]  dirFd           If specified the path should be relative to
+     *                              to this directory.
+     *  @param[in]  path            The path to the directory to create.
+     *
+     *  @return true on success, false on failure.
+     */
+    static bool rmdirRecursive(int dirFd, const std::string& path);
+
+    // -------------------------------------------------------------------------
+    /**
+     *  @brief Removes the contents of a directory but leave the actual
+     *  directory in place.
+     *
+     *  This is equivalent to the 'rm -rf <dir>/ *' command.
+     *
+     *  If the pathname given in pathname is relative, then it is interpreted
+     *  relative to the directory referred to by the file descriptor dirFd, if
+     *  dirFd is not supplied then it's relative to the cwd.
+     *
+     *  @warning This function only supports deleting directories with contents
+     *  that are less than 128 levels deep, this is to avoid running out of
+     *  file descriptors.
+     *
+     *  @param[in]  dirFd           If specified the path should be relative to
+     *                              to this directory.
+     *  @param[in]  path            The path to the directory to create.
+     *
+     *  @return true on success, false on failure.
+     */
+    static bool rmdirContents(int dirFd, const std::string& path);
+    static bool deleteRecursive(int dirfd, int depth);
+
+    // Tests
+#ifdef ENABLE_TESTS
+    static bool Test_mkdirRecursive(const std::string& rootfsPath);
+    static bool Test_openLoopDevice();
+    static bool Test_attachLoopDevice(std::string& imagePath);
+    static bool Test_cleanMountLostAndFound(const std::string& rootfsPath);
+    static bool Test_checkWriteReadMount(const std::string& tmpPath);
+#endif // ENABLE_TESTS
+
+};
+
+#endif // !defined(ANDROID_HELPER_H)

--- a/rdkPlugins/AndroidRuntime/source/AndroidRuntimePlugin.cpp
+++ b/rdkPlugins/AndroidRuntime/source/AndroidRuntimePlugin.cpp
@@ -1,0 +1,380 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or imied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "AndroidRuntimePlugin.h"
+#include "AndroidHelper.h"
+#include "rt_defs_plugins.h"
+
+#include <Logging.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <limits.h>
+
+REGISTER_RDK_PLUGIN(AndroidRuntimePlugin);
+
+AndroidRuntimePlugin::AndroidRuntimePlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
+                                 const std::shared_ptr<DobbyRdkPluginUtils> &utils,
+                                 const std::string &rootfsPath)
+    : mName("AndroidRuntime"),
+      mRootfsPath(rootfsPath),
+      mContainerConfig(containerConfig),
+      mUtils(utils)
+{
+    AI_LOG_FN_ENTRY();
+
+    if (mContainerConfig == nullptr ||
+        mContainerConfig->rdk_plugins->androidruntime == nullptr ||
+        mContainerConfig->rdk_plugins->androidruntime->data == nullptr)
+    {
+        AI_LOG_ERROR("No AndroidRuntime configuration provided");
+        return;
+    }
+
+    const rt_defs_plugins_android_runtime_data *pluginData = mContainerConfig->rdk_plugins->androidruntime->data;
+
+    if(pluginData->system_path == nullptr)
+    {
+        AI_LOG_ERROR("No path to system.img provided");
+        return;
+    }
+    mSystemPath = std::string(pluginData->system_path);
+    AI_LOG_INFO("Android system.img path is %s\n", mSystemPath.c_str());
+
+    if(pluginData->vendor_path == nullptr)
+    {
+        AI_LOG_ERROR("No path to vendor.img provided");
+        return;
+    }
+    mVendorPath = std::string(pluginData->vendor_path);
+    AI_LOG_INFO("Android vendor.img path is %s\n", mVendorPath.c_str());
+
+    if(pluginData->data_path == nullptr)
+    {
+        AI_LOG_ERROR("No path to data directory provided");
+        return;
+    }
+    mDataPath = std::string(pluginData->data_path);
+    AI_LOG_INFO("Android userdata path is %s\n", mDataPath.c_str());
+
+    if(pluginData->cache_path == nullptr)
+    {
+        AI_LOG_ERROR("No path to cache directory provided");
+        return;
+    }
+    mCachePath = std::string(pluginData->cache_path);
+    AI_LOG_INFO("Android cache path is %s\n", mCachePath.c_str());
+
+    if(pluginData->cmdline_path == nullptr)
+    {
+        AI_LOG_ERROR("No path to kernel commandline file provided");
+        return;
+    }
+    mCmdlinePath = std::string(pluginData->cmdline_path);
+    AI_LOG_INFO("Android cmdline path is %s\n", mCmdlinePath.c_str());
+
+    mValid = true;
+    AI_LOG_INFO("Started Android runtime plugin");
+    AI_LOG_FN_EXIT();
+}
+
+unsigned AndroidRuntimePlugin::hookHints() const
+{
+    return IDobbyRdkPlugin::HintFlags::PostInstallationFlag |
+           IDobbyRdkPlugin::HintFlags::PostHaltFlag;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief postInstalllation OCI hook.
+ *
+ *  If set_tz parameter is set then its value should be a path to file.
+ *  Read this file and put its contents into containers TZ env var.
+ *
+ *  @return true on success, false on failure.
+ */
+bool AndroidRuntimePlugin::postInstallation()
+{
+    AI_LOG_FN_ENTRY();
+
+    if (!mValid)
+    {
+        AI_LOG_ERROR("Configuration not valid - not mounting");
+        return false;
+    }
+
+    doMounts();
+
+    std::string etcPath = mRootfsPath + "etc";
+    struct stat s;
+
+    // There may be a symlink from /etc to /system/etc in the container, remove it if present
+    // so that the Networking plugin can populate /etc
+    if (lstat(etcPath.c_str(), &s) == 0)
+    {
+        if (S_ISLNK(s.st_mode))
+        {
+            if(unlink(etcPath.c_str()) < 0)
+            {
+                AI_LOG_SYS_ERROR_EXIT(errno, "Failed to remove %s symlink", etcPath.c_str());
+                return false;
+            }
+            else
+            {
+                AI_LOG_INFO("Removed symlink %s", etcPath.c_str());
+            }
+        }
+    }
+    else
+    {
+        AI_LOG_INFO("%s cannot be statted", etcPath.c_str());
+    }
+
+    if (mUtils->mkdirRecursive(mRootfsPath + "/etc", 0755))
+    {
+        AI_LOG_INFO("Ensured /etc exists in rootfs");
+    }
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief postHalt OCI hook.
+ *
+ *
+ *  @return true on success, false on failure.
+ */
+bool AndroidRuntimePlugin::postHalt()
+{
+    AI_LOG_FN_ENTRY();
+
+    doUnmounts();
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+
+/**
+ * @brief Should return the names of the plugins this plugin depends on.
+ *
+ * This can be used to determine the order in which the plugins should be
+ * processed when running hooks.
+ *
+ * @return Names of the plugins this plugin depends on.
+ */
+std::vector<std::string> AndroidRuntimePlugin::getDependencies() const
+{
+    std::vector<std::string> dependencies;
+
+    return dependencies;
+}
+
+bool AndroidRuntimePlugin::doLoopMount(const std::string &src, const std::string &dest)
+{
+    AI_LOG_FN_ENTRY();
+    int fdSrc = open(src.c_str(), O_RDWR);
+
+    if (fdSrc < 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "Failed to open source file %s", src.c_str());
+        return false;
+    }
+
+    if (!mUtils->mkdirRecursive(dest, 0755))
+    {
+        AI_LOG_ERROR_EXIT("Failed to create loop mount destination directory %s", dest.c_str());
+        return false;
+    }
+
+    std::string deviceLoop;
+    int fdLoop = AndroidHelper::openLoopDevice(&deviceLoop);
+    if (fdLoop < 0)
+    {
+        close(fdSrc);
+        AI_LOG_SYS_ERROR_EXIT(errno, "Failed to open free loop device");
+        return false;
+    }
+
+    int fdAttached = AndroidHelper::attachFileToLoopDevice(fdLoop, fdSrc);
+    if (fdAttached < 0)
+    {
+        close(fdSrc);
+        close(fdLoop);
+        AI_LOG_SYS_ERROR_EXIT(errno, "Failed to open free loop device");
+        return false;
+    }
+
+    if (mount(deviceLoop.c_str(), dest.c_str(), "ext4", 0, NULL) < 0)
+    {
+        close(fdAttached);
+        close(fdSrc);
+        close(fdLoop);
+        AI_LOG_SYS_ERROR_EXIT(errno, "Failed to mount system.img");
+        return false;
+    }
+
+    close(fdLoop); // fd is associated to mount now, so close this one so loop device will auto-free when unmounted
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+bool AndroidRuntimePlugin::doBindMount(const std::string &src, const std::string &dest)
+{
+    AI_LOG_FN_ENTRY();
+    if (access(src.c_str(), F_OK) != 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "Failed to open source file %s", src.c_str());
+        return false;
+    }
+
+    if (!mUtils->mkdirRecursive(dest, 0755))
+    {
+        AI_LOG_ERROR_EXIT("Failed to create bind mount destination directory %s", dest.c_str());
+        return false;
+    }
+
+    if (mount(src.c_str(), dest.c_str(), NULL, MS_BIND, nullptr) < 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "Mount failed %s->%s", src.c_str(), dest.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+bool AndroidRuntimePlugin::doBindFile(const std::string &src, const std::string &dest)
+{
+    AI_LOG_FN_ENTRY();
+    if (access(src.c_str(), F_OK) != 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "Failed to open source file %s", src.c_str());
+        return false;
+    }
+
+    int fdDest = open(dest.c_str(), O_RDWR | O_CREAT);
+    if (fdDest < 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "Failed to open destination file for bind %s", dest.c_str());
+        return false;
+    }
+    close(fdDest);
+
+    if (mount(src.c_str(), dest.c_str(), NULL, MS_BIND, nullptr) < 0)
+    {
+        AI_LOG_SYS_ERROR_EXIT(errno, "Bind mount file failed %s->%s", src.c_str(), dest.c_str());
+        return false;
+    }
+
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+#define MOUNT_VENDOR  "/vendor"
+#define MOUNT_DATA    "/data"
+#define MOUNT_CACHE   "/cache"
+#define MOUNT_CMDLINE "/cmdline"
+
+bool AndroidRuntimePlugin::doMounts()
+{
+    AI_LOG_FN_ENTRY();
+
+    if(!mMounted.empty())
+    {
+        AI_LOG_ERROR("Attempt to mount again before unmounting previous");
+        return false;
+    }
+
+    std::string dest;
+
+    dest = mRootfsPath;
+    if (!doLoopMount(mSystemPath.c_str(), dest))
+    {
+        AI_LOG_ERROR_EXIT("Failed to loop mount %s", dest.c_str());
+        return false;
+    }
+    mMounted.push_back(dest.c_str());
+
+    dest = mRootfsPath + MOUNT_VENDOR;
+    if (!doLoopMount(mVendorPath.c_str(), dest))
+    {
+        AI_LOG_ERROR_EXIT("Failed to loop mount %s", mVendorPath.c_str());
+        return false;
+    }
+    mMounted.push_back(dest.c_str());
+
+    dest = mRootfsPath + MOUNT_DATA;
+    if(!doBindMount(mDataPath, dest))
+    {
+        AI_LOG_ERROR_EXIT("Failed to bind mount %s->%s", mDataPath.c_str(), dest.c_str());
+        return false;
+    }
+    mMounted.push_back(dest.c_str());
+
+    dest = mRootfsPath + MOUNT_DATA + MOUNT_CACHE;
+    if(!doBindMount(mCachePath, dest))
+    {
+        AI_LOG_ERROR_EXIT("Failed to bind mount %s->%s", mCachePath.c_str(), dest.c_str());
+        return false;
+    }
+    mMounted.push_back(dest.c_str());
+
+    dest = mRootfsPath + MOUNT_CMDLINE;
+    if(!doBindFile(mCmdlinePath, dest))
+    {
+        AI_LOG_ERROR_EXIT("Failed to bind file %s->%s", mCmdlinePath.c_str(), dest.c_str());
+        return false;
+    }
+    mMounted.push_back(dest.c_str());
+
+    for(std::string s : mMounted)
+    {
+        AI_LOG_INFO("Mounted %s", s.c_str());
+    }
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+bool AndroidRuntimePlugin::doUnmounts()
+{
+    AI_LOG_FN_ENTRY();
+
+    AI_LOG_INFO("doUnmount complete");
+    for(std::vector<std::string>::reverse_iterator it = mMounted.rbegin(); it != mMounted.rend(); it++)
+    {
+        AI_LOG_INFO("Unmounting %s", it->c_str());
+        if(umount2(it->c_str(), UMOUNT_NOFOLLOW) < 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "Failed to unmount %s", it->c_str());
+        }
+    }
+    mMounted.clear();
+
+    AI_LOG_INFO("doUnmount complete");
+
+    AI_LOG_FN_EXIT();
+
+    return true;
+}

--- a/rdkPlugins/AndroidRuntime/source/AndroidRuntimePlugin.h
+++ b/rdkPlugins/AndroidRuntime/source/AndroidRuntimePlugin.h
@@ -1,0 +1,80 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 Sky UK
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef ANDROIDRUNTIMEPLUGIN_H
+#define ANDROIDRUNTIMEPLUGIN_H
+
+#include <RdkPluginBase.h>
+#include <complex>
+
+/**
+ * @brief Dobby AndroidRuntime plugin.
+ *
+ * This plugin mounts and Android system into the container:
+ *      - system.img
+ *      - vendor.img
+ *      - data and cache directory
+ *      - kernel command line
+ *
+ */
+class AndroidRuntimePlugin : public RdkPluginBase
+{
+public:
+    AndroidRuntimePlugin(std::shared_ptr<rt_dobby_schema> &containerConfig,
+                    const std::shared_ptr<DobbyRdkPluginUtils> &utils,
+                    const std::string &rootfsPath);
+
+public:
+    inline std::string name() const override
+    {
+        return mName;
+    };
+
+    unsigned hookHints() const override;
+
+public:
+    bool postInstallation() override;
+    bool postHalt() override;
+
+public:
+    std::vector<std::string> getDependencies() const override;
+
+private:
+    bool doMounts();
+    bool doLoopMount(const std::string &src, const std::string &dest);
+    bool doBindMount(const std::string &src, const std::string &dest);
+    bool doBindFile(const std::string &src, const std::string &dest);
+    bool doUnmounts();
+    const std::string mName;
+    const std::string mRootfsPath;
+    std::shared_ptr<rt_dobby_schema> mContainerConfig;
+    const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
+
+    bool mValid = false;
+
+    std::string mSystemPath;
+    std::string mVendorPath;
+    std::string mDataPath;
+    std::string mCachePath;
+    std::string mCmdlinePath;
+    std::string mApkPath;
+    std::vector<std::string> mMounted;
+};
+
+#endif // !defined(ANDROIDRUNTIMEPLUGIN_H)

--- a/rdkPlugins/AndroidRuntime/source/AndroidRuntimePlugin.h
+++ b/rdkPlugins/AndroidRuntime/source/AndroidRuntimePlugin.h
@@ -60,6 +60,7 @@ private:
     bool doLoopMount(const std::string &src, const std::string &dest);
     bool doBindMount(const std::string &src, const std::string &dest);
     bool doBindFile(const std::string &src, const std::string &dest);
+    bool doTmpfsMount(const std::string &dest);
     bool doUnmounts();
     const std::string mName;
     const std::string mRootfsPath;
@@ -67,6 +68,8 @@ private:
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
 
     bool mValid = false;
+
+    std::string mRootFsType;
 
     std::string mSystemPath;
     std::string mVendorPath;

--- a/settings/include/IDobbySettings.h
+++ b/settings/include/IDobbySettings.h
@@ -196,6 +196,7 @@ public:
         std::set<int> groupIds;
         std::list<ExtraMount> extraMounts;
         std::map<std::string, std::string> extraEnvVariables;
+        std::string appArmorProfile;
     };
 
     // -------------------------------------------------------------------------

--- a/settings/include/IDobbySettings.h
+++ b/settings/include/IDobbySettings.h
@@ -157,6 +157,55 @@ public:
      */
     virtual std::shared_ptr<HardwareAccessSettings> vpuAccessSettings() const = 0;
 
+    /**
+     *  Describes the details of any extra device nodes needed for Android Runtime.
+     *  This is needed due to the need for specific major and minor numbers.
+     */
+    struct AndroidDeviceNode
+    {
+        std::string path;
+        int major;
+        int minor;
+        int filemode;
+    };
+
+    // -------------------------------------------------------------------------
+    /**
+     *  Describes the details of anything extra needed to enable Android Runtime.
+     *
+     *      - deviceNodes
+     *          List of extra device nodes that need to be mapped into
+     *          the container to allow the apps to use the H/W.
+     *      - groupIds
+     *          The group id that the app needs to be in to access the
+     *          H/W device nodes. If not empty then the containered app will be
+     *          in that supplementary group(s).
+     *      - extraMounts
+     *          The details of any additional mounts required to access
+     *          the H/W. For example this is used on nexus platforms to map in
+     *          the nexus server socket.  This can also be used to map in
+     *          extra files / sockets used by the software.
+     *      - extraEnvVariables
+     *          A list of extra environment variables that will be set for all
+     *          containers if the given H/W access is requested.
+     *
+     */
+    struct AndroidAccessSettings
+    {
+        std::list<AndroidDeviceNode> deviceNodes;
+        std::set<int> groupIds;
+        std::list<ExtraMount> extraMounts;
+        std::map<std::string, std::string> extraEnvVariables;
+    };
+
+    // -------------------------------------------------------------------------
+    /**
+     *  @brief Returns any extra details needed to access the VPU (video
+     *  pipeline) inside the container.
+     *
+     */
+    virtual std::shared_ptr<AndroidAccessSettings> androidAccessSettings() const = 0;
+
     // -------------------------------------------------------------------------
     /**
      *  @brief Returns the set of external interface that container traffic

--- a/settings/include/Settings.h
+++ b/settings/include/Settings.h
@@ -68,6 +68,7 @@ public:
 public:
     std::shared_ptr<HardwareAccessSettings> gpuAccessSettings() const override;
     std::shared_ptr<HardwareAccessSettings> vpuAccessSettings() const override;
+    std::shared_ptr<AndroidAccessSettings> androidAccessSettings() const override;
 
     std::vector<std::string> externalInterfaces() const override;
     std::string addressRangeStr() const override;
@@ -110,6 +111,15 @@ private:
     std::shared_ptr<HardwareAccessSettings> getHardwareAccess(const Json::Value& root,
                                                               const Json::Path& path) const;
 
+    std::list<AndroidDeviceNode> getAndroidNodes(const Json::Value& root,
+                                           const Json::Path& path) const;
+
+    bool processAndroidDevice(const Json::Value& value,
+                              AndroidDeviceNode* devNode) const;
+
+    std::shared_ptr<AndroidAccessSettings> getAndroidAccess(const Json::Value& root,
+		                                            const Json::Path& path) const;
+
     void dumpHardwareAccess(int aiLogLevel, const std::string& name,
                             const std::shared_ptr<const HardwareAccessSettings>& hwAccess) const;
 
@@ -122,6 +132,7 @@ private:
 
     std::shared_ptr<HardwareAccessSettings> mGpuHardwareAccess;
     std::shared_ptr<HardwareAccessSettings> mVpuHardwareAccess;
+    std::shared_ptr<AndroidAccessSettings> mAndroidHardwareAccess;
 
     std::vector<std::string> mExternalInterfaces;
     std::pair<std::string, in_addr_t> mAddressRange;

--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -164,6 +164,12 @@ Settings::Settings(const Json::Value& settings)
             getHardwareAccess(settings, Json::Path(".vpu"));
     }
 
+    // process the Android settings
+    {
+        mAndroidHardwareAccess =
+            getAndroidAccess(settings, Json::Path(".android"));
+    }
+
     // process the network settings
     {
         Json::Value externalIfaces = Json::Path(".network.externalInterfaces").resolve(settings);
@@ -473,6 +479,16 @@ std::shared_ptr<IDobbySettings::HardwareAccessSettings> Settings::vpuAccessSetti
     return mVpuHardwareAccess;
 }
 
+// -----------------------------------------------------------------------------
+/**
+ *  @brief
+ *
+ */
+std::shared_ptr<IDobbySettings::AndroidAccessSettings> Settings::androidAccessSettings() const
+{
+    return mAndroidHardwareAccess;
+}
+
  // -----------------------------------------------------------------------------
  /**
  *  @brief
@@ -592,6 +608,7 @@ void Settings::dump(int aiLogLevel) const
 
     dumpHardwareAccess(aiLogLevel, "gpu", mGpuHardwareAccess);
     dumpHardwareAccess(aiLogLevel, "vpu", mVpuHardwareAccess);
+    //dumpHardwareAccess(aiLogLevel, "android", mAndroidHardwareAccess);
 }
 
 // -----------------------------------------------------------------------------
@@ -941,6 +958,66 @@ std::list<std::string> Settings::getDevNodes(const Json::Value& root,
     return result;
 }
 
+std::list<Settings::AndroidDeviceNode> Settings::getAndroidNodes(const Json::Value& root,
+                                                 const Json::Path& path) const
+{
+    const Json::Value &devNodes = Json::Path(path).resolve(root);
+    if (devNodes.isNull())
+    {
+	return std::list<AndroidDeviceNode>();
+    }
+    else if (!devNodes.isArray())
+    {
+        AI_LOG_ERROR("JSON value in settings file is not an array (of dev nodes)");
+	return std::list<AndroidDeviceNode>();
+    }
+
+    std::list<AndroidDeviceNode> result;
+    for (const Json::Value &devNode : devNodes)
+    {
+	if (!devNode.isObject())
+	{
+	    AI_LOG_ERROR("invalid JSON value in dev nodes array in settings file");
+	    return std::list<AndroidDeviceNode>();
+	}
+
+	AndroidDeviceNode androidDevNode;
+	if (processAndroidDevice(devNode, &androidDevNode))
+	{
+	    result.emplace_back(androidDevNode);
+	}
+    }
+
+    return result;
+}
+
+bool Settings::processAndroidDevice(const Json::Value& value, AndroidDeviceNode* devNode) const
+{
+    const Json::Value& path = value["path"];
+    const Json::Value& major = value["major"];
+    const Json::Value& minor = value["minor"];
+    const Json::Value& fileMode = value["fileMode"];
+
+    if (!path.isString())
+    {
+        AI_LOG_ERROR("invalid 'path' JSON field");
+	return false;
+    }
+
+    if (!major.isInt() || !minor.isInt() || !fileMode.isInt())
+    {
+        AI_LOG_ERROR("invalid 'major', 'minor' or 'fileMode' JSON field");
+	return false;
+    }
+
+    devNode->path = path.asString();
+    devNode->major = major.asInt();
+    devNode->minor = minor.asInt();
+    devNode->filemode = fileMode.asInt();
+
+    return true;
+}
+
 // -----------------------------------------------------------------------------
 /**
  *  @brief Attempts to read the mount JSON structure(s) from the object.
@@ -1022,7 +1099,8 @@ bool Settings::processMountObject(const Json::Value& value, ExtraMount* mount) c
     static const std::set<std::string> mountFlags =
         {
             "rbind", "bind", "silent", "ro", "sync", "nosuid", "dirsync",
-            "nodiratime", "relatime", "noexec", "nodev", "noatime", "strictatime"
+            "nodiratime", "relatime", "noexec", "nodev", "noatime", "strictatime",
+            "mode=0755"
         };
 
     // convert the mount flags
@@ -1115,6 +1193,85 @@ std::shared_ptr<IDobbySettings::HardwareAccessSettings> Settings::getHardwareAcc
     // Nb: validation that the paths are actually dev nodes is done in the
     // DobbyConfig code
     accessSettings->deviceNodes = getDevNodes(hw, Json::Path(".devNodes"));
+
+    // get any extra mounts
+    accessSettings->extraMounts = getExtraMounts(hw, Json::Path(".extraMounts"));
+
+    // get any extra environment vars
+    accessSettings->extraEnvVariables = getEnvVarsFromJson(hw, Json::Path(".extraEnvVariables"));
+
+    return accessSettings;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Processes a json 'android' object.
+ *
+ *  The JSON is expected to look like the following:
+ *
+ *      {
+ *          "groupIds": [ "video" ],
+ *          "devNodes": [
+ *              {
+ *                  "path": "/dev/kmsg",
+ *                  "fileMode": 438,
+ *                  "major": 1,
+ *                  "minor": 11
+ *              },
+ *          "extraEnvVariables": [
+ *              "ENABLE_MEDIAINFO=0"
+ *          ],
+ *          "extraMounts": [
+ *              {
+ *                  "source": "/etc/xdg/gstomx.conf",
+ *                  "destination": "/etc/xdg/gstomx.conf",
+ *                  "type": "bind",
+ *                  "options": [ "bind", "ro", "nosuid", "nodev", "noexec" ]
+ *              },
+ *              ...
+ *          ]
+ *      }
+ *
+ *  @return
+ */
+
+std::shared_ptr<IDobbySettings::AndroidAccessSettings> Settings::getAndroidAccess(const Json::Value& root,
+                                                                                    const Json::Path& path) const
+{
+    auto accessSettings =
+            std::make_shared<IDobbySettings::AndroidAccessSettings>();
+
+    // get the 'android' object from the json
+    const Json::Value hw = Json::Path(path).resolve(root);
+    if (hw.isNull())
+    {
+        // it's not an error if the value does not exist in the JSON
+        return accessSettings;
+    }
+    else if (!hw.isObject())
+    {
+        // however it is an error if present but not a json object
+        AI_LOG_ERROR("invalid 'android' JSON field in dobby settings file");
+        return accessSettings;
+    }
+
+
+    // get the group id(s) required
+    const Json::Value groupIds = hw["groupIds"];
+    if (!groupIds.isNull())
+    {
+        accessSettings->groupIds = getGroupIds(groupIds);
+    }
+    else
+    {
+        const Json::Value groupId = hw["groupId"];
+        if (!groupId.isNull())
+            accessSettings->groupIds = getGroupIds(groupId);
+    }
+
+    // Nb: validation that the paths are actually dev nodes is done in the
+    // DobbyConfig code
+    accessSettings->deviceNodes = getAndroidNodes(hw, Json::Path(".devNodes"));
 
     // get any extra mounts
     accessSettings->extraMounts = getExtraMounts(hw, Json::Path(".extraMounts"));

--- a/settings/source/Settings.cpp
+++ b/settings/source/Settings.cpp
@@ -964,28 +964,28 @@ std::list<Settings::AndroidDeviceNode> Settings::getAndroidNodes(const Json::Val
     const Json::Value &devNodes = Json::Path(path).resolve(root);
     if (devNodes.isNull())
     {
-	return std::list<AndroidDeviceNode>();
+        return std::list<AndroidDeviceNode>();
     }
     else if (!devNodes.isArray())
     {
         AI_LOG_ERROR("JSON value in settings file is not an array (of dev nodes)");
-	return std::list<AndroidDeviceNode>();
+        return std::list<AndroidDeviceNode>();
     }
 
     std::list<AndroidDeviceNode> result;
     for (const Json::Value &devNode : devNodes)
     {
-	if (!devNode.isObject())
-	{
-	    AI_LOG_ERROR("invalid JSON value in dev nodes array in settings file");
-	    return std::list<AndroidDeviceNode>();
-	}
+        if (!devNode.isObject())
+        {
+            AI_LOG_ERROR("invalid JSON value in dev nodes array in settings file");
+            return std::list<AndroidDeviceNode>();
+        }
 
-	AndroidDeviceNode androidDevNode;
-	if (processAndroidDevice(devNode, &androidDevNode))
-	{
-	    result.emplace_back(androidDevNode);
-	}
+        AndroidDeviceNode androidDevNode;
+        if (processAndroidDevice(devNode, &androidDevNode))
+        {
+            result.emplace_back(androidDevNode);
+        }
     }
 
     return result;
@@ -1278,6 +1278,20 @@ std::shared_ptr<IDobbySettings::AndroidAccessSettings> Settings::getAndroidAcces
 
     // get any extra environment vars
     accessSettings->extraEnvVariables = getEnvVarsFromJson(hw, Json::Path(".extraEnvVariables"));
+
+    const Json::Value appArmorProfile = hw["appArmorProfile"];
+    if (appArmorProfile.isNull())
+    {
+        AI_LOG_INFO("No Android AppArmor profile provided - will use default");
+    }
+    else if (appArmorProfile.isString())
+    {
+        accessSettings->appArmorProfile = appArmorProfile.asString();
+    }
+    else
+    {
+        AI_LOG_ERROR("Invalid entry in android.appArmorProfile");
+    }
 
     return accessSettings;
 }

--- a/tests/L1_testing/mocks/DobbySettingsMock.h
+++ b/tests/L1_testing/mocks/DobbySettingsMock.h
@@ -31,6 +31,7 @@ class DobbySettingsMock : public IDobbySettings {
     MOCK_METHOD(std::string, consoleSocketPath, (), (const, override));
     MOCK_METHOD(std::shared_ptr<HardwareAccessSettings>, gpuAccessSettings, (), (const, override));
     MOCK_METHOD(std::shared_ptr<HardwareAccessSettings>, vpuAccessSettings, (), (const, override));
+    MOCK_METHOD(std::shared_ptr<AndroidAccessSettings>, androidAccessSettings, (), (const, override));
     MOCK_METHOD(std::vector<std::string>, externalInterfaces, (), (const, override));
     MOCK_METHOD(std::string, addressRangeStr, (), (const, override));
     MOCK_METHOD(in_addr_t, addressRange, (), (const, override));

--- a/tests/L1_testing/mocks/DobbySpecConfig.h
+++ b/tests/L1_testing/mocks/DobbySpecConfig.h
@@ -43,6 +43,7 @@ public:
     virtual bool isValid() const =0;
     virtual std::shared_ptr<rt_dobby_schema> config() const =0;
     virtual bool restartOnCrash() const =0;
+    virtual bool androidEnabled() const =0;
 
 };
 
@@ -70,6 +71,7 @@ public:
 
     std::shared_ptr<rt_dobby_schema> config() const;
     bool restartOnCrash() const;
+    bool androidEnabled() const;
 };
 
 #endif // !defined(DOBBYSPECCONFIG_H)

--- a/tests/L1_testing/mocks/DobbySpecConfigMock.cpp
+++ b/tests/L1_testing/mocks/DobbySpecConfigMock.cpp
@@ -85,3 +85,10 @@ bool DobbySpecConfig::restartOnCrash() const
 
     return impl->restartOnCrash();
 }
+
+bool DobbySpecConfig::androidEnabled() const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->androidEnabled();
+}

--- a/tests/L1_testing/mocks/DobbySpecConfigMock.h
+++ b/tests/L1_testing/mocks/DobbySpecConfigMock.h
@@ -36,5 +36,6 @@ public:
     MOCK_METHOD(bool ,isValid, (), (const,override));
     MOCK_METHOD(std::shared_ptr<rt_dobby_schema> ,config, (), (const));
     MOCK_METHOD(bool ,restartOnCrash, (), (const));
+    MOCK_METHOD(bool ,androidEnabled, (), (const));
 
 };


### PR DESCRIPTION
- Manage mounting android partitions
- OCI Template modifications for Android
- Extra settings for Android specific bind mounts and devices

It is not required to modify the base dobby.bb, but a device specific addition to the Dobby config must be made as required to support running Android on a specific device.
 
### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)