### PR TITLE
[RDK-52502] added new mount/unmount APIs

### DIFF
--- a/AppInfrastructure/Public/Dobby/IDobbyProxy.h
+++ b/AppInfrastructure/Public/Dobby/IDobbyProxy.h
@@ -148,6 +148,10 @@ public:
 
     virtual bool wakeupContainer(int32_t descriptor) const = 0;
 
+    virtual bool addContainerMount(int32_t descriptor, const std::string& source, const std::string& destination, int32_t mountFlags) const = 0;
+    
+    virtual bool removeContainerMount(int32_t descriptor, const std::string& source) const = 0;
+
     virtual bool execInContainer(int32_t cd,
                                  const std::string& options,
                                  const std::string& command) const = 0;

--- a/AppInfrastructure/Public/Dobby/IDobbyProxy.h
+++ b/AppInfrastructure/Public/Dobby/IDobbyProxy.h
@@ -148,7 +148,7 @@ public:
 
     virtual bool wakeupContainer(int32_t descriptor) const = 0;
 
-    virtual bool addContainerMount(int32_t descriptor, const std::string& source, const std::string& destination, int32_t mountFlags) const = 0;
+    virtual bool addContainerMount(int32_t descriptor, const std::string& source, const std::string& destination, const std::string& mountFlags) const = 0;
     
     virtual bool removeContainerMount(int32_t descriptor, const std::string& source) const = 0;
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,13 @@ cmake_minimum_required( VERSION 3.7.0 )
 include(GNUInstallDirs)
 
 # Project setup
-project( Dobby VERSION "3.10.2" )
+project( Dobby VERSION "3.11.0" )
 
 
 # Set the major and minor version numbers of dobby (also used by plugins)
 set( DOBBY_MAJOR_VERSION 3 )
-set( DOBBY_MINOR_VERSION 10 )
-set( DOBBY_MICRO_VERSION 2 )
+set( DOBBY_MINOR_VERSION 11 )
+set( DOBBY_MICRO_VERSION 0 )
 
 set(INSTALL_CMAKE_DIR lib/cmake/Dobby)
 

--- a/README.md
+++ b/README.md
@@ -131,15 +131,19 @@ vagrant@dobby-vagrant:~$ DobbyTool help
 quit              quit
 help              help [command]
 shutdown          shutdown
-start             start [options...] <id> <specfile/bundlepath> [command]
+start             start [options...] <id> <bundlepath> [command]
 stop              stop <id> [options...]
 pause             pause <id>
 resume            resume <id>
+hibernate         hibernate [options...] <id>
+wakeup            wakeup <id>
+mount             mount <id> <source> <destination> <mountFlags>
+unmount           unmount <id> <source>
 exec              exec [options...] <id> <command>
 list              list
 info              info <id>
-dumpspec          dumpspec <id> [options...]
-bundle            bundle <id> <specfile> [options...]
+wait              wait <id> <state>
+set-log-level     set-log-level <level>
 set-dbus          set-dbus <private>|<public> <address>
 ```
 For more information about a command, run `DobbyTool help [command]`. For example:

--- a/client/lib/include/DobbyProxy.h
+++ b/client/lib/include/DobbyProxy.h
@@ -102,6 +102,10 @@ public:
     bool hibernateContainer(int32_t descriptor, const std::string& options) const override;
 
     bool wakeupContainer(int32_t descriptor) const override;
+    
+    bool addContainerMount(int32_t descriptor, const std::string& source, const std::string& destination, int32_t mountFlags) const override;
+    
+    bool removeContainerMount(int32_t descriptor, const std::string& source) const override;
 
     bool execInContainer(int32_t cd,
                          const std::string& options,

--- a/client/lib/include/DobbyProxy.h
+++ b/client/lib/include/DobbyProxy.h
@@ -103,7 +103,7 @@ public:
 
     bool wakeupContainer(int32_t descriptor) const override;
     
-    bool addContainerMount(int32_t descriptor, const std::string& source, const std::string& destination, int32_t mountFlags) const override;
+    bool addContainerMount(int32_t descriptor, const std::string& source, const std::string& destination, const std::string& mountFlags) const override;
     
     bool removeContainerMount(int32_t descriptor, const std::string& source) const override;
 

--- a/client/lib/source/DobbyProxy.cpp
+++ b/client/lib/source/DobbyProxy.cpp
@@ -892,6 +892,75 @@ bool DobbyProxy::wakeupContainer(int32_t cd) const
 
 // -----------------------------------------------------------------------------
 /**
+ *  @brief mounts a USB mass storage device inside container
+ *
+ *  @param[in]  cd              The container descriptor.
+ *  @param[in]  source          path of the mount device on the host
+ *  @param[in]  destination     path of the mount on the container 
+ *  @param[in]  mountFlags      should contain OPEN_TREE_CLONE
+ *
+ *  @return true on success, false on failure.
+ */
+bool DobbyProxy::addContainerMount(int32_t cd, const std::string& source, const std::string& destination, int32_t mountFlags) const
+{
+    AI_LOG_FN_ENTRY();
+
+    // Send off the request
+    const AI_IPC::VariantList params = { cd, source, destination, mountFlags};
+    AI_IPC::VariantList returns;
+
+    bool result = false;
+
+    if (invokeMethod(DOBBY_CTRL_INTERFACE,
+                     DOBBY_CTRL_METHOD_MOUNT,
+                     params, returns))
+    {
+        if (!AI_IPC::parseVariantList<bool>(returns, &result))
+        {
+            result = false;
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+    return result;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief unmounts a USB mass storage device inside the container
+ *
+ *  @param[in]  cd              The container descriptor.
+ *  @param[in]  source          path of the mount device on the host
+ *
+ *  @return true on success, false on failure.
+ */
+bool DobbyProxy::removeContainerMount(int32_t cd, const std::string &source) const
+{
+
+    AI_LOG_FN_ENTRY();
+
+    // Send off the request
+    const AI_IPC::VariantList params = { cd, source };
+    AI_IPC::VariantList returns;
+
+    bool result = false;
+
+    if (invokeMethod(DOBBY_CTRL_INTERFACE,
+                     DOBBY_CTRL_METHOD_UNMOUNT,
+                     params, returns))
+    {
+        if (!AI_IPC::parseVariantList<bool>(returns, &result))
+        {
+            result = false;
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+    return result;
+}
+
+// -----------------------------------------------------------------------------
+/**
  *  @brief Executes a command in the given container.
  *
  *  @param[in]  cd              The container descriptor.

--- a/client/lib/source/DobbyProxy.cpp
+++ b/client/lib/source/DobbyProxy.cpp
@@ -897,11 +897,13 @@ bool DobbyProxy::wakeupContainer(int32_t cd) const
  *  @param[in]  cd              The container descriptor.
  *  @param[in]  source          path of the mount device on the host
  *  @param[in]  destination     path of the mount on the container 
- *  @param[in]  mountFlags      should contain OPEN_TREE_CLONE
+ *  @param[in]  mountFlags      The mount flags is a string with comma separated list of flags
+ *                              e.g. "rbind,ro"
+ *                              it should include "bind"
  *
  *  @return true on success, false on failure.
  */
-bool DobbyProxy::addContainerMount(int32_t cd, const std::string& source, const std::string& destination, int32_t mountFlags) const
+bool DobbyProxy::addContainerMount(int32_t cd, const std::string& source, const std::string& destination, const std::string& mountFlags) const
 {
     AI_LOG_FN_ENTRY();
 

--- a/client/tool/source/Main.cpp
+++ b/client/tool/source/Main.cpp
@@ -596,6 +596,94 @@ static void wakeupCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
  *
  *
  */
+static void mountCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
+                         const std::shared_ptr<const IReadLineContext>& readLine,
+                         const std::vector<std::string>& args)
+{
+    if (args.size() < 4 || args[0].empty() || args[1].empty() || args[2].empty() || args[3].empty())
+    {
+        readLine->printLnError("must provide at least 4 args; <id> <source> <destination> <mountFlags>");
+        return;
+    }
+
+    std::string id = args[0];
+    if (id.empty())
+    {
+        readLine->printLnError("invalid container id '%s'", id.c_str());
+        return;
+    }
+    std::string source(args[1]);
+    std::string destination(args[2]);
+    std::string mountFlags(args[3]);
+    
+    int32_t cd = getContainerDescriptor(dobbyProxy, id);
+    if (cd < 0)
+    {
+        readLine->printLnError("failed to find container '%s'", id.c_str());
+    }
+    else
+    {
+        if (!dobbyProxy->addContainerMount(cd, source, destination, std::stoi(mountFlags)))
+        {
+            readLine->printLnError("failed to mount %s inside the container %s", source.c_str(), id.c_str());
+        }
+        else
+        {
+            readLine->printLn("mount successful for container '%s'", id.c_str());
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief
+ *
+ *
+ *
+ */
+static void unmountCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
+                         const std::shared_ptr<const IReadLineContext>& readLine,
+                         const std::vector<std::string>& args)
+{
+    if (args.size() < 2 || args[0].empty() || args[1].empty())
+    {
+        readLine->printLnError("must provide at least two args; <id> <source>");
+        return;
+    }
+
+    std::string id = args[0];
+    if (id.empty())
+    {
+        readLine->printLnError("invalid container id '%s'", id.c_str());
+        return;
+    }
+    std::string source(args[1]);
+    
+    int32_t cd = getContainerDescriptor(dobbyProxy, id);
+    if (cd < 0)
+    {
+        readLine->printLnError("failed to find container '%s'", id.c_str());
+    }
+    else
+    {
+        if (!dobbyProxy->removeContainerMount(cd, source))
+        {
+            readLine->printLnError("failed to unmount %s inside the container %s", source.c_str(), id.c_str());
+        }
+        else
+        {
+            readLine->printLn("unmount successful for container '%s'", id.c_str());
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief
+ *
+ *
+ *
+ */
 static void execCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
                         const std::shared_ptr<const IReadLineContext>& readLine,
                         const std::vector<std::string>& args)
@@ -1179,7 +1267,19 @@ static void initCommands(const std::shared_ptr<IReadLine>& readLine,
                          "wakeup <id>",
                          "wakeup a container with the given id\n",
                          "\n");
-
+    
+    readLine->addCommand("mount",
+                         std::bind(mountCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),
+                         "mount <id> <source> <destination> <mountFlags>",
+                         "mount a USB mass storage device\n",
+                         "\n");
+    
+    readLine->addCommand("unmount",
+                         std::bind(unmountCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),
+                         "unmount <id> <source>",
+                         "unmount a USB mass storage device inside the container with the given id\n",
+                         "\n");
+    
     readLine->addCommand("exec",
                          std::bind(execCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),
                          "exec [options...] <id> <command>",

--- a/client/tool/source/Main.cpp
+++ b/client/tool/source/Main.cpp
@@ -623,7 +623,7 @@ static void mountCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
     }
     else
     {
-        if (!dobbyProxy->addContainerMount(cd, source, destination, std::stoi(mountFlags)))
+        if (!dobbyProxy->addContainerMount(cd, source, destination, mountFlags))
         {
             readLine->printLnError("failed to mount %s inside the container %s", source.c_str(), id.c_str());
         }

--- a/daemon/lib/include/Dobby.h
+++ b/daemon/lib/include/Dobby.h
@@ -91,6 +91,8 @@ private:
     DOBBY_DBUS_METHOD(resume);
     DOBBY_DBUS_METHOD(hibernate);
     DOBBY_DBUS_METHOD(wakeup);
+    DOBBY_DBUS_METHOD(addMount);
+    DOBBY_DBUS_METHOD(removeMount);
     DOBBY_DBUS_METHOD(exec);
     DOBBY_DBUS_METHOD(list);
     DOBBY_DBUS_METHOD(getState);

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -650,6 +650,8 @@ void Dobby::initIpcMethods()
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_RESUME,                  &Dobby::resume                 },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_HIBERNATE,               &Dobby::hibernate              },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_WAKEUP,                  &Dobby::wakeup                 },
+        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_MOUNT,                   &Dobby::addMount                  },
+        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_UNMOUNT,                 &Dobby::removeMount                },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_EXEC,                    &Dobby::exec                   },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_GETSTATE,                &Dobby::getState               },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_GETINFO,                 &Dobby::getInfo                },
@@ -1410,6 +1412,118 @@ void Dobby::wakeup(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
             {
                 // Try and wakeup the container
                 bool result = manager->wakeupContainer(descriptor);
+
+                // Fire off the reply
+                if (!replySender->sendReply({ result }))
+                {
+                    AI_LOG_ERROR("failed to send reply");
+                }
+            };
+
+        // Queue the work, if successful then we're done
+        if (mWorkQueue->postWork(std::move(doWakeupLambda)))
+        {
+            AI_LOG_FN_EXIT();
+            return;
+        }
+    }
+
+    // Fire off the reply
+    AI_IPC::VariantList results = { false };
+    if (!replySender->sendReply(results))
+    {
+        AI_LOG_ERROR("failed to send reply");
+    }
+
+    AI_LOG_FN_EXIT();
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief mount a USB mass storage device inside container
+ *
+ *
+ *
+ *
+ */
+void Dobby::addMount(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
+{
+    AI_LOG_FN_ENTRY();
+
+    // Expecting 4 arguments  (int32_t cd, string source, string target, int32_t mountFlags)
+    int32_t descriptor;
+    std::string source;
+    std::string destination;
+    int32_t mountFlags;
+
+    if (!AI_IPC::parseVariantList
+            <int32_t, std::string, std::string, int32_t>
+            (replySender->getMethodCallArguments(), &descriptor, &source, &destination, &mountFlags))
+    {
+        AI_LOG_ERROR("error getting the args");
+    }
+    else
+    {
+        auto doWakeupLambda =
+            [manager = mManager, descriptor, source, destination, mountFlags, replySender]()
+            {
+                // Try and wakeup the container
+                bool result = manager->addMount(descriptor, source, destination, mountFlags);
+
+                // Fire off the reply
+                if (!replySender->sendReply({ result }))
+                {
+                    AI_LOG_ERROR("failed to send reply");
+                }
+            };
+
+        // Queue the work, if successful then we're done
+        if (mWorkQueue->postWork(std::move(doWakeupLambda)))
+        {
+            AI_LOG_FN_EXIT();
+            return;
+        }
+    }
+
+    // Fire off the reply
+    AI_IPC::VariantList results = { false };
+    if (!replySender->sendReply(results))
+    {
+        AI_LOG_ERROR("failed to send reply");
+    }
+
+    AI_LOG_FN_EXIT();
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief unmount a USB mass storage device inside container
+ *
+ *
+ *
+ *
+ */
+void Dobby::removeMount(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
+{
+    AI_LOG_FN_ENTRY();
+
+    // Expecting 2 arguments  (int32_t cd, string source)
+    int32_t descriptor;
+    std::string source;
+
+    if (!AI_IPC::parseVariantList
+            <int32_t, std::string>
+            (replySender->getMethodCallArguments(), &descriptor, &source))
+    {
+        AI_LOG_ERROR("error getting the args");
+    }
+    else
+    {
+        auto doWakeupLambda =
+            [manager = mManager, descriptor, source, replySender]()
+            {
+                // Try and wakeup the container
+                bool result = manager->removeMount(descriptor, source);
 
                 // Fire off the reply
                 if (!replySender->sendReply({ result }))

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -1464,10 +1464,10 @@ void Dobby::addMount(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
     }
     else
     {
-        auto doWakeupLambda =
+        auto doMountLambda =
             [manager = mManager, descriptor, source, destination, mountFlags, replySender]()
             {
-                // Try and wakeup the container
+                // add the mount inside the container
                 bool result = manager->addMount(descriptor, source, destination, mountFlags);
 
                 // Fire off the reply
@@ -1478,7 +1478,7 @@ void Dobby::addMount(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
             };
 
         // Queue the work, if successful then we're done
-        if (mWorkQueue->postWork(std::move(doWakeupLambda)))
+        if (mWorkQueue->postWork(std::move(doMountLambda)))
         {
             AI_LOG_FN_EXIT();
             return;
@@ -1519,10 +1519,10 @@ void Dobby::removeMount(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
     }
     else
     {
-        auto doWakeupLambda =
+        auto doUnmountLambda =
             [manager = mManager, descriptor, source, replySender]()
             {
-                // Try and wakeup the container
+                //remove the mount inside the container
                 bool result = manager->removeMount(descriptor, source);
 
                 // Fire off the reply
@@ -1533,7 +1533,7 @@ void Dobby::removeMount(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
             };
 
         // Queue the work, if successful then we're done
-        if (mWorkQueue->postWork(std::move(doWakeupLambda)))
+        if (mWorkQueue->postWork(std::move(doUnmountLambda)))
         {
             AI_LOG_FN_EXIT();
             return;

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -1450,14 +1450,14 @@ void Dobby::addMount(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
 {
     AI_LOG_FN_ENTRY();
 
-    // Expecting 4 arguments  (int32_t cd, string source, string target, int32_t mountFlags)
+    // Expecting 4 arguments  (int32_t cd, string source, string target, string mountFlags)
     int32_t descriptor;
     std::string source;
     std::string destination;
-    int32_t mountFlags;
+    std::string mountFlags;
 
     if (!AI_IPC::parseVariantList
-            <int32_t, std::string, std::string, int32_t>
+            <int32_t, std::string, std::string, std::string>
             (replySender->getMethodCallArguments(), &descriptor, &source, &destination, &mountFlags))
     {
         AI_LOG_ERROR("error getting the args");

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1838,7 +1838,6 @@ bool DobbyManager::addMount(int32_t cd, const std::string &source, const std::st
             {
                 mountOptions |= flagName.second;
                 found = true;
-                AI_LOG_INFO("found flag: %s, value: %lu", flag.c_str(), flagName.second);
                 break;
             }
         }

--- a/daemon/lib/source/include/DobbyManager.h
+++ b/daemon/lib/source/include/DobbyManager.h
@@ -122,6 +122,13 @@ public:
     bool hibernateContainer(int32_t cd, const std::string& options);
     bool wakeupContainer(int32_t cd);
 
+    bool addMount(int32_t cd, 
+                  const std::string& source, 
+                  const std::string& destination, 
+                  int32_t mountFlags);
+
+    bool removeMount(int32_t cd, const std::string& source);
+
     bool execInContainer(int32_t cd,
                          const std::string& options,
                          const std::string& command);

--- a/daemon/lib/source/include/DobbyManager.h
+++ b/daemon/lib/source/include/DobbyManager.h
@@ -125,7 +125,7 @@ public:
     bool addMount(int32_t cd, 
                   const std::string& source, 
                   const std::string& destination, 
-                  int32_t mountFlags);
+                  const std::string& mountFlags);
 
     bool removeMount(int32_t cd, const std::string& source);
 

--- a/protocol/include/DobbyProtocol.h
+++ b/protocol/include/DobbyProtocol.h
@@ -54,6 +54,8 @@
 #define DOBBY_CTRL_METHOD_RESUME                    "Resume"
 #define DOBBY_CTRL_METHOD_HIBERNATE                 "Hibernate"
 #define DOBBY_CTRL_METHOD_WAKEUP                    "Wakeup"
+#define DOBBY_CTRL_METHOD_MOUNT                     "Mount"
+#define DOBBY_CTRL_METHOD_UNMOUNT                   "Unmount"
 #define DOBBY_CTRL_METHOD_EXEC                      "Exec"
 #define DOBBY_CTRL_METHOD_GETSTATE                  "GetState"
 #define DOBBY_CTRL_METHOD_GETINFO                   "GetInfo"

--- a/tests/L1_testing/mocks/DobbyManagerMock.cpp
+++ b/tests/L1_testing/mocks/DobbyManagerMock.cpp
@@ -125,6 +125,23 @@ bool DobbyManager::wakeupContainer(int32_t cd)
     return true;
 }
 
+bool DobbyManager::addMount(int32_t cd, 
+                        const std::string& source, 
+                        const std::string& destination, 
+                        int32_t mountFlags)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->addMount(cd, source, destination, mountFlags);
+}
+
+bool DobbyManager::removeMount(int32_t cd, const std::string& source)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->removeMount(cd, source);
+}
+
 bool DobbyManager::execInContainer(int32_t cd,
                             const std::string& options,
                             const std::string& command)

--- a/tests/L1_testing/mocks/DobbyManagerMock.cpp
+++ b/tests/L1_testing/mocks/DobbyManagerMock.cpp
@@ -128,7 +128,7 @@ bool DobbyManager::wakeupContainer(int32_t cd)
 bool DobbyManager::addMount(int32_t cd, 
                         const std::string& source, 
                         const std::string& destination, 
-                        int32_t mountFlags)
+                        const std::string& mountFlags)
 {
    EXPECT_NE(impl, nullptr);
 

--- a/tests/L1_testing/mocks/DobbyManagerMock.h
+++ b/tests/L1_testing/mocks/DobbyManagerMock.h
@@ -60,7 +60,7 @@ public:
 
     MOCK_METHOD(bool, wakeupContainer, (int32_t cd), (override));
 
-    MOCK_METHOD(bool, addMount, (int32_t cd, const std::string& source, const std::string& destination, int32_t mountFlags), (override));
+    MOCK_METHOD(bool, addMount, (int32_t cd, const std::string& source, const std::string& destination, const std::string& mountFlags), (override));
 
     MOCK_METHOD(bool, removeMount, (int32_t cd, const std::string& source), (override));
 

--- a/tests/L1_testing/mocks/DobbyManagerMock.h
+++ b/tests/L1_testing/mocks/DobbyManagerMock.h
@@ -60,6 +60,10 @@ public:
 
     MOCK_METHOD(bool, wakeupContainer, (int32_t cd), (override));
 
+    MOCK_METHOD(bool, addMount, (int32_t cd, const std::string& source, const std::string& destination, int32_t mountFlags), (override));
+
+    MOCK_METHOD(bool, removeMount, (int32_t cd, const std::string& source), (override));
+
     MOCK_METHOD(bool, execInContainer, (int32_t cd,
                                    const std::string& options,
                                    const std::string& command), (override));

--- a/tests/L1_testing/mocks/DobbyUtils.h
+++ b/tests/L1_testing/mocks/DobbyUtils.h
@@ -67,6 +67,8 @@ public:
     virtual bool callInNamespaceImpl(pid_t pid, int nsType, const std::function<void()>& func) const = 0;
     virtual bool callInNamespaceImpl(int namespaceFd, const std::function<void()>& func) const = 0;
     virtual int startTimerImpl(const std::chrono::milliseconds& timeout,bool oneShot,const std::function<bool()>& handler) const = 0;
+    virtual uid_t getUID(pid_t pid) const=0;
+    virtual gid_t getGID(pid_t pid) const=0;
 };
 
 class DobbyUtils : public virtual IDobbyUtils_v3 {
@@ -106,9 +108,11 @@ public:
     void clearContainerMetaData(const ContainerId &id) override;
     bool insertEbtablesRule(const std::string &args) const override;
     bool deleteEbtablesRule(const std::string &args) const override;
-    bool callInNamespaceImpl(pid_t pid, int nsType, const std::function<void()>& func) const override;
-    bool callInNamespaceImpl(int namespaceFd, const std::function<void()>& func) const override;
+    bool callInNamespaceImpl(pid_t pid, int nsType, const std::function<bool()>& func) const override;
+    bool callInNamespaceImpl(int namespaceFd, const std::function<bool()>& func) const override;
     int startTimerImpl(const std::chrono::milliseconds& timeout,bool oneShot,const std::function<bool()>& handler) const override;
+    uid_t getUID(pid_t pid) const override;
+    gid_t getGID(pid_t pid) const override;
 
 };
 

--- a/tests/L1_testing/mocks/DobbyUtilsMock.cpp
+++ b/tests/L1_testing/mocks/DobbyUtilsMock.cpp
@@ -215,14 +215,14 @@ bool DobbyUtils::deleteEbtablesRule(const std::string &args) const
     return impl->deleteEbtablesRule(args);
 }
 
-bool DobbyUtils::callInNamespaceImpl(pid_t pid, int nsType, const std::function<void()>& func) const
+bool DobbyUtils::callInNamespaceImpl(pid_t pid, int nsType, const std::function<bool()>& func) const
 {
    EXPECT_NE(impl, nullptr);
 
     return impl->callInNamespaceImpl(pid,nsType,func);
 }
 
-bool DobbyUtils::callInNamespaceImpl(int namespaceFd, const std::function<void()>& func) const
+bool DobbyUtils::callInNamespaceImpl(int namespaceFd, const std::function<bool()>& func) const
 {
    EXPECT_NE(impl, nullptr);
 
@@ -237,3 +237,16 @@ int DobbyUtils::startTimerImpl(const std::chrono::milliseconds& timeout,bool one
 }
 
 
+gid_t DobbyUtils::getGID(pid_t pid) const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getGID(pid);
+}
+
+uid_t DobbyUtils::getUID(pid_t pid) const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getUID(pid);
+}

--- a/tests/L1_testing/mocks/DobbyUtilsMock.h
+++ b/tests/L1_testing/mocks/DobbyUtilsMock.h
@@ -53,5 +53,7 @@ public:
     MOCK_METHOD(bool, callInNamespaceImpl, (pid_t pid, int nsType, const std::function<void()>& func), (const, override));
     MOCK_METHOD(bool, callInNamespaceImpl, (int namespaceFd, const std::function<void()>& func), (const, override));
     MOCK_METHOD(int, startTimerImpl, (const std::chrono::milliseconds& timeout,bool oneShot,const std::function<bool()>& handler), (const, override));
+    MOCK_METHOD(gid_t, getUID, (pid_t pid), (const, override));
+    MOCK_METHOD(gid_t, getGID, (pid_t pid), (const, override));
 
 };

--- a/tests/L1_testing/mocks/dobbymanager/DobbyManager.h
+++ b/tests/L1_testing/mocks/dobbymanager/DobbyManager.h
@@ -94,7 +94,11 @@ public:
     virtual bool hibernateContainer(int32_t cd, const std::string& options) = 0;
 
     virtual bool wakeupContainer(int32_t cd) = 0;
+    
+    virtual bool addMount(int32_t cd, const std::string& source, const std::string& destination, int32_t mountFlags) = 0;
 
+    virtual bool removeMount(int32_t cd, const std::string& source) = 0;
+    
     virtual bool execInContainer(int32_t cd,
                              const std::string& options,
                              const std::string& command) = 0;
@@ -157,6 +161,8 @@ public:
     bool resumeContainer(int32_t cd);
     bool hibernateContainer(int32_t cd, const std::string& options);
     bool wakeupContainer(int32_t cd);
+    bool addMount(int32_t cd, const std::string& source, const std::string& destination, int32_t mountFlags);
+    bool removeMount(int32_t cd, const std::string& source);
     bool execInContainer(int32_t cd,
                                 const std::string& options,
                                 const std::string& command);

--- a/tests/L1_testing/mocks/dobbymanager/DobbyManager.h
+++ b/tests/L1_testing/mocks/dobbymanager/DobbyManager.h
@@ -95,7 +95,7 @@ public:
 
     virtual bool wakeupContainer(int32_t cd) = 0;
     
-    virtual bool addMount(int32_t cd, const std::string& source, const std::string& destination, int32_t mountFlags) = 0;
+    virtual bool addMount(int32_t cd, const std::string& source, const std::string& destination, const std::string& mountFlags) = 0;
 
     virtual bool removeMount(int32_t cd, const std::string& source) = 0;
     
@@ -161,7 +161,7 @@ public:
     bool resumeContainer(int32_t cd);
     bool hibernateContainer(int32_t cd, const std::string& options);
     bool wakeupContainer(int32_t cd);
-    bool addMount(int32_t cd, const std::string& source, const std::string& destination, int32_t mountFlags);
+    bool addMount(int32_t cd, const std::string& source, const std::string& destination, const std::string& mountFlags);
     bool removeMount(int32_t cd, const std::string& source);
     bool execInContainer(int32_t cd,
                                 const std::string& options,

--- a/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -3765,8 +3765,7 @@ TEST_F(DaemonDobbyManagerTest, execInContainer_FailedToExecuteCommand)
 TEST_F(DaemonDobbyManagerTest, execInContainer_FailureAsContainerNotRunning)
 {
     bool return_value;
-    pid_t pid1 = 1234;
-    pid_t pid2 = 0;
+
     std::string options = "--tty";
     std::string command = "fork exec";
     int32_t cd = 1234;

--- a/utils/include/DobbyUtils.h
+++ b/utils/include/DobbyUtils.h
@@ -84,13 +84,13 @@ public:
 
 private:
     bool callInNamespaceImpl(pid_t pid, int nsType,
-                             const std::function<void()>& func) const override;
+                             const std::function<bool()>& func) const override;
 
     bool callInNamespaceImpl(int namespaceFd,
-                             const std::function<void()>& func) const override;
+                             const std::function<bool()>& func) const override;
 
     void nsThread(int newNsFd, int nsType, bool* success,
-                  std::function<void()>& func) const;
+                  std::function<bool()>& func) const;
 
 public:
     bool writeTextFileAt(int dirFd, const std::string& path,
@@ -148,6 +148,11 @@ public:
 
 private:
     bool executeCommand(const std::string &command) const;
+    int  getGIDorUID(pid_t pid, const std::string& idType) const;
+
+public:
+    uid_t getUID(pid_t pid) const override;
+    gid_t getGID(pid_t pid) const override;
 
 private:
     std::mutex mMetaDataLock;

--- a/utils/include/IDobbyUtils.h
+++ b/utils/include/IDobbyUtils.h
@@ -494,7 +494,7 @@ protected:
      *
      *  @return true on success, false on failure.
      */
-    virtual bool callInNamespaceImpl(pid_t pid, int nsType, const std::function<void()>& func) const = 0;
+    virtual bool callInNamespaceImpl(pid_t pid, int nsType, const std::function<bool()>& func) const = 0;
 
     // -------------------------------------------------------------------------
     /**
@@ -508,7 +508,7 @@ protected:
      *
      *  @return true on success, false on failure.
      */
-    virtual bool callInNamespaceImpl(int namespaceFd, const std::function<void()>& func) const = 0;
+    virtual bool callInNamespaceImpl(int namespaceFd, const std::function<bool()>& func) const = 0;
 
     // -------------------------------------------------------------------------
     /**
@@ -530,6 +530,29 @@ protected:
                                bool oneShot,
                                const std::function<bool()>& handler) const = 0;
 
+    // -------------------------------------------------------------------------
+    /**
+     *  @brief Returns the GID for the given PID
+     *
+     *  @see IDobbyUtils::getGID
+     *
+     *  @param[in]  pid    The PID of the process to get the GID for
+     *
+     *  @return the GID of the process, or 0 if the GID could not be found
+     */
+    virtual gid_t getGID(pid_t pid) const = 0;
+
+    // -------------------------------------------------------------------------
+    /**
+     *  @brief Returns the UID for the given PID
+     *
+     *  @see IDobbyUtils::getUID
+     *
+     *  @param[in]  pid    The PID of the process to get the UID for
+     *
+     *  @return the UID of the process, or 0 if the UID could not be found
+     */
+    virtual uid_t getUID(pid_t pid) const = 0;
 
 };
 
@@ -561,6 +584,8 @@ public:
     using IDobbyUtils_v1::cancelTimer;
     using IDobbyUtils_v1::getDriverMajorNumber;
     using IDobbyUtils_v1::deviceAllowed;
+    using IDobbyUtils_v1::getGID;
+    using IDobbyUtils_v1::getUID;
 
 public:
 
@@ -626,6 +651,8 @@ public:
     using IDobbyUtils_v1::cancelTimer;
     using IDobbyUtils_v1::getDriverMajorNumber;
     using IDobbyUtils_v1::deviceAllowed;
+    using IDobbyUtils_v1::getGID;
+    using IDobbyUtils_v1::getUID;
 
     using IDobbyUtils_v2::setIntegerMetaData;
     using IDobbyUtils_v2::getIntegerMetaData;

--- a/utils/source/DobbyUtils.cpp
+++ b/utils/source/DobbyUtils.cpp
@@ -564,7 +564,6 @@ void DobbyUtils::nsThread(int newNsFd, int nsType, bool* success,
     // execute the caller's function
      *success = func();
 
-    //*success = true;
     AI_LOG_FN_EXIT();
 }
 

--- a/utils/source/DobbyUtils.cpp
+++ b/utils/source/DobbyUtils.cpp
@@ -541,7 +541,7 @@ int DobbyUtils::getNamespaceFd(pid_t pid, int nsType) const
  *  @return true if successifully entered the namespace, otherwise false.
  */
 void DobbyUtils::nsThread(int newNsFd, int nsType, bool* success,
-                          std::function<void()>& func) const
+                          std::function<bool()>& func) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -562,9 +562,9 @@ void DobbyUtils::nsThread(int newNsFd, int nsType, bool* success,
     }
 
     // execute the caller's function
-    func();
+     *success = func();
 
-    *success = true;
+    //*success = true;
     AI_LOG_FN_EXIT();
 }
 
@@ -585,7 +585,7 @@ void DobbyUtils::nsThread(int newNsFd, int nsType, bool* success,
  *  @return true if successifully entered the namespace, otherwise false.
  */
 bool DobbyUtils::callInNamespaceImpl(int namespaceFd,
-                                     const std::function<void()>& func) const
+                                     const std::function<bool()>& func) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -628,7 +628,7 @@ bool DobbyUtils::callInNamespaceImpl(int namespaceFd,
  *  @return true if successifully entered the namespace, otherwise false.
  */
 bool DobbyUtils::callInNamespaceImpl(pid_t pid, int nsType,
-                                     const std::function<void()>& func) const
+                                     const std::function<bool()>& func) const
 {
     AI_LOG_FN_ENTRY();
 
@@ -1661,4 +1661,73 @@ bool DobbyUtils::executeCommand(const std::string &command) const
     }
 
     return true;
+}
+// -------------------------------------------------------------------------
+/**
+ *  @brief Returns the effective GID or UID for the given PID 
+ *         by parsing /proc/<PID>/status
+ *
+ *  @param[in]  pid    The PID of the process to get the GID for
+ *  @param[in]  idType The type of ID to get, either "Gid" or "Uid"
+ *
+ *  @return the GID or UID of the process, or -1 if the ID could not be found
+ */
+int DobbyUtils::getGIDorUID(pid_t pid, const std::string& idType) const
+{
+    char filePathBuf[32];
+    sprintf(filePathBuf, "/proc/%d/status", pid);
+
+    int fd = open(filePathBuf, O_CLOEXEC | O_RDONLY);
+    if (fd < 0)
+    {
+        AI_LOG_SYS_ERROR(errno, "failed to open procfs file @ '%s'", filePathBuf);
+        return -1;
+    }
+
+    __gnu_cxx::stdio_filebuf<char> statusFileBuf(fd, std::ios::in);
+    std::istream statusFileStream(&statusFileBuf);
+    
+    std::string line;
+    while (std::getline(statusFileStream, line))
+    {
+        if (line.compare(0, idType.size(), idType) == 0)
+        {
+            int realId = -1, effectiveId = -1, savedId = 1, filesystemId = 1;
+
+            if (sscanf(line.c_str(), (idType + ":\t%d\t%d\t%d\t%d").c_str(), &realId, &effectiveId, &savedId, &filesystemId) != 4)
+            {
+                AI_LOG_WARN("failed to parse %s field, '%s'", idType.c_str(), line.c_str());
+                return -1;
+            }
+
+            return effectiveId;
+        }
+    }
+
+    AI_LOG_WARN("failed to find the %s field in the '%s' file", idType.c_str(), filePathBuf);
+    return -1;
+}
+// -------------------------------------------------------------------------
+/**
+ *  @brief Returns the GID for the given PID
+ *
+ *  @param[in]  pid    The PID of the process to get the GID for
+ *
+ *  @return the GID of the process, or -1 if the GID could not be found
+ */
+gid_t DobbyUtils::getGID(pid_t pid) const
+{
+    return static_cast<gid_t>(getGIDorUID(pid, "Gid"));
+}
+// -------------------------------------------------------------------------
+/**
+ *  @brief Returns the UID for the given PID
+ *
+ *  @param[in]  pid    The PID of the process to get the UID for
+ *
+ *  @return the UID of the process, or -1 if the UID could not be found
+ */
+uid_t DobbyUtils::getUID(pid_t pid) const
+{
+    return static_cast<uid_t>(getGIDorUID(pid, "Uid"));
 }


### PR DESCRIPTION
initial implementation of mount & unmount operations

### Description
What does this PR change/fix and why?
Adds new mount & unmount API calls to support dynamic mounting/unmounting of USB mass storage devices

### Test Procedure
Use the following commands to mount and unmount directories in already running containers:
```
DobbyTool mount com.sky.as.apps_com.bskyb.epgui  /mnt/usb /tmp/newmount ro,bind
DobbyTool unmount com.sky.as.apps_com.bskyb.epgui /tmp/newmount
```

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [x] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)