### PR TITLE
RDK-48618 : Skip the installation of settings file if DONT_INSTALL_DEVICESETTINGSFILE is set

### DIFF
--- a/daemon/process/CMakeLists.txt
+++ b/daemon/process/CMakeLists.txt
@@ -128,11 +128,14 @@ endif()
 
 message("Using settings from ${DOBBY_SETTINGS_FILE}")
 
-install(
-        FILES       "${DOBBY_SETTINGS_FILE}"
-        RENAME      dobby.json
-        DESTINATION /etc/ )
-
+if ( "${DOBBY_SETTINGS_FILE}" STREQUAL "DONT_INSTALL_DEVICESETTINGSFILE" )
+        message("Skipping the installation of device settings file")
+else()
+        install(
+                FILES       "${DOBBY_SETTINGS_FILE}"
+                RENAME      dobby.json
+                DESTINATION /etc/ )
+endif()
 
 if (USE_SYSTEMD)
         # Install a systemd launch service config and enables it by default

--- a/daemon/process/CMakeLists.txt
+++ b/daemon/process/CMakeLists.txt
@@ -126,11 +126,10 @@ else()
         endif()
 endif()
 
-message("Using settings from ${DOBBY_SETTINGS_FILE}")
-
 if ( "${DOBBY_SETTINGS_FILE}" STREQUAL "DONT_INSTALL_DEVICESETTINGSFILE" )
         message("Skipping the installation of device settings file")
 else()
+        message("Using settings from ${DOBBY_SETTINGS_FILE}")
         install(
                 FILES       "${DOBBY_SETTINGS_FILE}"
                 RENAME      dobby.json


### PR DESCRIPTION
### Description
In RDK-E, we need to skip the installation of settings file from middleware layer. So, in dobby recipe if "DONT_INSTALL_DEVICESETTINGSFILE" is set, skip the installation of settings file.

### Test Procedure
Check whether /etc/dobby.json is not present in the rootfs when build option "DONT_INSTALL_DEVICESETTINGSFILE is set.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)