### PR TITLE
DELIA-68669 : unmount /tmp/communicator from dobby.json

### DIFF
--- a/rdkPlugins/Thunder/source/ThunderPlugin.cpp
+++ b/rdkPlugins/Thunder/source/ThunderPlugin.cpp
@@ -166,6 +166,7 @@ bool ThunderPlugin::postInstallation()
 
             mUtils->addMount(mSocketPath, mSocketPath, "bind",
                              {"bind", "ro", "nosuid", "nodev", "noexec"});
+        }
     }
     mUtils->addMount("/tmp/communicator", "/tmp/communicator", "bind",
                              {"bind", "ro", "nosuid", "nodev", "noexec"});


### PR DESCRIPTION
Reason for change: unmount /tmp/communicator from dobby.json and add the mount in plugin only when a container needs Thunder IPC access.
Test Procedure: 1.Verify whether /tmp/communicator is mounted inside container.
2.Ensure there are no issues on rialto intergration
Risks: Low
Signed-off-by: Soundaryaa Sitaram<Soundaryaa_Sitaram@comcast.com>