### PR TITLE
RDKEMW-10995: Fix to prevent double close issue

### DIFF
--- a/rdkPlugins/Logging/source/FileSink.cpp
+++ b/rdkPlugins/Logging/source/FileSink.cpp
@@ -120,6 +120,11 @@ void FileSink::DumpLog(const int bufferFd)
 
     std::lock_guard<std::mutex> locker(mLock);
 
+    if (mOutputFileFd < 0) {
+        AI_LOG_ERROR("Invalid output file descriptor");
+        return;
+     }
+
     ssize_t ret;
     ssize_t offset = 0;
 

--- a/rdkPlugins/Logging/source/FileSink.cpp
+++ b/rdkPlugins/Logging/source/FileSink.cpp
@@ -77,7 +77,7 @@ FileSink::FileSink(const std::string &containerId, std::shared_ptr<rt_dobby_sche
     {
         // Couldn't open our output file, send to /dev/null to avoid blocking
         AI_LOG_SYS_ERROR(errno, "Failed to open container logfile - sending to /dev/null");
-        if (mDevNullFd > 0)
+        if (mDevNullFd >= 0)
         {
             mOutputFileFd = mDevNullFd;
         }
@@ -88,17 +88,20 @@ FileSink::FileSink(const std::string &containerId, std::shared_ptr<rt_dobby_sche
 
 FileSink::~FileSink()
 {
-    // Close everything we opened
-    if (close(mDevNullFd) < 0)
-    {
-        AI_LOG_SYS_ERROR(errno, "Failed to close /dev/null");
-    }
-
-    if (mOutputFileFd > 0)
+    // Close everything we opened; avoid closing the same fd twice
+    if (mOutputFileFd >= 0 && mOutputFileFd != mDevNullFd)
     {
         if (close(mOutputFileFd) < 0)
         {
             AI_LOG_SYS_ERROR(errno, "Failed to close output file");
+        }
+    }
+
+    if (mDevNullFd >= 0)
+    {
+        if (close(mDevNullFd) < 0)
+        {
+            AI_LOG_SYS_ERROR(errno, "Failed to close /dev/null");
         }
     }
 }


### PR DESCRIPTION
### Description
Added proper fd validation and avoids closing the same fd twice

### Test Procedure
How to test this PR (if applicable)

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)