### PR TITLE
DELIA-67877: Use AppArmor sysfs interface for checking whether a profile is loaded

### DIFF
--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -27,6 +27,7 @@
 #include <glob.h>
 #include <sys/stat.h>
 #include <fstream>
+#include <fcntl.h>
 #include <FileUtilities.h>
 
 #define OCI_VERSION_CURRENT         "1.0.2"         // currently used version of OCI in bundles
@@ -780,32 +781,34 @@ bool DobbyConfig::updateBundleConfig(const ContainerId& id, std::shared_ptr<rt_d
  */
 
 bool DobbyConfig::isApparmorProfileLoaded(const char *profile) const
-{
-    FILE *fp = nullptr;
-    char line[256];
-    bool status = false;
+ {
+     bool status = false;
+     int fd = open("/proc/self/attr/current", O_WRONLY);
 
-    fp = fopen("/sys/kernel/security/apparmor/profiles", "r");
+     if (fd < 0)
+     {
+         AI_LOG_ERROR("/proc/self/attr/current open failed");
+         return status;
+     }
+     char profile_name[256];
+     snprintf(profile_name, sizeof(profile_name), "permprofile %s", profile);
 
-    if (fp == nullptr)
-    {
-        AI_LOG_ERROR("/sys/kernel/security/apparmor/profiles open failed");
-        return status;
-    }
+     if (write(fd, profile_name, strlen(profile_name)) < 0)
+     {
+         if (errno == ENOENT)
+             AI_LOG_INFO("Apparmor profile [%s] doesn't exist", profile);
+         else
+             AI_LOG_ERROR("/proc/self/attr/current write failed");
+     }
+     else
+     {
+         status = true;
+         AI_LOG_INFO("Apparmor profile [%s] is loaded", profile);
+     }
 
-    while (fgets(line, sizeof(line), fp))
-    {
-        if (strstr(line, profile))
-        {
-            status = true;
-            AI_LOG_INFO("Apparmor profile [%s] is loaded", profile);
-            break;
-        }
-    }
-
-    fclose(fp);
-    return status;
-}
+     close(fd);
+     return status;
+ }
 
 // -----------------------------------------------------------------------------
 /**


### PR DESCRIPTION
### Description
Parsing the entirety of /sys/kernel/security/apparmor/profiles can be slow and the file can grow fairly large when complain mode is in use. Instead we can use the AppArmor sysfs interface for checking whether a profile is loaded or not. This queries the kernel directly instead of parsing the entire file.

### Test Procedure
echo -n "permprofile dobby_default" > /proc/self/attr/current
Will return an error if the profile name dobby_default is not found, if it is then no error is returned

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)