### PR TITLE
RDKTV-35344: Dynamic mounts are failing to unmount

### DIFF
--- a/rdkPlugins/Storage/source/DynamicMountDetails.cpp
+++ b/rdkPlugins/Storage/source/DynamicMountDetails.cpp
@@ -211,7 +211,7 @@ bool DynamicMountDetails::onPostStop() const
 
     if (stat(targetPath.c_str(), &buffer) == 0)
     {
-        if (umount(targetPath.c_str()) == 0)
+        if (remove(targetPath.c_str()) == 0)
         {
             success = true;
         }


### PR DESCRIPTION
### Description
Removing the dynamic mounts in postStop hook, since it is failing to unmount when the container is stopping

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)