### PR TITLE
RDKEMW-15176: set swap memory limit for containers

### DIFF
--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -62,6 +62,10 @@ static const ctemplate::StaticTemplateString USERNS_DISABLED =
 
 static const ctemplate::StaticTemplateString MEM_LIMIT =
     STS_INIT(MEM_LIMIT, "MEM_LIMIT");
+static const ctemplate::StaticTemplateString MEM_SWAP_LIMIT =
+    STS_INIT(MEM_SWAP_LIMIT, "MEM_SWAP_LIMIT");
+
+static constexpr unsigned MEM_SWAP_LIMIT_EXTRA_BYTES = 200u * 1024u * 1024u;
 
 static const ctemplate::StaticTemplateString CPU_SHARES_ENABLED =
     STS_INIT(CPU_SHARES_ENABLED, "CPU_SHARES_ENABLED");
@@ -1274,6 +1278,7 @@ bool DobbySpecConfig::processMemLimit(const Json::Value& value,
     }
 
     dictionary->SetIntValue(MEM_LIMIT, memLimit);
+    dictionary->SetIntValue(MEM_SWAP_LIMIT, memLimit + MEM_SWAP_LIMIT_EXTRA_BYTES);
 
     return true;
 }

--- a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
@@ -327,7 +327,9 @@ static const char* ociJsonTemplate = R"JSON(
                 {{/DEV_WHITELIST_SECTION}}
             ],
             "memory": {
-                "limit": {{MEM_LIMIT}}
+                "limit": {{MEM_LIMIT}},
+                "swap": {{MEM_SWAP_LIMIT}},
+                "swappiness": 60
             },
             "cpu": {
                 {{#CPU_SHARES_ENABLED}}

--- a/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
@@ -338,7 +338,9 @@ static const char* ociJsonTemplate = R"JSON(
                 {{/DEV_WHITELIST_SECTION}}
             ],
             "memory": {
-                "limit": {{MEM_LIMIT}}
+                "limit": {{MEM_LIMIT}},
+                "swap": {{MEM_SWAP_LIMIT}},
+                "swappiness": 60
             },
             "cpu": {
                 {{#CPU_SHARES_ENABLED}}


### PR DESCRIPTION
Added "swap" limit in the OCI config templates to enable OOM killing when memory limit is reached when swap memory is enabled.

### Description
What does this PR change/fix and why?

If there is a corresponding JIRA ticket, please ensure it is in the title of the PR.

### Test Procedure
How to test this PR (if applicable)

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)