### PR TITLE
RDKEMW-12359: Prevent buffer overflow when the data contains protocol delimiter bytes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,13 @@ cmake_minimum_required( VERSION 3.7.0 )
 include(GNUInstallDirs)
 
 # Project setup
-project( Dobby VERSION "3.14.1" )
+project( Dobby VERSION "3.14.2" )
 
 
 # Set the major and minor version numbers of dobby (also used by plugins)
 set( DOBBY_MAJOR_VERSION 3 )
 set( DOBBY_MINOR_VERSION 14 )
-set( DOBBY_MICRO_VERSION 1 )
+set( DOBBY_MICRO_VERSION 2 )
 
 set(INSTALL_CMAKE_DIR lib/cmake/Dobby)
 

--- a/plugins/EthanLog/source/EthanLogClient.cpp
+++ b/plugins/EthanLog/source/EthanLogClient.cpp
@@ -432,7 +432,7 @@ void EthanLogClient::processLogData()
         if (msgStart != mMsgBuf)
         {
             mMsgLen -= (msgStart - mMsgBuf);
-            memmove(mMsgBuf, mMsgBuf, mMsgLen);
+            memmove(mMsgBuf, msgStart, mMsgLen);
         }
 
 
@@ -492,10 +492,18 @@ void EthanLogClient::processLogData()
                                              : (msgEnd - thisField);
                 fieldLen -= 2;
 
-                // skip empty fields
-                if (fieldLen > 0)
+                // determine the field type before applying length checks
+                char fieldType = *thisField;
+
+                // skip empty or invalid length fields (e.g. caused by binary
+                // data in the pipe containing accidental FIELD_DELIM (0x1f) or
+                // RECORD_DELIM (0x1e) bytes), but allow an empty 'M' (message)
+                // field so that it is still emitted as "MESSAGE=".
+                if ((fieldLen > 0) || ((fieldLen == 0) && (fieldType == 'M')))
                 {
-                    switch (*thisField++)
+                    // advance past the field type character
+                    thisField++;
+                    switch (fieldType)
                     {
                         case 'L':
                             if (!(msgFlags & FLAG_HAVE_LOG_LEVEL))
@@ -705,16 +713,30 @@ int EthanLogClient::processTimestamp(const char *field, ssize_t, struct iovec *i
 // -----------------------------------------------------------------------------
 /**
  * @brief Process the message field
- * @param[in]  tok     The field minus the leading 'F' character
+ * @param[in]  tok     The field minus the leading 'M' character
  * @param[out] message Upon return will point to the message string
  * @returns            the number of fields added to iov on success, -1 on failure
  */
 int EthanLogClient::processMessage(const char *field, ssize_t len, struct iovec *iov) const
 {
+    // Guard against negative length which can occur when binary/invalid data
+    // is received (e.g. from a container logging garbage bytes that accidentally
+    // contain a RECORD_DELIM (0x1e) byte, causing msgEnd to land before
+    // thisField). Without this check the std::min<size_t> cast below would
+    // wrap a negative ssize_t to SIZE_MAX, causing buffer overflow and memory
+    // corruption via memcpy. Note: len == 0 is a valid empty message per the
+    // protocol and is handled correctly below.
+    if (len < 0)
+    {
+        AI_LOG_ERROR("[EthanLog] processMessage called with invalid length %zd "
+                     "- dropping message to prevent buffer overflow", len);
+        return -1;
+    }
+
     static char buf[8 + ETHANLOG_MAX_LOG_MSG_LENGTH];
     memcpy(buf, "MESSAGE=", 8);
 
-    len = std::min<size_t>(ETHANLOG_MAX_LOG_MSG_LENGTH, len);
+    len = std::min<ssize_t>(static_cast<ssize_t>(ETHANLOG_MAX_LOG_MSG_LENGTH), len);
     memcpy(buf + 8, field, len);
 
     iov->iov_base = buf;

--- a/plugins/EthanLog/source/EthanLogClient.cpp
+++ b/plugins/EthanLog/source/EthanLogClient.cpp
@@ -722,13 +722,14 @@ int EthanLogClient::processMessage(const char *field, ssize_t len, struct iovec 
     // Guard against negative length which can occur when binary/invalid data
     // is received (e.g. from a container logging garbage bytes that accidentally
     // contain a RECORD_DELIM (0x1e) byte, causing msgEnd to land before
-    // thisField). Without this check the std::min<size_t> cast below would
-    // wrap a negative ssize_t to SIZE_MAX, causing buffer overflow and memory
-    // corruption via memcpy. Note: len == 0 is a valid empty message per the
-    // protocol and is handled correctly below.
+    // thisField). Without this check a negative ssize_t `len` would be
+    // implicitly converted to a large size_t when used as the length argument
+    // to memcpy and in length calculations (e.g. iov_len), leading to buffer
+    // overflow and memory corruption. Note: len == 0 is a valid empty message
+    // per the protocol and is handled correctly below.
     if (len < 0)
     {
-        AI_LOG_ERROR("[EthanLog] processMessage called with invalid length %zd "
+        AI_LOG_ERROR("processMessage called with invalid length %zd "
                      "- dropping message to prevent buffer overflow", len);
         return -1;
     }


### PR DESCRIPTION
### Description
- processMessage(): add len < 0 guard that logs an error and returns -1, dropping the malformed message safely before any memcpy
- processMessage(): change std::min<size_t> to std::min<ssize_t> to prevent silent unsigned wrap of negative length values
- processLogData(): fix memmove(mMsgBuf, mMsgBuf, mMsgLen) no-op bug; correct source pointer to msgStart so consumed bytes are actually discarded from the buffer

### Test Procedure
The crash is non-deterministic: it only occurs when the binary key bytes happen to contain a 0x1e or 0x1f byte

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)