### PR TITLE
DELIA-67400: Trim minidump filename length

### DIFF
--- a/rdkPlugins/Minidump/source/Minidump.cpp
+++ b/rdkPlugins/Minidump/source/Minidump.cpp
@@ -136,7 +136,7 @@ bool Minidump::postHalt()
  * @return Destination minidump file path string
  */
 #define FIREBOLT_STATE  "fireboltState"
-#define MINIDUMP_DESTFILE_LENGTH 70
+#define MINIDUMP_FILENAME_LENGTH 44
 #define MINIDUMP_FN_SEPERATOR "<#=#>"
 
 std::string Minidump::getDestinationFile()
@@ -156,15 +156,15 @@ std::string Minidump::getDestinationFile()
     auto it = annotations.find(FIREBOLT_STATE);
     if (it != annotations.end()) {
         fileName = mUtils->getContainerId() + MINIDUMP_FN_SEPERATOR + it->second.c_str() + MINIDUMP_FN_SEPERATOR + timeString.str();
-        if (fileName.length() > MINIDUMP_DESTFILE_LENGTH-dir.length()-4)
-            fileName.resize(MINIDUMP_DESTFILE_LENGTH-dir.length()-4);
+        if (fileName.length() > MINIDUMP_FILENAME_LENGTH)
+            fileName.resize(MINIDUMP_FILENAME_LENGTH);
         destFile = dir + "/" + fileName + ".dmp";
         AI_LOG_INFO("Firebolt state: %s, minidump filename: %s", it->second.c_str(), destFile.c_str());
     }else{
         AI_LOG_INFO("Firebolt state not found");
         fileName = mUtils->getContainerId() + MINIDUMP_FN_SEPERATOR + timeString.str();
-        if (fileName.length() > MINIDUMP_DESTFILE_LENGTH-dir.length()-4)
-            fileName.resize(MINIDUMP_DESTFILE_LENGTH-dir.length()-4);
+        if (fileName.length() > MINIDUMP_FILENAME_LENGTH)
+            fileName.resize(MINIDUMP_FILENAME_LENGTH);
         destFile = dir + "/" + fileName + ".dmp";
     }
 

--- a/rdkPlugins/Minidump/source/Minidump.cpp
+++ b/rdkPlugins/Minidump/source/Minidump.cpp
@@ -136,7 +136,8 @@ bool Minidump::postHalt()
  * @return Destination minidump file path string
  */
 #define FIREBOLT_STATE  "fireboltState"
-#define MINIDUMP_FN_SEPERATOR "<#=#>"
+#define MINIDUMP_FILENAME_LENGTH 70
+
 
 std::string Minidump::getDestinationFile()
 {
@@ -146,6 +147,7 @@ std::string Minidump::getDestinationFile()
     std::stringstream timeString;
     timeString << std::put_time(std::localtime(&currentTime), "%FT%T");
     std::string destFile;
+    std::string fileName;
 
     std::string dir(mContainerConfig->rdk_plugins->minidump->data->destination_path);
 
@@ -153,11 +155,17 @@ std::string Minidump::getDestinationFile()
 
     auto it = annotations.find(FIREBOLT_STATE);
     if (it != annotations.end()) {
-        destFile = dir + "/" + mUtils->getContainerId() + MINIDUMP_FN_SEPERATOR + it->second.c_str() + MINIDUMP_FN_SEPERATOR + timeString.str() + ".dmp";
+        fileName = mUtils->getContainerId() + "_" + it->second.c_str() + "_" + timeString.str();
+        if (fileName.length() > MINIDUMP_FILENAME_LENGTH)
+            fileName.resize(MINIDUMP_FILENAME_LENGTH);
+        destFile = dir + "/" + fileName + ".dmp";
         AI_LOG_INFO("Firebolt state: %s, minidump filename: %s", it->second.c_str(), destFile.c_str());
     }else{
         AI_LOG_INFO("Firebolt state not found");
-        destFile = dir + "/" + mUtils->getContainerId() + MINIDUMP_FN_SEPERATOR + timeString.str() + ".dmp";
+        fileName = mUtils->getContainerId() + "_" + timeString.str();
+        if (fileName.length() > MINIDUMP_FILENAME_LENGTH)
+            fileName.resize(MINIDUMP_FILENAME_LENGTH);
+        destFile = dir + "/" + fileName + ".dmp";
     }
 
     return destFile;

--- a/rdkPlugins/Minidump/source/Minidump.cpp
+++ b/rdkPlugins/Minidump/source/Minidump.cpp
@@ -136,8 +136,8 @@ bool Minidump::postHalt()
  * @return Destination minidump file path string
  */
 #define FIREBOLT_STATE  "fireboltState"
-#define MINIDUMP_FILENAME_LENGTH 70
-
+#define MINIDUMP_DESTFILE_LENGTH 70
+#define MINIDUMP_FN_SEPERATOR "<#=#>"
 
 std::string Minidump::getDestinationFile()
 {
@@ -155,16 +155,16 @@ std::string Minidump::getDestinationFile()
 
     auto it = annotations.find(FIREBOLT_STATE);
     if (it != annotations.end()) {
-        fileName = mUtils->getContainerId() + "_" + it->second.c_str() + "_" + timeString.str();
-        if (fileName.length() > MINIDUMP_FILENAME_LENGTH)
-            fileName.resize(MINIDUMP_FILENAME_LENGTH);
+        fileName = mUtils->getContainerId() + MINIDUMP_FN_SEPERATOR + it->second.c_str() + MINIDUMP_FN_SEPERATOR + timeString.str();
+        if (fileName.length() > MINIDUMP_DESTFILE_LENGTH-dir.length()-4)
+            fileName.resize(MINIDUMP_DESTFILE_LENGTH-dir.length()-4);
         destFile = dir + "/" + fileName + ".dmp";
         AI_LOG_INFO("Firebolt state: %s, minidump filename: %s", it->second.c_str(), destFile.c_str());
     }else{
         AI_LOG_INFO("Firebolt state not found");
-        fileName = mUtils->getContainerId() + "_" + timeString.str();
-        if (fileName.length() > MINIDUMP_FILENAME_LENGTH)
-            fileName.resize(MINIDUMP_FILENAME_LENGTH);
+        fileName = mUtils->getContainerId() + MINIDUMP_FN_SEPERATOR + timeString.str();
+        if (fileName.length() > MINIDUMP_DESTFILE_LENGTH-dir.length()-4)
+            fileName.resize(MINIDUMP_DESTFILE_LENGTH-dir.length()-4);
         destFile = dir + "/" + fileName + ".dmp";
     }
 


### PR DESCRIPTION
### Description
Minidump compression is failing due to "File name too long" issue. So, limiting the minidump file name length to 70 characters

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)