### PR TITLE
RDKTV-35223: fix storage plugin postStop() hook error handling

### DIFF
--- a/rdkPlugins/Storage/source/Storage.cpp
+++ b/rdkPlugins/Storage/source/Storage.cpp
@@ -278,9 +278,7 @@ bool Storage::postStop()
         // Clean up temp mount points
         if(!(*it)->removeNonPersistentImage())
         {
-            AI_LOG_ERROR_EXIT("failed to clean up non persistent image");
-            // This is probably to late to fail but do it either way
-            return false;
+            AI_LOG_ERROR("failed to clean up non persistent image");
         }
     }
 
@@ -290,9 +288,7 @@ bool Storage::postStop()
         // Clean up temp mount points
         if(!(*it)->onPostStop())
         {
-            AI_LOG_ERROR_EXIT("failed to remove dynamic mounts");
-            // This is probably to late to fail but do it either way
-            return false;
+            AI_LOG_ERROR("failed to remove dynamic mounts");
         }
     }
 
@@ -305,15 +301,14 @@ bool Storage::postStop()
     }
     else
     {
-        AI_LOG_DEBUG("unmounted temp mount @ '%s', now deleting mount point",
+        AI_LOG_INFO("unmounted temp mount @ '%s', now deleting mount point",
                     mTempMountPointOutsideContainer.c_str());
 
         // can now delete the temporary mount point
         if (rmdir(mTempMountPointOutsideContainer.c_str()) != 0)
         {
-            AI_LOG_ERROR_EXIT("failed to delete temp mount point @ '%s'",
-                             mTempMountPointOutsideContainer.c_str());
-            return false;
+            AI_LOG_ERROR("failed to delete temp mount point @ '%s'",
+                         mTempMountPointOutsideContainer.c_str());
         }
     }
 #endif


### PR DESCRIPTION
### Description
storage plugin postStop() hook should allow all internal modules to cleanup.

### Test Procedure
See Jira ticket

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)