### PR TITLE
Add ARP entires for container IPv4 address on container start.

### DIFF
--- a/rdkPlugins/Networking/include/Netlink.h
+++ b/rdkPlugins/Networking/include/Netlink.h
@@ -114,6 +114,11 @@ public:
     bool addRoute(const std::string& iface, const struct in6_addr destination,
                   const int netmask, const struct in6_addr gateway);
 
+    bool addArpEntry(const std::string &iface, in_addr_t address,
+                     const std::array<uint8_t, 6> &mac);
+
+    bool delArpEntry(const std::string &iface, in_addr_t address);
+
 private:
     bool applyChangesToLink(const std::string& ifaceName,
                             const NlLink& changes);

--- a/rdkPlugins/Networking/include/NetworkingHelper.h
+++ b/rdkPlugins/Networking/include/NetworkingHelper.h
@@ -21,6 +21,7 @@
 #define NETWORKINGHELPER_H
 
 #include <netinet/in.h>
+#include <array>
 #include <string>
 #include "NetworkingPluginCommon.h"
 
@@ -32,6 +33,7 @@ public:
 
 public:
     bool storeContainerInterface(in_addr_t addr, const std::string &vethName);
+    bool storeContainerVethPeerMac(const std::array<uint8_t, 6> &mac);
 
     bool ipv4() const;
     in_addr_t ipv4Addr() const;
@@ -42,6 +44,7 @@ public:
     std::string ipv6AddrStr() const;
 
     std::string vethName() const;
+    std::array<uint8_t, 6> vethPeerMac() const;
 
 public:
     static struct in6_addr in6addrCreate(const in_addr_t inaddr);
@@ -56,6 +59,7 @@ private:
     std::string mIpv6AddrStr;
 
     std::string mVethName;
+    std::array<uint8_t, 6> mVethPeerMac;
 };
 
 #endif // !defined(NETWORKINGHELPER_H)

--- a/rdkPlugins/Networking/source/NetworkingHelper.cpp
+++ b/rdkPlugins/Networking/source/NetworkingHelper.cpp
@@ -31,7 +31,8 @@ NetworkingHelper::NetworkingHelper(bool ipv4Enabled, bool ipv6Enabled)
     mIpv4AddrStr(std::string()),
     mIpv6Enabled(ipv6Enabled),
     mIpv6Addr(IN6ADDR_BASE),
-    mIpv6AddrStr(std::string())
+    mIpv6AddrStr(std::string()),
+    mVethPeerMac{ 0x00 }
 {
     if (!mIpv4Enabled && !mIpv6Enabled)
     {
@@ -83,6 +84,11 @@ std::string NetworkingHelper::vethName() const
     return mVethName;
 }
 
+std::array<uint8_t, 6> NetworkingHelper::vethPeerMac() const
+{
+    return mVethPeerMac;
+}
+
 // -----------------------------------------------------------------------------
 /**
  *  @brief Constructs addresses for the container based on input address. Also
@@ -115,6 +121,22 @@ bool NetworkingHelper::storeContainerInterface(in_addr_t addr, const std::string
 
     mVethName = vethName;
 
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Simply stores the MAC address of eth0 within the container.
+ *
+ *  This is used to update the ARP table on the bridge.
+ *
+ *  @param[in]  mac         The MAC address of the eth0 interface within the container.
+ *
+ *  @return true if successful, otherwise false
+ */
+bool NetworkingHelper::storeContainerVethPeerMac(const std::array<uint8_t, 6> &mac)
+{
+    mVethPeerMac = mac;
     return true;
 }
 


### PR DESCRIPTION
### Description
Found that inter-container network routing was intermittent and slow on some platforms with earlier kernels.  The problem seems to be that there was no ARP entries on the dobby0 bridge, sometimes they would show up, and sometimes a new container would still have stale entries from a previous container.

Similar problem reported here: https://github.com/moby/moby/issues/36174

To work around these issues, the NetworkPlugin is changed to add ARP rules to the cache on the dobby0 bridge when the container is started. When the container is stopped the ARP entry is removed.

Concerned about the container start time; I did some ad-hoc testing on the time it takes to add the ARP entries on broadom device and it's between 300us - 800us, so shouldn't add much to the container start time.  If this is a concern could change the code to only add the ARP entries if the inter-container networking config is set.

### Test Procedure
Create two containers and config the interContainer settings to connect the two and verify you can communicate.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)