### PR TITLE
ES1-1718 : Check for hibernate states in the cleanupContainersShutdown()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,13 @@ cmake_minimum_required( VERSION 3.7.0 )
 include(GNUInstallDirs)
 
 # Project setup
-project( Dobby VERSION "3.10.2" )
+project( Dobby VERSION "3.10.3" )
 
 
 # Set the major and minor version numbers of dobby (also used by plugins)
 set( DOBBY_MAJOR_VERSION 3 )
 set( DOBBY_MINOR_VERSION 10 )
-set( DOBBY_MICRO_VERSION 2 )
+set( DOBBY_MICRO_VERSION 3 )
 
 set(INSTALL_CMAKE_DIR lib/cmake/Dobby)
 

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -476,7 +476,10 @@ void DobbyManager::cleanupContainersShutdown()
     while (it != mContainers.end())
     {
         if ((it->second->state == DobbyContainer::State::Running) || \
-            (it->second->state == DobbyContainer::State::Paused))
+            (it->second->state == DobbyContainer::State::Paused) || \
+            (it->second->state == DobbyContainer::State::Hibernating) || \
+            (it->second->state == DobbyContainer::State::Hibernated) || \
+            (it->second->state == DobbyContainer::State::Awakening))
         {
             AI_LOG_INFO("Stopping container %s", it->first.c_str());
             // By calling the "proper" stop method here, any listening services will be


### PR DESCRIPTION
### Description
If the DobbyContainer state is not DobbyContainer::State::Running or DobbyContainer::State::Paused, the while loop keeps looping because the mContainer's data is not erased, and it is not moving to next iterator. So, check for 3 more hibernate states in the cleanupContainersShutdown() API. 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)