### PR TITLE
RDK-54347 : unshare system call not required

### DIFF
--- a/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
@@ -257,12 +257,12 @@ void DobbyRdkPluginUtils::nsThread(int newNsFd, int nsType, bool* success,
     AI_LOG_FN_ENTRY();
 
     // unshare the specific namespace from the thread
-    if (unshare(nsType) != 0)
+    /*if (unshare(nsType) != 0)
     {
         AI_LOG_SYS_ERROR_EXIT(errno, "failed to unshare");
         *success = false;
         return;
-    }
+    }*/
 
     // switch into the new namespace
     if (setns(newNsFd, nsType) != 0)


### PR DESCRIPTION
### Description
unshare system call is used for creating a new namespace, but in our case we just need to join an existing namespace. So, we do not need to call unshare() and can directly use setns() to switch to that namespace by opening the corresponding namespace file descriptor.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)