### PR TITLE
[RDK-54420] added annotation APIs to Dobby

### DIFF
--- a/AppInfrastructure/Public/Dobby/IDobbyProxy.h
+++ b/AppInfrastructure/Public/Dobby/IDobbyProxy.h
@@ -160,6 +160,9 @@ public:
                                const std::string& key,
                                const std::string& value) const = 0;
 
+    virtual bool removeAnnotation(int32_t cd,
+                               const std::string& key) const = 0;
+
     virtual bool execInContainer(int32_t cd,
                                  const std::string& options,
                                  const std::string& command) const = 0;

--- a/AppInfrastructure/Public/Dobby/IDobbyProxy.h
+++ b/AppInfrastructure/Public/Dobby/IDobbyProxy.h
@@ -156,6 +156,10 @@ public:
     
     virtual bool removeContainerMount(int32_t descriptor, const std::string& source) const = 0;
 
+    virtual bool addAnnotation(int32_t cd,
+                               const std::string& key,
+                               const std::string& value) const = 0;
+
     virtual bool execInContainer(int32_t cd,
                                  const std::string& options,
                                  const std::string& command) const = 0;

--- a/client/lib/include/DobbyProxy.h
+++ b/client/lib/include/DobbyProxy.h
@@ -109,6 +109,10 @@ public:
                            const std::vector<std::string>& mountFlags, 
                            const std::string& mountData) const override;
     
+    bool addAnnotation(int32_t cd,
+                       const std::string& key,
+                       const std::string& value) const override;
+
     bool removeContainerMount(int32_t descriptor, const std::string& source) const override;
 
     bool execInContainer(int32_t cd,

--- a/client/lib/include/DobbyProxy.h
+++ b/client/lib/include/DobbyProxy.h
@@ -113,6 +113,9 @@ public:
                        const std::string& key,
                        const std::string& value) const override;
 
+    bool removeAnnotation(int32_t cd,
+                       const std::string& key) const override;
+
     bool removeContainerMount(int32_t descriptor, const std::string& source) const override;
 
     bool execInContainer(int32_t cd,

--- a/client/lib/source/DobbyProxy.cpp
+++ b/client/lib/source/DobbyProxy.cpp
@@ -960,7 +960,38 @@ bool DobbyProxy::addAnnotation(int32_t cd, const std::string& key, const std::st
     AI_LOG_FN_EXIT();
     return result;
 }
+// -----------------------------------------------------------------------------
+/**
+ *  @brief removes a key value pair from the container annotation
+ *
+ *  @param[in]  cd         The container descriptor.
+ *  @param[in]  key        The key string
+ *
+ *  @return true on success, false on failure.
+ */
+bool DobbyProxy::removeAnnotation(int32_t cd, const std::string& key) const
+{
+    AI_LOG_FN_ENTRY();
 
+    // Send off the request
+    const AI_IPC::VariantList params = { cd, key};
+    AI_IPC::VariantList returns;
+
+    bool result = false;
+
+    if (invokeMethod(DOBBY_CTRL_INTERFACE,
+                     DOBBY_CTRL_METHOD_REMOVE_ANNOTATION,
+                     params, returns))
+    {
+        if (!AI_IPC::parseVariantList<bool>(returns, &result))
+        {
+            result = false;
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+    return result;
+}
 // -----------------------------------------------------------------------------
 /**
  *  @brief unmounts a directory/device inside the container

--- a/client/lib/source/DobbyProxy.cpp
+++ b/client/lib/source/DobbyProxy.cpp
@@ -927,6 +927,39 @@ bool DobbyProxy::addContainerMount(int32_t cd, const std::string& source, const 
     AI_LOG_FN_EXIT();
     return result;
 }
+// -----------------------------------------------------------------------------
+/**
+ *  @brief adds a key value pair to the container annotation
+ *
+ *  @param[in]  cd         The container descriptor.
+ *  @param[in]  key        The key string
+ *  @param[in]  value      The value string
+ *
+ *  @return true on success, false on failure.
+ */
+bool DobbyProxy::addAnnotation(int32_t cd, const std::string& key, const std::string& value) const
+{
+    AI_LOG_FN_ENTRY();
+
+    // Send off the request
+    const AI_IPC::VariantList params = { cd, key, value};
+    AI_IPC::VariantList returns;
+
+    bool result = false;
+
+    if (invokeMethod(DOBBY_CTRL_INTERFACE,
+                     DOBBY_CTRL_METHOD_ANNOTATE,
+                     params, returns))
+    {
+        if (!AI_IPC::parseVariantList<bool>(returns, &result))
+        {
+            result = false;
+        }
+    }
+
+    AI_LOG_FN_EXIT();
+    return result;
+}
 
 // -----------------------------------------------------------------------------
 /**

--- a/client/tool/source/Main.cpp
+++ b/client/tool/source/Main.cpp
@@ -737,7 +737,48 @@ static void annotateCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
         }
     }
 }
+// -----------------------------------------------------------------------------
+/**
+ * @brief
+ *
+ *
+ *
+ */
+static void removeAnnotationCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
+                         const std::shared_ptr<const IReadLineContext>& readLine,
+                         const std::vector<std::string>& args)
+{
+    if (args.size() < 2 || args[0].empty() || args[1].empty())
+    {
+        readLine->printLnError("must provide at least 2 args; <id> <key>");
+        return;
+    }
 
+    std::string id = args[0];
+    if (id.empty())
+    {
+        readLine->printLnError("invalid container id '%s'", id.c_str());
+        return;
+    }
+    std::string annotateKey(args[1]);
+
+    int32_t cd = getContainerDescriptor(dobbyProxy, id);
+    if (cd < 0)
+    {
+        readLine->printLnError("failed to find container '%s'", id.c_str());
+    }
+    else
+    {
+        if (!dobbyProxy->removeAnnotation(cd, annotateKey))
+        {
+            readLine->printLnError("failed to remove %s key from the container %s annotations", annotateKey.c_str(), id.c_str());
+        }
+        else
+        {
+            readLine->printLn("removed %s key from container '%s' annotations", annotateKey.c_str(), id.c_str());
+        }
+    }
+}
 // -----------------------------------------------------------------------------
 /**
  * @brief
@@ -1345,6 +1386,12 @@ static void initCommands(const std::shared_ptr<IReadLine>& readLine,
                          std::bind(annotateCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),
                          "annonate <id> <key> <value>",
                          "annotate the container with a key value pair\n",
+                         "\n");
+
+    readLine->addCommand("remove-annotation",
+                         std::bind(removeAnnotationCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),
+                         "remove-annotation <id> <key>",
+                         "removes a key from the container's annotations\n",
                          "\n");
 
     readLine->addCommand("exec",

--- a/client/tool/source/Main.cpp
+++ b/client/tool/source/Main.cpp
@@ -694,6 +694,49 @@ static void unmountCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
         }
     }
 }
+// -----------------------------------------------------------------------------
+/**
+ * @brief
+ *
+ *
+ *
+ */
+static void annotateCommand(const std::shared_ptr<IDobbyProxy>& dobbyProxy,
+                         const std::shared_ptr<const IReadLineContext>& readLine,
+                         const std::vector<std::string>& args)
+{
+    if (args.size() < 3 || args[0].empty() || args[1].empty() || args[2].empty())
+    {
+        readLine->printLnError("must provide at least 3 args; <id> <key> <value>");
+        return;
+    }
+
+    std::string id = args[0];
+    if (id.empty())
+    {
+        readLine->printLnError("invalid container id '%s'", id.c_str());
+        return;
+    }
+    std::string annotateKey(args[1]);
+    std::string annotateValue(args[2]);
+
+    int32_t cd = getContainerDescriptor(dobbyProxy, id);
+    if (cd < 0)
+    {
+        readLine->printLnError("failed to find container '%s'", id.c_str());
+    }
+    else
+    {
+        if (!dobbyProxy->addAnnotation(cd, annotateKey, annotateValue))
+        {
+            readLine->printLnError("failed to add %s %s pair inside the container %s", annotateKey.c_str(), annotateValue.c_str(), id.c_str());
+        }
+        else
+        {
+            readLine->printLn("annotate successful for container '%s'", id.c_str());
+        }
+    }
+}
 
 // -----------------------------------------------------------------------------
 /**
@@ -1297,7 +1340,13 @@ static void initCommands(const std::shared_ptr<IReadLine>& readLine,
                          "unmount <id> <source>",
                          "unmount a directory inside the container with the given id\n",
                          "\n");
-    
+
+    readLine->addCommand("annotate",
+                         std::bind(annotateCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),
+                         "annonate <id> <key> <value>",
+                         "annotate the container with a key value pair\n",
+                         "\n");
+
     readLine->addCommand("exec",
                          std::bind(execCommand, dobbyProxy, std::placeholders::_1, std::placeholders::_2),
                          "exec [options...] <id> <command>",

--- a/daemon/lib/include/Dobby.h
+++ b/daemon/lib/include/Dobby.h
@@ -113,6 +113,7 @@ private:
 #endif
 
     DOBBY_DBUS_METHOD(addAnnotation);
+    DOBBY_DBUS_METHOD(removeAnnotation);
 
     #undef DOBBY_DBUS_METHOD
 

--- a/daemon/lib/include/Dobby.h
+++ b/daemon/lib/include/Dobby.h
@@ -112,6 +112,8 @@ private:
     DOBBY_DBUS_METHOD(stopInProcessTracing);
 #endif
 
+    DOBBY_DBUS_METHOD(addAnnotation);
+
     #undef DOBBY_DBUS_METHOD
 
 private:

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -650,8 +650,8 @@ void Dobby::initIpcMethods()
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_RESUME,                  &Dobby::resume                 },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_HIBERNATE,               &Dobby::hibernate              },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_WAKEUP,                  &Dobby::wakeup                 },
-        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_MOUNT,                   &Dobby::addMount                  },
-        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_UNMOUNT,                 &Dobby::removeMount                },
+        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_MOUNT,                   &Dobby::addMount               },
+        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_UNMOUNT,                 &Dobby::removeMount            },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_EXEC,                    &Dobby::exec                   },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_GETSTATE,                &Dobby::getState               },
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_GETINFO,                 &Dobby::getInfo                },
@@ -670,6 +670,7 @@ void Dobby::initIpcMethods()
         {   DOBBY_DEBUG_INTERFACE,       DOBBY_DEBUG_START_INPROCESS_TRACING,       &Dobby::startInProcessTracing  },
         {   DOBBY_DEBUG_INTERFACE,       DOBBY_DEBUG_STOP_INPROCESS_TRACING,        &Dobby::stopInProcessTracing   },
 #endif // defined(AI_ENABLE_TRACING)
+        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_ANNOTATE,                &Dobby::addAnnotation          },
     };
 
     // ... register them all
@@ -1551,6 +1552,61 @@ void Dobby::removeMount(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
     AI_LOG_FN_EXIT();
 }
 
+// -----------------------------------------------------------------------------
+/**
+ *  @brief annotate a container (add a key value pair)
+ *
+ *
+ *
+ *
+ */
+void Dobby::addAnnotation(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
+{
+    AI_LOG_FN_ENTRY();
+
+    // Expecting 3 arguments  (int32_t cd, string key, string value)
+    int32_t descriptor;
+    std::string key;
+    std::string value;
+
+    if (!AI_IPC::parseVariantList
+            <int32_t, std::string, std::string>
+            (replySender->getMethodCallArguments(), &descriptor, &key, &value))
+    {
+        AI_LOG_ERROR("error getting the args");
+    }
+    else
+    {
+        auto doAnnotateLambda =
+            [manager = mManager, descriptor, key, value, replySender]()
+            {
+                //remove the mount inside the container
+                bool result = manager->annotate(descriptor, key, value);
+
+                // Fire off the reply
+                if (!replySender->sendReply({ result }))
+                {
+                    AI_LOG_ERROR("failed to send reply");
+                }
+            };
+
+        // Queue the work, if successful then we're done
+        if (mWorkQueue->postWork(std::move(doAnnotateLambda)))
+        {
+            AI_LOG_FN_EXIT();
+            return;
+        }
+    }
+
+    // Fire off the reply
+    AI_IPC::VariantList results = { false };
+    if (!replySender->sendReply(results))
+    {
+        AI_LOG_ERROR("failed to send reply");
+    }
+
+    AI_LOG_FN_EXIT();
+}
 // -----------------------------------------------------------------------------
 /**
  *  @brief Executes a command in a container

--- a/daemon/lib/source/Dobby.cpp
+++ b/daemon/lib/source/Dobby.cpp
@@ -671,6 +671,7 @@ void Dobby::initIpcMethods()
         {   DOBBY_DEBUG_INTERFACE,       DOBBY_DEBUG_STOP_INPROCESS_TRACING,        &Dobby::stopInProcessTracing   },
 #endif // defined(AI_ENABLE_TRACING)
         {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_ANNOTATE,                &Dobby::addAnnotation          },
+        {   DOBBY_CTRL_INTERFACE,        DOBBY_CTRL_METHOD_REMOVE_ANNOTATION,       &Dobby::removeAnnotation       },
     };
 
     // ... register them all
@@ -1580,7 +1581,7 @@ void Dobby::addAnnotation(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
         auto doAnnotateLambda =
             [manager = mManager, descriptor, key, value, replySender]()
             {
-                //remove the mount inside the container
+                //add the key value pair to the annotations
                 bool result = manager->annotate(descriptor, key, value);
 
                 // Fire off the reply
@@ -1592,6 +1593,60 @@ void Dobby::addAnnotation(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender
 
         // Queue the work, if successful then we're done
         if (mWorkQueue->postWork(std::move(doAnnotateLambda)))
+        {
+            AI_LOG_FN_EXIT();
+            return;
+        }
+    }
+
+    // Fire off the reply
+    AI_IPC::VariantList results = { false };
+    if (!replySender->sendReply(results))
+    {
+        AI_LOG_ERROR("failed to send reply");
+    }
+
+    AI_LOG_FN_EXIT();
+}
+// -----------------------------------------------------------------------------
+/**
+ *  @brief remove a key from container annotations
+ *
+ *
+ *
+ *
+ */
+void Dobby::removeAnnotation(std::shared_ptr<AI_IPC::IAsyncReplySender> replySender)
+{
+    AI_LOG_FN_ENTRY();
+
+    // Expecting 2 arguments  (int32_t cd, string key)
+    int32_t descriptor;
+    std::string key;
+
+    if (!AI_IPC::parseVariantList
+            <int32_t, std::string>
+            (replySender->getMethodCallArguments(), &descriptor, &key))
+    {
+        AI_LOG_ERROR("error getting the args");
+    }
+    else
+    {
+        auto doremoveAnnotationLambda =
+            [manager = mManager, descriptor, key, replySender]()
+            {
+                //remove the key from the annotations
+                bool result = manager->removeAnnotation(descriptor, key);
+
+                // Fire off the reply
+                if (!replySender->sendReply({ result }))
+                {
+                    AI_LOG_ERROR("failed to send reply");
+                }
+            };
+
+        // Queue the work, if successful then we're done
+        if (mWorkQueue->postWork(std::move(doremoveAnnotationLambda)))
         {
             AI_LOG_FN_EXIT();
             return;

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1785,6 +1785,48 @@ bool DobbyManager::annotate(int32_t cd, const std::string &key, const std::strin
 }
 // -----------------------------------------------------------------------------
 /**
+ *  @brief removes a key-value pair annotation from a running container
+ *
+ *  @param[in]  cd      The descriptor of the container to annotate.
+ *  @param[in]  key     The key of the annotation.
+ *
+ *  @return true if the annotation was successfully removed.
+ */
+bool DobbyManager::removeAnnotation(int32_t cd, const std::string &key)
+{
+    AI_LOG_FN_ENTRY();
+    bool ret = false;
+
+    std::lock_guard<std::mutex> locker(mLock);
+
+    // find the container
+    auto it = mContainers.cbegin();
+    for (; it != mContainers.cend(); ++it)
+    {
+        if (it->second && (it->second->descriptor == cd))
+            break;
+    }
+
+    if (it == mContainers.cend())
+    {
+        AI_LOG_WARN("failed to find container with descriptor %d", cd);
+        AI_LOG_FN_EXIT();
+        return false;
+    }
+    const ContainerId &id = it->first;
+    const std::unique_ptr<DobbyContainer> &container = it->second;
+
+    if(container->rdkPluginManager->getUtils()->removeAnnotation(key)){
+        AI_LOG_INFO("successfully removed key '%s' from container '%s'", key.c_str(), id.c_str());
+        ret = true;
+    }else{
+        AI_LOG_WARN("failed to remove key '%s' from container '%s'", key.c_str(), id.c_str());
+    }
+    AI_LOG_FN_EXIT();
+    return ret;
+}
+// -----------------------------------------------------------------------------
+/**
  *  @brief adds a mount to a running container
  *
  *  @param[in]  cd           The descriptor of the container to checkpoint.

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1744,7 +1744,45 @@ bool DobbyManager::wakeupContainer(int32_t cd)
     AI_LOG_FN_EXIT();
     return true;
 }
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Adds a key-value pair annotation to a running container
+ *
+ *  @param[in]  cd      The descriptor of the container to annotate.
+ *  @param[in]  key     The key of the annotation.
+ *  @param[in]  value   The value of the annotation.
+ *
+ *  @return true if the annotation was successfully added.
+ */
+bool DobbyManager::annotate(int32_t cd, const std::string &key, const std::string &value)
+{
+    AI_LOG_FN_ENTRY();
 
+    std::lock_guard<std::mutex> locker(mLock);
+
+    // find the container
+    auto it = mContainers.cbegin();
+    for (; it != mContainers.cend(); ++it)
+    {
+        if (it->second && (it->second->descriptor == cd))
+            break;
+    }
+
+    if (it == mContainers.cend())
+    {
+        AI_LOG_WARN("failed to find container with descriptor %d", cd);
+        AI_LOG_FN_EXIT();
+        return false;
+    }
+    const ContainerId &id = it->first;
+    const std::unique_ptr<DobbyContainer> &container = it->second;
+
+    container->rdkPluginManager->getUtils()->addAnnotation(key, value);
+
+    AI_LOG_INFO("successfully added annotation '%s':'%s' to container '%s'", key.c_str(), value.c_str(), id.c_str());
+    AI_LOG_FN_EXIT();
+    return true;
+}
 // -----------------------------------------------------------------------------
 /**
  *  @brief adds a mount to a running container
@@ -2384,6 +2422,14 @@ std::string DobbyManager::statsOfContainer(int32_t cd) const
             case DobbyContainer::State::Awakening:
                 jsonStats["state"] = "awakening";
                 break;
+        }
+
+        const std::unique_ptr<DobbyContainer> &container = it->second;
+
+        const std::map<std::string, std::string> annotations = container->rdkPluginManager->getUtils()->getAnnotations();
+        for (const auto &annotation : annotations)
+        {
+            jsonStats["annotations"][annotation.first] = annotation.second;
         }
 
         // convert the json stats to a string and return

--- a/daemon/lib/source/include/DobbyManager.h
+++ b/daemon/lib/source/include/DobbyManager.h
@@ -130,6 +130,8 @@ public:
 
     bool removeMount(int32_t cd, const std::string& source);
 
+    bool annotate(int32_t cd, const std::string &key, const std::string &value);
+
     bool execInContainer(int32_t cd,
                          const std::string& options,
                          const std::string& command);

--- a/daemon/lib/source/include/DobbyManager.h
+++ b/daemon/lib/source/include/DobbyManager.h
@@ -131,6 +131,7 @@ public:
     bool removeMount(int32_t cd, const std::string& source);
 
     bool annotate(int32_t cd, const std::string &key, const std::string &value);
+    bool removeAnnotation(int32_t cd, const std::string &key);
 
     bool execInContainer(int32_t cd,
                          const std::string& options,

--- a/pluginLauncher/lib/include/DobbyRdkPluginManager.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginManager.h
@@ -68,6 +68,11 @@ public:
         return mContainerConfig;
     };
 
+    std::shared_ptr<DobbyRdkPluginUtils> getUtils() const
+    {
+        return mUtils;
+    }
+
 private:
     bool loadPlugins();
     bool preprocessPlugins();
@@ -95,6 +100,7 @@ private:
     const std::string mPluginPath;
     const std::shared_ptr<DobbyRdkPluginUtils> mUtils;
     std::unique_ptr<DobbyRdkPluginDependencySolver> mDependencySolver;
+    std::map<std::string, std::string> mAnnotations;
 };
 
 #endif // !defined(DOBBYRDKPLUGINMANAGER_H)

--- a/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
@@ -159,6 +159,7 @@ public:
     std::list<int> files(const std::string& pluginName) const;
 
     bool addAnnotation(const std::string &key, const std::string &value);
+    bool removeAnnotation(const std::string &key);
     std::map<std::string, std::string> getAnnotations() const { return mAnnotations; };
 
     int exitStatus;

--- a/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
+++ b/pluginLauncher/lib/include/DobbyRdkPluginUtils.h
@@ -41,6 +41,7 @@
 #include <mutex>
 #include <arpa/inet.h>
 #include <vector>
+#include <map>
 
 
 // TODO:: This would be better stored in the dobby workspace dir rather than /tmp,
@@ -157,6 +158,9 @@ public:
 
     std::list<int> files(const std::string& pluginName) const;
 
+    bool addAnnotation(const std::string &key, const std::string &value);
+    std::map<std::string, std::string> getAnnotations() const { return mAnnotations; };
+
     int exitStatus;
 
 private:
@@ -170,6 +174,8 @@ private:
     std::shared_ptr<IDobbyStartState> mStartState;
 
     const std::string mContainerId;
+
+    std::map<std::string, std::string> mAnnotations;
 };
 
 #endif // !defined(DOBBYRDKPLUGINUTILS_H)

--- a/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
@@ -736,3 +736,25 @@ std::string DobbyRdkPluginUtils::ipAddressToString(const in_addr_t &ipAddress)
     AI_LOG_DEBUG("Converted IP %u -> %s", ipAddress, str);
     return std::string(str);
 }
+
+// -------------------------------------------------------------------------
+/**
+ *  @brief adds a key value pair to the annotations
+ *
+ *  @param[in]  key     The key to add
+ *  @param[in]  value   The value to add
+ *
+ *  @return true on success, false on failure
+ */
+bool DobbyRdkPluginUtils::addAnnotation(const std::string &key, const std::string &value)
+{
+    AI_LOG_FN_ENTRY();
+
+    std::lock_guard<std::mutex> locker(mLock);
+
+    mAnnotations[key] = value;
+
+    AI_LOG_FN_EXIT();
+
+    return true;
+}

--- a/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
@@ -758,3 +758,31 @@ bool DobbyRdkPluginUtils::addAnnotation(const std::string &key, const std::strin
 
     return true;
 }
+
+// -------------------------------------------------------------------------
+/**
+ *  @brief removes a key value pair from the annotations
+ *
+ *  @param[in]  key     The key to remove
+ *
+ *  @return true on success, false on failure
+ */
+bool DobbyRdkPluginUtils::removeAnnotation(const std::string &key)
+{
+    AI_LOG_FN_ENTRY();
+    bool success = false;
+
+    std::lock_guard<std::mutex> locker(mLock);
+
+    const auto it = mAnnotations.find(key);
+    if (it != mAnnotations.end()){
+        mAnnotations.erase(it);
+        success = true;
+    } else {
+        AI_LOG_ERROR("Key %s not found in annotations", key.c_str());
+    }
+
+    AI_LOG_FN_EXIT();
+
+    return success;
+}

--- a/protocol/include/DobbyProtocol.h
+++ b/protocol/include/DobbyProtocol.h
@@ -56,6 +56,7 @@
 #define DOBBY_CTRL_METHOD_WAKEUP                    "Wakeup"
 #define DOBBY_CTRL_METHOD_MOUNT                     "Mount"
 #define DOBBY_CTRL_METHOD_UNMOUNT                   "Unmount"
+#define DOBBY_CTRL_METHOD_ANNOTATE                  "Annotate"
 #define DOBBY_CTRL_METHOD_EXEC                      "Exec"
 #define DOBBY_CTRL_METHOD_GETSTATE                  "GetState"
 #define DOBBY_CTRL_METHOD_GETINFO                   "GetInfo"

--- a/protocol/include/DobbyProtocol.h
+++ b/protocol/include/DobbyProtocol.h
@@ -57,6 +57,7 @@
 #define DOBBY_CTRL_METHOD_MOUNT                     "Mount"
 #define DOBBY_CTRL_METHOD_UNMOUNT                   "Unmount"
 #define DOBBY_CTRL_METHOD_ANNOTATE                  "Annotate"
+#define DOBBY_CTRL_METHOD_REMOVE_ANNOTATION         "RemoveAnnotation"
 #define DOBBY_CTRL_METHOD_EXEC                      "Exec"
 #define DOBBY_CTRL_METHOD_GETSTATE                  "GetState"
 #define DOBBY_CTRL_METHOD_GETINFO                   "GetInfo"

--- a/tests/L1_testing/mocks/DobbyManagerMock.cpp
+++ b/tests/L1_testing/mocks/DobbyManagerMock.cpp
@@ -152,6 +152,15 @@ bool DobbyManager::execInContainer(int32_t cd,
     return impl->execInContainer(cd, options, command);
 }
 
+bool DobbyManager::annotate(int32_t cd,
+                            const std::string& key,
+                            const std::string& value)
+{
+   EXPECT_NE(impl, nullptr);
+
+   return impl->annotate(cd, key, value);
+}
+
 std::list<std::pair<int32_t, ContainerId>> DobbyManager::listContainers()
 {
    EXPECT_NE(impl, nullptr);

--- a/tests/L1_testing/mocks/DobbyManagerMock.cpp
+++ b/tests/L1_testing/mocks/DobbyManagerMock.cpp
@@ -160,7 +160,13 @@ bool DobbyManager::annotate(int32_t cd,
 
    return impl->annotate(cd, key, value);
 }
+bool DobbyManager::removeAnnotation(int32_t cd,
+                            const std::string& key)
+{
+   EXPECT_NE(impl, nullptr);
 
+   return impl->removeAnnotation(cd, key);
+}
 std::list<std::pair<int32_t, ContainerId>> DobbyManager::listContainers()
 {
    EXPECT_NE(impl, nullptr);

--- a/tests/L1_testing/mocks/DobbyManagerMock.h
+++ b/tests/L1_testing/mocks/DobbyManagerMock.h
@@ -76,6 +76,9 @@ public:
                                  const std::string &key,
                                  const std::string &value), (override));
 
+    MOCK_METHOD(bool, removeAnnotation, (int32_t cd,
+                                 const std::string &key), (override));
+
     MOCK_METHOD((std::list<std::pair<int32_t, ContainerId>>), listContainers, (), (const,override));
 
     MOCK_METHOD(int32_t, stateOfContainer, (int32_t cd), (const,override));

--- a/tests/L1_testing/mocks/DobbyManagerMock.h
+++ b/tests/L1_testing/mocks/DobbyManagerMock.h
@@ -72,6 +72,10 @@ public:
                                    const std::string& options,
                                    const std::string& command), (override));
 
+    MOCK_METHOD(bool, annotate, (int32_t cd,
+                                 const std::string &key,
+                                 const std::string &value), (override));
+
     MOCK_METHOD((std::list<std::pair<int32_t, ContainerId>>), listContainers, (), (const,override));
 
     MOCK_METHOD(int32_t, stateOfContainer, (int32_t cd), (const,override));

--- a/tests/L1_testing/mocks/DobbyRdkPluginManager.h
+++ b/tests/L1_testing/mocks/DobbyRdkPluginManager.h
@@ -35,7 +35,7 @@ public:
     virtual void setExitStatus(int status) = 0;
     virtual const std::vector<std::string> listLoadedPlugins() const = 0;
     virtual std::shared_ptr<IDobbyRdkLoggingPlugin> getContainerLogger() const = 0;
-
+    virtual std::shared_ptr<DobbyRdkPluginUtils> getUtils() const = 0;
 };
 
 class DobbyRdkPluginManager {
@@ -55,7 +55,7 @@ public:
     void setExitStatus(int status) const;
     const std::vector<std::string> listLoadedPlugins() const;
     std::shared_ptr<IDobbyRdkLoggingPlugin> getContainerLogger() const;
-
+    std::shared_ptr<DobbyRdkPluginUtils> getUtils() const;
 };
 
 #endif // !defined(DOBBYRDKPLUGINMANAGER_H)

--- a/tests/L1_testing/mocks/DobbyRdkPluginManagerMock.cpp
+++ b/tests/L1_testing/mocks/DobbyRdkPluginManagerMock.cpp
@@ -73,3 +73,9 @@ std::shared_ptr<IDobbyRdkLoggingPlugin> DobbyRdkPluginManager::getContainerLogge
     return impl->getContainerLogger();
 }
 
+std::shared_ptr<DobbyRdkPluginUtils> DobbyRdkPluginManager::getUtils() const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getUtils();
+}

--- a/tests/L1_testing/mocks/DobbyRdkPluginManagerMock.h
+++ b/tests/L1_testing/mocks/DobbyRdkPluginManagerMock.h
@@ -32,5 +32,6 @@ public:
     MOCK_METHOD(std::shared_ptr<IDobbyRdkLoggingPlugin>, getContainerLogger, (), (const,override));
     MOCK_METHOD(bool, runPlugins,(const IDobbyRdkPlugin::HintFlags &hookPoint,const uint timeoutMs ),( const,override));
     MOCK_METHOD(bool, runPlugins,(const IDobbyRdkPlugin::HintFlags &hookPoint),( const,override));
+    MOCK_METHOD(std::shared_ptr<DobbyRdkPluginUtils>,  getUtils, (), (const, override));
 };
 

--- a/tests/L1_testing/mocks/DobbyRdkPluginUtils.h
+++ b/tests/L1_testing/mocks/DobbyRdkPluginUtils.h
@@ -77,6 +77,8 @@ public:
     virtual int addFileDescriptor(const std::string& pluginName, int fd) = 0;
     virtual std::list<int> files() const = 0;
     virtual std::list<int> files(const std::string& pluginName) const = 0;
+    virtual bool addAnnotation(const std::string &key, const std::string &value) = 0;
+    virtual std::map<std::string, std::string> getAnnotations() const = 0;
 };
 
 class DobbyRdkPluginUtils {
@@ -118,6 +120,8 @@ public:
     int addFileDescriptor(const std::string& pluginName, int fd);
     std::list<int> files();
     std::list<int> files(const std::string& pluginName);
+    bool addAnnotation(const std::string &key, const std::string &value);
+    std::map<std::string, std::string> getAnnotations() const;
 };
 
 

--- a/tests/L1_testing/mocks/DobbyRdkPluginUtils.h
+++ b/tests/L1_testing/mocks/DobbyRdkPluginUtils.h
@@ -78,6 +78,7 @@ public:
     virtual std::list<int> files() const = 0;
     virtual std::list<int> files(const std::string& pluginName) const = 0;
     virtual bool addAnnotation(const std::string &key, const std::string &value) = 0;
+    virtual bool removeAnnotation(const std::string &key) = 0;
     virtual std::map<std::string, std::string> getAnnotations() const = 0;
 };
 
@@ -121,6 +122,7 @@ public:
     std::list<int> files();
     std::list<int> files(const std::string& pluginName);
     bool addAnnotation(const std::string &key, const std::string &value);
+    bool removeAnnotation(const std::string &key);
     std::map<std::string, std::string> getAnnotations() const;
 };
 

--- a/tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.cpp
+++ b/tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.cpp
@@ -163,6 +163,13 @@ bool DobbyRdkPluginUtils::addAnnotation(const std::string& key, const std::strin
     return impl->addAnnotation(key, value);
 }
 
+bool DobbyRdkPluginUtils::removeAnnotation(const std::string& key)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->removeAnnotation(key);
+}
+
 std::map<std::string, std::string> DobbyRdkPluginUtils::getAnnotations() const
 {
    EXPECT_NE(impl, nullptr);

--- a/tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.cpp
+++ b/tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.cpp
@@ -156,3 +156,16 @@ std::list<int> DobbyRdkPluginUtils::files(const std::string& pluginName)
     return impl->files(pluginName);
 }
 
+bool DobbyRdkPluginUtils::addAnnotation(const std::string& key, const std::string& value)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->addAnnotation(key, value);
+}
+
+std::map<std::string, std::string> DobbyRdkPluginUtils::getAnnotations() const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getAnnotations();
+}

--- a/tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.h
+++ b/tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.h
@@ -43,7 +43,7 @@ public:
     MOCK_METHOD(int, addFileDescriptor, (const std::string& pluginName, int fd), (override));
     MOCK_METHOD(std::list<int>, files, (), (const,override));
     MOCK_METHOD(std::list<int>, files, (const std::string& pluginName), (const,override));
-
-
+    MOCK_METHOD(bool, addAnnotation, (const std::string &key, const std::string &value), (override));
+    MOCK_METHOD((std::map<std::string, std::string>), getAnnotations, (), (const, override));
 };
 

--- a/tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.h
+++ b/tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.h
@@ -44,6 +44,7 @@ public:
     MOCK_METHOD(std::list<int>, files, (), (const,override));
     MOCK_METHOD(std::list<int>, files, (const std::string& pluginName), (const,override));
     MOCK_METHOD(bool, addAnnotation, (const std::string &key, const std::string &value), (override));
+    MOCK_METHOD(bool, removeAnnotation, (const std::string &key), (override));
     MOCK_METHOD((std::map<std::string, std::string>), getAnnotations, (), (const, override));
 };
 

--- a/tests/L1_testing/mocks/dobbymanager/DobbyManager.h
+++ b/tests/L1_testing/mocks/dobbymanager/DobbyManager.h
@@ -107,6 +107,9 @@ public:
                         const std::string& key,
                         const std::string& value) = 0;
 
+    virtual bool removeAnnotation(int32_t cd,
+                        const std::string& key) = 0;
+
     virtual std::list<std::pair<int32_t, ContainerId>> listContainers() const = 0;
 
     virtual int32_t stateOfContainer(int32_t cd) const = 0;
@@ -177,6 +180,9 @@ public:
     bool annotate(int32_t cd,
                 const std::string& key,
                 const std::string& value);
+
+    bool removeAnnotation(int32_t cd,
+                const std::string& key);
 
     std::list<std::pair<int32_t, ContainerId>> listContainers();
     int32_t stateOfContainer(int32_t cd);

--- a/tests/L1_testing/mocks/dobbymanager/DobbyManager.h
+++ b/tests/L1_testing/mocks/dobbymanager/DobbyManager.h
@@ -103,6 +103,10 @@ public:
                              const std::string& options,
                              const std::string& command) = 0;
 
+    virtual bool annotate(int32_t cd,
+                        const std::string& key,
+                        const std::string& value) = 0;
+
     virtual std::list<std::pair<int32_t, ContainerId>> listContainers() const = 0;
 
     virtual int32_t stateOfContainer(int32_t cd) const = 0;
@@ -170,6 +174,10 @@ public:
     bool execInContainer(int32_t cd,
                                 const std::string& options,
                                 const std::string& command);
+    bool annotate(int32_t cd,
+                const std::string& key,
+                const std::string& value);
+
     std::list<std::pair<int32_t, ContainerId>> listContainers();
     int32_t stateOfContainer(int32_t cd);
     std::string statsOfContainer(int32_t cd);

--- a/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -4048,3 +4048,57 @@ TEST_F(DaemonDobbyManagerTest, annotate_FailedToFindContainer)
     bool return_value = dobbyManager_test->annotate(expect_cd, key, value);
     EXPECT_EQ(return_value,false);
 }
+
+/* -----------------------------------------------------------------------------
+ *  Test functions for : removeAnnotation()
+ *
+ *
+ * Use case coverage:
+ *                @Success :1
+ *                @Failure :1
+ *  -----------------------------------------------------------------------------
+*/
+/**
+ * @brief Test removeAnnotation
+ * Check method is successfull when correct arguments and containerId is used
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, removeAnnotation_success)
+{
+    int32_t cd = 1234;
+    std::string key = "foo";
+
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    EXPECT_CALL(*p_rdkPluginUtilsMock,removeAnnotation(::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(true));
+
+    bool return_value = dobbyManager_test->removeAnnotation(cd, key);
+    EXPECT_EQ(return_value,true);
+}
+
+/**
+ * @brief Test removeAnnotation
+ * Check the removeAnnotation method failed when valid Container Id is not found
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, removeAnnotation_FailedToFindContainer)
+{
+    int32_t cd = 1234;
+    int32_t expect_cd = 2345;
+    std::string key = "foo";
+
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    bool return_value = dobbyManager_test->removeAnnotation(expect_cd, key);
+    EXPECT_EQ(return_value,false);
+}

--- a/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -3993,3 +3993,58 @@ TEST_F(DaemonDobbyManagerTest, removeMount_FailedToFindContainer)
     EXPECT_EQ(return_value,false);
 }
 
+/* -----------------------------------------------------------------------------
+ *  Test functions for : annotate()
+ *
+ *
+ * Use case coverage:
+ *                @Success :1
+ *                @Failure :1
+ *  -----------------------------------------------------------------------------
+*/
+/**
+ * @brief Test annotate
+ * Check the annotate method is successfull when correct arguments and containerId is used
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, annotate_success)
+{
+    int32_t cd = 1234;
+    std::string key = "foo";
+    std::string value = "bar";
+
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+    
+    EXPECT_CALL(*p_rdkPluginUtilsMock,addAnnotation(::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(true));
+
+    bool return_value = dobbyManager_test->annotate(cd, key, value);
+    EXPECT_EQ(return_value,true);
+}
+
+/**
+ * @brief Test annotate
+ * Check the annotate method failed when valid Container Id is not found
+ *
+ * @return false.
+ */
+TEST_F(DaemonDobbyManagerTest, annotate_FailedToFindContainer)
+{
+    int32_t cd = 1234;
+    int32_t expect_cd = 2345;
+    std::string key = "foo";
+    std::string value = "bar";
+
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+
+    expect_startContainerFromBundle(cd,id);
+
+    bool return_value = dobbyManager_test->annotate(expect_cd, key, value);
+    EXPECT_EQ(return_value,false);
+}

--- a/tests/L2_testing/test_runner/annotation_tests.py
+++ b/tests/L2_testing/test_runner/annotation_tests.py
@@ -1,0 +1,107 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2024 Sky UK
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import test_utils
+from pathlib import Path
+
+tests = [
+    test_utils.Test("annotate()",
+                    "sleepy",
+                    "\"Key1\" : \"Value1\"",
+                    "Starts container, adds a key&value pair, confirms container info contains the annotation"),
+]
+
+
+def execute_test():
+    with test_utils.dobby_daemon():
+        output_table = []
+
+        for test in tests:
+            result = test_container(test.container_id, test.expected_output)
+            output = test_utils.create_simple_test_output(test, result[0], result[1])
+
+            output_table.append(output)
+            test_utils.print_single_result(output)
+
+
+    return test_utils.count_print_results(output_table)
+
+
+def test_container(container_id, expected_output):
+    """Runs container and check if output contains expected output
+
+    Parameters:
+    container_id (string): name of container to run
+    expected_output (string): output that should be provided by container
+
+    Returns:
+    (pass (bool), message (string)): Returns if expected output found and message
+
+    """
+    test_utils.print_log("Running %s container test" % container_id, test_utils.Severity.debug)
+
+    with test_utils.untar_bundle(container_id) as bundle_path:
+        command = ["DobbyTool",
+                "start",
+                container_id,
+                bundle_path]
+
+        status = test_utils.run_command_line(command)
+        if "started '" + container_id + "' container" not in status.stdout:
+            return False, "Container did not launch successfully"
+
+        return validate_annotation(container_id, expected_output)
+
+
+def validate_annotation(container_id, expected_output):
+    """Helper function for finding if annotation is present in container info
+
+    Parameters:
+    container_id (string): name of container to run
+    expected_output (string): expected key value pair annotation
+
+    Returns:
+    (pass (bool), message (string)): True if annotation is found in container info
+
+    """
+    annotateCommand = ["DobbyTool",
+                        "annotate",
+                        container_id,
+                        "Key1",
+                        "Value1"]
+        
+    status = test_utils.run_command_line(annotateCommand)
+    if "annotate successful for container '" + container_id + "'" not in status.stdout:
+        return False, "annotation failed"
+
+    infoCommand = ["DobbyTool",
+                "info",
+                container_id]
+        
+    status = test_utils.run_command_line(infoCommand)
+    
+    test_utils.print_log("command returned %s" % status.stdout, test_utils.Severity.debug)
+
+    if expected_output not in status.stdout:
+        return False, "annotation is not found in container info"
+    else:
+        return True, "Test passed"
+    
+
+if __name__ == "__main__":
+    test_utils.parse_arguments(__file__, True)
+    execute_test()

--- a/tests/L2_testing/test_runner/annotation_tests.py
+++ b/tests/L2_testing/test_runner/annotation_tests.py
@@ -16,13 +16,12 @@
 # limitations under the License.
 
 import test_utils
-from pathlib import Path
 
 tests = [
-    test_utils.Test("annotate()",
+    test_utils.Test("annotations",
                     "sleepy",
                     "\"Key1\" : \"Value1\"",
-                    "Starts container, adds a key&value pair, confirms container info contains the annotation"),
+                    "Starts container, adds a key&value pair, confirms annotation, then removes the annotation and confirms removal"),
 ]
 
 
@@ -98,8 +97,30 @@ def validate_annotation(container_id, expected_output):
 
     if expected_output not in status.stdout:
         return False, "annotation is not found in container info"
-    else:
-        return True, "Test passed"
+
+    removeAnnotationCommand = ["DobbyTool",
+                        "remove-annotation",
+                        container_id,
+                        "Key1"]
+    status = test_utils.run_command_line(removeAnnotationCommand)
+
+    test_utils.print_log("command returned %s" % status.stdout, test_utils.Severity.debug)
+
+    if "removed Key1 key from container '" + container_id + "'" not in status.stdout:
+        return False, "remove annotation failed"
+
+    infoCommand = ["DobbyTool",
+                "info",
+                container_id]
+
+    status = test_utils.run_command_line(infoCommand)
+
+    test_utils.print_log("command returned %s" % status.stdout, test_utils.Severity.debug)
+
+    if expected_output in status.stdout:
+        return False, "annotation is still found in container info after removal"
+
+    return True, "Test passed"
     
 
 if __name__ == "__main__":

--- a/tests/L2_testing/test_runner/runner.py
+++ b/tests/L2_testing/test_runner/runner.py
@@ -27,6 +27,7 @@ import gui_containers
 import network_tests
 import pid_limit_tests
 import memcr_tests
+import annotation_tests
 import sys
 import json
 
@@ -37,6 +38,7 @@ supported_tests = [basic_sanity_tests,
                    bundle_generation,
                    plugin_launcher,
                    command_line_containers,
+                   annotation_tests,
                    start_from_bundle,
                    thunder_plugin,
                    network_tests,


### PR DESCRIPTION
### Description

Adds "annotate()" and "removeAnnotation()" APIs to Dobby. With this method, key/value pairs can be set for containers at runtime. 

### Test Procedure
```
vagrant@dobby-vagrant-focal-arm64:~/srcDobby/build$ DobbyTool annotate sleep12 key1 value1
annotate successful for container 'sleep12'
vagrant@dobby-vagrant-focal-arm64:~/srcDobby/build$ DobbyTool annotate sleep12 key2 value2
annotate successful for container 'sleep12'
vagrant@dobby-vagrant-focal-arm64:~/srcDobby/build$ DobbyTool annotate sleep12 key3 value3
annotate successful for container 'sleep12'
vagrant@dobby-vagrant-focal-arm64:~/srcDobby/build$ DobbyTool annotate sleep12 key2 value5
annotate successful for container 'sleep12'
vagrant@dobby-vagrant-focal-arm64:~/srcDobby/build$ DobbyTool info sleep12
{
 "annotations" :
 {
  "key1" : "value1",
  "key2" : "value5",
  "key3" : "value3"
 },
 "id" : "sleep12",
 "state" : "running",
 "timestamp" : 1319810849810469
}
vagrant@dobby-vagrant-focal-arm64:~/srcDobby/build$ DobbyTool remove-annotation sleep12 key5
removed key5 key from container 'sleep12' annotations
vagrant@dobby-vagrant-focal-arm64:~/srcDobby/build$ DobbyTool info sleep12
{
 "annotations" :
 {
  "key1" : "value1",
  "key2" : "value5",
  "key3" : "value3"
 },
 "id" : "sleep12",
 "state" : "running",
 "timestamp" : 1319841586979048
}
vagrant@dobby-vagrant-focal-arm64:~/srcDobby/build$ DobbyTool remove-annotation sleep12 key2
removed key2 key from container 'sleep12' annotations
vagrant@dobby-vagrant-focal-arm64:~/srcDobby/build$ DobbyTool info sleep12
{
 "annotations" :
 {
  "key1" : "value1",
  "key3" : "value3"
 },
 "id" : "sleep12",
 "state" : "running",
 "timestamp" : 1319852633313708
}
```

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)