### PR TITLE
RDKEMW-16955: Log firebolt state of the app in OOMCrash plugin

### DIFF
--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -635,7 +635,7 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
     // step 6 - enable the RDK plugins section
     dictionary->ShowSection(ENABLE_RDK_PLUGINS);
 
-    // step 6.5 - add any default plugins in the settings file
+    // step 6.1 - add any default plugins in the settings file
     Json::Value rdkPluginData = mRdkPluginsData;
     for (const auto& pluginName : mDefaultPlugins)
     {
@@ -643,6 +643,13 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
         mRdkPluginsJson[pluginName]["required"] = false;
     }
 
+
+    // step 6.2 - always enable the OOMCrash plugin (unless already configured)
+    if (!mRdkPluginsJson.isMember("oomcrash"))
+    {
+        mRdkPluginsJson["oomcrash"]["data"] = Json::Value(Json::objectValue);
+        mRdkPluginsJson["oomcrash"]["required"] = false;
+    }
     // step 7 - process RDK plugins json into dictionary
     if (!processRdkPlugins(mSpec["rdkPlugins"], mDictionary))
     {

--- a/bundle/runtime-schemas/defs-plugins.json
+++ b/bundle/runtime-schemas/defs-plugins.json
@@ -651,9 +651,6 @@
                 },
                 "data": {
                     "type": "object",
-                    "required": [
-                        "path"
-                    ],
                     "properties": {
                         "path": {
                             "type": "string"

--- a/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
@@ -42,80 +42,6 @@
 #include <list>
 #include <thread>
 
-#ifdef USE_SYSTEMD
-#define SD_JOURNAL_SUPPRESS_LOCATION
-#include <systemd/sd-journal.h>
-#include <syslog.h>
-
-// -----------------------------------------------------------------------------
-/**
- * @brief Redirect this process's AI_LOG output to a journald *stream* fd
- * instead of per-message datagrams.
- *
- * Plugin hooks run inside a short-lived worker process forked by
- * executeHookTimeout(). If that worker logs via sd_journal_send() (datagrams)
- * and then _exit()s, journald may not have resolved /proc/<pid> for message
- * attribution before the pid disappears, so the messages get dropped (a
- * journald PID-resolution race). A journald stream fd avoids this: journald
- * captures the sender's identity via SO_PEERCRED at connect time - while we
- * are still alive - so every line written is attributed correctly even after
- * we exit, and the kernel preserves the buffered stream data until journald
- * reads EOF.
- *
- * @return The stream fd on success (left open for the lifetime of the
- *         process), or -1 on failure (logging is left unchanged).
- */
-static int redirectLoggingToJournaldStream()
-{
-    int journalFd = sd_journal_stream_fd("DobbyDaemon", LOG_INFO, 1 /* level_prefix */);
-    if (journalFd < 0)
-    {
-        // Leave the inherited logger in place - no worse than before
-        return -1;
-    }
-
-    AICommon::initLogging(
-        [journalFd](int level, const char *file, const char *func, int line, const char *message)
-        {
-            int priority;
-            const char *levelStr;
-            switch (level)
-            {
-                case AI_DEBUG_LEVEL_FATAL:     priority = LOG_CRIT;    levelStr = "FTL: "; break;
-                case AI_DEBUG_LEVEL_ERROR:     priority = LOG_ERR;     levelStr = "ERR: "; break;
-                case AI_DEBUG_LEVEL_WARNING:   priority = LOG_WARNING; levelStr = "WRN: "; break;
-                case AI_DEBUG_LEVEL_MILESTONE: priority = LOG_NOTICE;  levelStr = "MIL: "; break;
-                case AI_DEBUG_LEVEL_INFO:      priority = LOG_INFO;    levelStr = "NFO: "; break;
-                case AI_DEBUG_LEVEL_DEBUG:     priority = LOG_DEBUG;   levelStr = "DBG: "; break;
-                default:                       priority = LOG_INFO;    levelStr = ": ";    break;
-            }
-
-            // With level_prefix enabled, journald reads a leading "<N>" on each
-            // line to set the message priority, then stores the remainder as
-            // the message text. Match the daemon's journald format exactly: the
-            // text is just "<level>: <message>" (file/func/line were carried in
-            // separate CODE_* fields, not the message text).
-            (void)file;
-            (void)func;
-            (void)line;
-            char buf[512];
-            int len = snprintf(buf, sizeof(buf), "<%d>%s%s\n",
-                               priority, levelStr, message);
-            if (len < 0)
-                return;
-            if (len > static_cast<int>(sizeof(buf)))
-                len = sizeof(buf);
-
-            // write() copies into journald's socket buffer synchronously, so the
-            // data is safe even if we _exit() immediately afterwards.
-            ssize_t written = TEMP_FAILURE_RETRY(write(journalFd, buf, len));
-            (void)written;
-        });
-
-    return journalFd;
-}
-#endif // USE_SYSTEMD
-
 // -----------------------------------------------------------------------------
 /**
  * @brief Create instance of DobbyRdkPlugin Manager and load all plugins that
@@ -788,13 +714,6 @@ bool DobbyRdkPluginManager::executeHookTimeout(const std::string &pluginName,
         // Create a new SID for the child process
         if (setsid() < 0)
             _exit(EXIT_FAILURE);
-
-#ifdef USE_SYSTEMD
-        // This worker is short-lived: it runs the hook and then _exit()s below.
-        // Route its logs through a journald stream fd so they aren't dropped by
-        // the journald PID-resolution race (see redirectLoggingToJournaldStream).
-        redirectLoggingToJournaldStream();
-#endif
 
         char result = static_cast<char>(executeHook(pluginName, hook));
          // Set result in shared memory

--- a/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
@@ -92,19 +92,15 @@ static int redirectLoggingToJournaldStream()
 
             // With level_prefix enabled, journald reads a leading "<N>" on each
             // line to set the message priority, then stores the remainder as
-            // the message text. Mirror the usual Dobby log format for the text.
+            // the message text. Match the daemon's journald format exactly: the
+            // text is just "<level>: <message>" (file/func/line were carried in
+            // separate CODE_* fields, not the message text).
+            (void)file;
+            (void)func;
+            (void)line;
             char buf[512];
-            int len;
-            if (!file || !func || (line <= 0))
-            {
-                len = snprintf(buf, sizeof(buf), "<%d>%s%s\n",
+            int len = snprintf(buf, sizeof(buf), "<%d>%s%s\n",
                                priority, levelStr, message);
-            }
-            else
-            {
-                len = snprintf(buf, sizeof(buf), "<%d>%s< M:%.64s F:%.64s L:%d > %s\n",
-                               priority, levelStr, file, func, line, message);
-            }
             if (len < 0)
                 return;
             if (len > static_cast<int>(sizeof(buf)))

--- a/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
@@ -42,6 +42,84 @@
 #include <list>
 #include <thread>
 
+#ifdef USE_SYSTEMD
+#define SD_JOURNAL_SUPPRESS_LOCATION
+#include <systemd/sd-journal.h>
+#include <syslog.h>
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Redirect this process's AI_LOG output to a journald *stream* fd
+ * instead of per-message datagrams.
+ *
+ * Plugin hooks run inside a short-lived worker process forked by
+ * executeHookTimeout(). If that worker logs via sd_journal_send() (datagrams)
+ * and then _exit()s, journald may not have resolved /proc/<pid> for message
+ * attribution before the pid disappears, so the messages get dropped (a
+ * journald PID-resolution race). A journald stream fd avoids this: journald
+ * captures the sender's identity via SO_PEERCRED at connect time - while we
+ * are still alive - so every line written is attributed correctly even after
+ * we exit, and the kernel preserves the buffered stream data until journald
+ * reads EOF.
+ *
+ * @return The stream fd on success (left open for the lifetime of the
+ *         process), or -1 on failure (logging is left unchanged).
+ */
+static int redirectLoggingToJournaldStream()
+{
+    int journalFd = sd_journal_stream_fd("DobbyDaemon", LOG_INFO, 1 /* level_prefix */);
+    if (journalFd < 0)
+    {
+        // Leave the inherited logger in place - no worse than before
+        return -1;
+    }
+
+    AICommon::initLogging(
+        [journalFd](int level, const char *file, const char *func, int line, const char *message)
+        {
+            int priority;
+            const char *levelStr;
+            switch (level)
+            {
+                case AI_DEBUG_LEVEL_FATAL:     priority = LOG_CRIT;    levelStr = "FTL: "; break;
+                case AI_DEBUG_LEVEL_ERROR:     priority = LOG_ERR;     levelStr = "ERR: "; break;
+                case AI_DEBUG_LEVEL_WARNING:   priority = LOG_WARNING; levelStr = "WRN: "; break;
+                case AI_DEBUG_LEVEL_MILESTONE: priority = LOG_NOTICE;  levelStr = "MIL: "; break;
+                case AI_DEBUG_LEVEL_INFO:      priority = LOG_INFO;    levelStr = "NFO: "; break;
+                case AI_DEBUG_LEVEL_DEBUG:     priority = LOG_DEBUG;   levelStr = "DBG: "; break;
+                default:                       priority = LOG_INFO;    levelStr = ": ";    break;
+            }
+
+            // With level_prefix enabled, journald reads a leading "<N>" on each
+            // line to set the message priority, then stores the remainder as
+            // the message text. Mirror the usual Dobby log format for the text.
+            char buf[512];
+            int len;
+            if (!file || !func || (line <= 0))
+            {
+                len = snprintf(buf, sizeof(buf), "<%d>%s%s\n",
+                               priority, levelStr, message);
+            }
+            else
+            {
+                len = snprintf(buf, sizeof(buf), "<%d>%s< M:%.64s F:%.64s L:%d > %s\n",
+                               priority, levelStr, file, func, line, message);
+            }
+            if (len < 0)
+                return;
+            if (len > static_cast<int>(sizeof(buf)))
+                len = sizeof(buf);
+
+            // write() copies into journald's socket buffer synchronously, so the
+            // data is safe even if we _exit() immediately afterwards.
+            ssize_t written = TEMP_FAILURE_RETRY(write(journalFd, buf, len));
+            (void)written;
+        });
+
+    return journalFd;
+}
+#endif // USE_SYSTEMD
+
 // -----------------------------------------------------------------------------
 /**
  * @brief Create instance of DobbyRdkPlugin Manager and load all plugins that
@@ -714,6 +792,13 @@ bool DobbyRdkPluginManager::executeHookTimeout(const std::string &pluginName,
         // Create a new SID for the child process
         if (setsid() < 0)
             _exit(EXIT_FAILURE);
+
+#ifdef USE_SYSTEMD
+        // This worker is short-lived: it runs the hook and then _exit()s below.
+        // Route its logs through a journald stream fd so they aren't dropped by
+        // the journald PID-resolution race (see redirectLoggingToJournaldStream).
+        redirectLoggingToJournaldStream();
+#endif
 
         char result = static_cast<char>(executeHook(pluginName, hook));
          // Set result in shared memory

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
@@ -18,6 +18,11 @@
 */
 
 #include "OOMCrashPlugin.h"
+
+#include <map>
+
+#define FIREBOLT_STATE          "fireboltState"
+#define FIREBOLT_STATE_PREV     "fireboltState_prev"
 /**
  * Need to do this at the start of every plugin to make sure the correct
  * C methods are visible to allow PluginLauncher to find the plugin
@@ -70,11 +75,12 @@ bool OOMCrash::postInstallation()
         return false;
     }
 
-    const std::string path = mContainerConfig->rdk_plugins->oomcrash->data->path;
+    const char *pathPtr = mContainerConfig->rdk_plugins->oomcrash->data->path;
+    const std::string path = pathPtr ? pathPtr : "";
     if (path.empty())
     {
-        AI_LOG_ERROR("OOMCrash path is empty");
-        return false;
+        AI_LOG_INFO("OOMCrash path not configured, skipping mount setup for container '%s'", mUtils->getContainerId().c_str());
+        return true;
     }
 
     if (!mUtils->mkdirRecursive((mRootfsPath + path).c_str(), 0755) && errno != EEXIST)
@@ -112,23 +118,17 @@ bool OOMCrash::postHalt()
         return false;
     }
 
-    bool oomDetected = false;
-    if (mUtils->exitStatus != 0)
-        oomDetected = checkForOOM();
+    bool oomDetected = checkForOOM();
 
-    if (oomDetected)
+    const char *pathPtr = mContainerConfig->rdk_plugins->oomcrash->data->path;
+    const std::string path = pathPtr ? pathPtr : "";
+
+    if (oomDetected && !path.empty())
         createFileForOOM();
 
     // Remove the crashFile if container exits normally or if no OOM detected
-    if (mUtils->exitStatus == 0 || !oomDetected)
+    if (!path.empty() && (mUtils->exitStatus == 0 || !oomDetected))
     {
-        std::string path = mContainerConfig->rdk_plugins->oomcrash->data->path;
-        if (path.empty())
-        {
-            AI_LOG_ERROR("OOMCrash path is empty");
-            return false;
-        }
-
         std::string crashFile = path + "/oom_crashed_" + mUtils->getContainerId() + ".txt";
         if (remove(crashFile.c_str()) != 0)
         {
@@ -173,68 +173,200 @@ std::vector<std::string> OOMCrash::getDependencies() const
 }
 
 /**
- * @brief Read cgroup file.
+ * @brief Read the oom_kill counter from the cgroup memory.oom_control file.
  *
- *  @param[out]  val      gives the number of times that the cgroup limit was exceeded.
+ *  The memory.oom_control file contains multiple key-value lines, e.g.:
  *
- * @return true on successfully reading from the file.
+ *  Kernel >= 4.13:
+ *    oom_kill_disable 0
+ *    under_oom        0
+ *    oom_kill         1
+ *
+ *  Kernel < 4.13:
+ *    oom_kill_disable 0
+ *    under_oom        0
+ *
+ *  On older kernels the 'oom_kill' counter does not exist, so we fall back
+ *  to the 'under_oom' flag which is 1 while the cgroup is in OOM state.
+ *
+ *  @param[out]  val   Set to the value of the 'oom_kill' field (or 'under_oom'
+ *                     on older kernels) on success.
+ *
+ * @return true on successfully reading and parsing the field.
  */
 
 bool OOMCrash::readCgroup(unsigned long *val)
 {
-    std::string path = "/sys/fs/cgroup/memory/" + mUtils->getContainerId() + "/memory.failcnt";
+    std::string path = "/sys/fs/cgroup/memory/" + mUtils->getContainerId() + "/memory.oom_control";
 
     FILE *fp = fopen(path.c_str(), "r");
     if (!fp)
     {
-        if (errno != ENOENT)
-            AI_LOG_ERROR("failed to open '%s' (%d - %s)", path.c_str(), errno, strerror(errno));
-
+        AI_LOG_ERROR("failed to open '%s' (%d - %s)", path.c_str(), errno, strerror(errno));
         return false;
     }
 
     char* line = nullptr;
     size_t len = 0;
     ssize_t rd;
+    bool foundOomKill = false;
+    unsigned long underOom = 0;
+    bool foundUnderOom = false;
 
-    if ((rd = getline(&line, &len, fp)) < 0)
+    while ((rd = getline(&line, &len, fp)) > 0)
     {
-        if (line)
-            free(line);
-        fclose(fp);
-        AI_LOG_ERROR("failed to read cgroup file line (%d - %s)", errno, strerror(errno));
-        return false;
+        unsigned long v;
+        // sscanf won't match "oom_kill_disable" because the space in the
+        // format requires whitespace where "_disable" has an underscore.
+        if (sscanf(line, "oom_kill %lu", &v) == 1)
+        {
+            *val = v;
+            foundOomKill = true;
+            break;
+        }
+        if (sscanf(line, "under_oom %lu", &v) == 1)
+        {
+            underOom = v;
+            foundUnderOom = true;
+        }
     }
 
-    *val = strtoul(line, nullptr, 0);
-
+    if (line)
+        free(line);
     fclose(fp);
-    free(line);
 
-    return true;
+    // Prefer oom_kill (kernel >= 4.13); fall back to under_oom for older kernels
+    if (foundOomKill)
+        return true;
+
+    if (foundUnderOom)
+    {
+        AI_LOG_INFO("'oom_kill' field not present (kernel < 4.13), using 'under_oom' fallback");
+        *val = underOom;
+        return true;
+    }
+
+    AI_LOG_ERROR("neither 'oom_kill' nor 'under_oom' found in '%s'", path.c_str());
+    return false;
 }
 
 /**
- * @brief Check for Out of Memory by reading cgroup file.
+ * @brief Check if memory (or memory+swap) max usage reached the configured
+ *        limit, indicating the container hit its memory ceiling.
+ *
+ *  This is used as a fallback OOM indicator on older kernels (< 4.13) where
+ *  the oom_kill counter does not exist and under_oom is transient.
+ *  memory.max_usage_in_bytes is the high-water mark and persists until the
+ *  cgroup is destroyed.
+ *
+ * @return true if max usage >= limit for memory or memory+swap.
+ */
+bool OOMCrash::isMemoryAtLimit()
+{
+    std::string basePath = "/sys/fs/cgroup/memory/" + mUtils->getContainerId();
+
+    const char *pairs[][2] = {
+        { "/memory.max_usage_in_bytes",      "/memory.limit_in_bytes" },
+        { "/memory.memsw.max_usage_in_bytes", "/memory.memsw.limit_in_bytes" },
+    };
+
+    for (const auto &pair : pairs)
+    {
+        unsigned long maxUsage = 0, limit = 0;
+        std::string maxPath  = basePath + pair[0];
+        std::string limPath  = basePath + pair[1];
+
+        FILE *fpMax = fopen(maxPath.c_str(), "r");
+        FILE *fpLim = fopen(limPath.c_str(), "r");
+
+        bool ok = (fpMax && fpLim &&
+                   fscanf(fpMax, "%lu", &maxUsage) == 1 &&
+                   fscanf(fpLim, "%lu", &limit) == 1);
+
+        if (fpMax) fclose(fpMax);
+        if (fpLim) fclose(fpLim);
+
+        if (ok && limit > 0 && maxUsage >= limit)
+        {
+            AI_LOG_INFO("%s=%lu reached %s=%lu", pair[0]+1, maxUsage, pair[1]+1, limit);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Check for Out of Memory by reading cgroup files.
+ *
+ *  Detection priority:
+ *    1. oom_kill  > 0            (kernel >= 4.13, definitive)
+ *    2. under_oom > 0            (kernel <  4.13, transient flag)
+ *    3. max_usage_in_bytes >= limit  (all kernels, persistent high-water mark)
  *
  * @return true if OOM detected.
  */
 
 bool OOMCrash::checkForOOM()
 {
-    unsigned long failCnt;
-    bool status;
-    if (readCgroup(&failCnt) && (failCnt > 0))
+    unsigned long oomKill = 0;
+    bool cgroupRead = readCgroup(&oomKill);
+
+    // Priority 1 & 2: oom_kill or under_oom confirmed OOM
+    if (cgroupRead && oomKill > 0)
     {
-        AI_LOG_WARN("memory allocation failure detected in %s container, likely OOM (failcnt = %lu)", mUtils->getContainerId().c_str(), failCnt);
-        status = true; 
+        AI_LOG_INFO("oom_control reports OOM (value=%lu) for container '%s'",
+                    oomKill, mUtils->getContainerId().c_str());
+    }
+    // Priority 3: on kernel < 4.13 under_oom may have cleared — check max_usage
+    else if (isMemoryAtLimit())
+    {
+        AI_LOG_WARN("oom_control did not confirm OOM but max memory usage reached limit "
+                    "for container '%s'", mUtils->getContainerId().c_str());
     }
     else
     {
-        AI_LOG_WARN("No OOM failure detected in %s container", mUtils->getContainerId().c_str());
-        status = false;
+        AI_LOG_INFO("No OOM kill detected in container '%s'", mUtils->getContainerId().c_str());
+        return false;
     }
-    return status;
+
+    // OOM kill confirmed - retrieve firebolt state from annotations.
+    // AppService often transitions the app to "background" after the OOM kill
+    // but before postHalt runs.  Since the container exited abnormally, prefer
+    // the previous fireboltState value (which was the state at the time of the
+    // actual OOM kill) over the current value which may have been overwritten
+    // by a post-crash transition.
+    std::map<std::string, std::string> annotations = mUtils->getAnnotations();
+    std::string fireboltState;
+
+    auto prevIt = annotations.find(FIREBOLT_STATE_PREV);
+    if (prevIt != annotations.end())
+    {
+        fireboltState = prevIt->second;
+        AI_LOG_INFO("Using previous fireboltState '%s' (current may have been "
+                    "set after OOM kill)", fireboltState.c_str());
+    }
+    else
+    {
+        auto it = annotations.find(FIREBOLT_STATE);
+        if (it != annotations.end())
+        {
+            fireboltState = it->second;
+        }
+    }
+
+    if (!fireboltState.empty())
+    {
+        AI_LOG_WARN("OOM kill detected: container '%s' fireboltState '%s'",
+                    mUtils->getContainerId().c_str(), fireboltState.c_str());
+    }
+    else
+    {
+        AI_LOG_WARN("OOM kill detected: container '%s' (firebolt state unknown)",
+                    mUtils->getContainerId().c_str());
+    }
+
+    return true;
 }
 
 /**

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
@@ -20,7 +20,6 @@
 #include "OOMCrashPlugin.h"
 
 #include <map>
-#include <unistd.h>
 
 #define FIREBOLT_STATE          "fireboltState"
 #define FIREBOLT_STATE_PREV     "fireboltState_prev"
@@ -148,16 +147,6 @@ bool OOMCrash::postHalt()
     }
 
     AI_LOG_INFO("OOMCrash postHalt hook is running for container with hostname %s", mUtils->getContainerId().c_str());
-
-    // TEMPORARY DIAGNOSTIC: keep this forked child process alive briefly so
-    // journald has time to resolve /proc/<pid>/ and process the AI_LOG
-    // messages above before the child calls _exit(0).  If the AI_LOG lines
-    // now appear reliably in the journal (whereas without this sleep they
-    // were intermittently dropped), it proves the log loss is a journald
-    // PID-resolution race against the short-lived child, not a logging bug.
-    // REMOVE before merging.
-    usleep(200000); // 200 ms
-
     return true;
 }
 

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
@@ -175,32 +175,30 @@ std::vector<std::string> OOMCrash::getDependencies() const
 }
 
 /**
- * @brief Read cgroup file to detect OOM.
+ * @brief Read the cgroup OOM kill counter for the container.
  *
- *  On cgroups v1 reads memory.failcnt from
- *  /sys/fs/cgroup/memory/<id>/memory.failcnt.
+ *  cgroups v1: parses memory.oom_control from
+ *    /sys/fs/cgroup/memory/<id>/memory.oom_control
  *
- *  On cgroups v2 reads the oom_kill field from
- *  /sys/fs/cgroup/<id>/memory.events.
+ *    Kernel >= 4.13 exposes an 'oom_kill' field — a monotonic count of
+ *    processes killed by the OOM killer.  This is the preferred value.
  *
- *  The memory.oom_control file contains multiple key-value lines, e.g.:
+ *    Kernel < 4.13 does not have 'oom_kill'; 'under_oom' is 1 while the
+ *    cgroup is actively under OOM pressure (transient — may clear before
+ *    postHalt runs; isMemoryAtLimit() is then used as a final fallback).
  *
- *  Kernel >= 4.13:
- *    oom_kill_disable 0
- *    under_oom        0
- *    oom_kill         1
+ *    Note: memory.failcnt counts allocation failures, NOT OOM kills.
+ *    With swap available the kernel may swap rather than kill, and the
+ *    counter resets to 0 on cgroup recreation, making it unreliable.
  *
- *  Kernel < 4.13:
- *    oom_kill_disable 0
- *    under_oom        0
+ *  cgroups v2: reads the 'oom_kill' field from
+ *    /sys/fs/cgroup/<id>/memory.events — a monotonic count of OOM kills.
+ *    Falls back to the system.slice scope path if the direct path is absent.
  *
- *  On older kernels the 'oom_kill' counter does not exist, so we fall back
- *  to the 'under_oom' flag which is 1 while the cgroup is in OOM state.
+ *  @param[out]  val   Set to the oom_kill counter (v1 kernel >= 4.13 or v2),
+ *                     or the under_oom flag (v1 kernel < 4.13) on success.
  *
- *  @param[out]  val   Set to the value of the 'oom_kill' field (or 'under_oom'
- *                     on older kernels) on success.
- *
- * @return true on successfully reading and parsing the field.
+ * @return true on successfully reading and parsing the value.
  */
 
 bool OOMCrash::readCgroup(unsigned long *val)
@@ -221,7 +219,7 @@ bool OOMCrash::readCgroup(unsigned long *val)
     else
     {
         // On cgroups v1, use the legacy per-controller path
-        path = "/sys/fs/cgroup/memory/" + containerId + "/memory.failcnt";
+        path = "/sys/fs/cgroup/memory/" + containerId + "/memory.oom_control";
     }
 
     FILE *fp = fopen(path.c_str(), "r");
@@ -246,9 +244,6 @@ bool OOMCrash::readCgroup(unsigned long *val)
     char* line = nullptr;
     size_t len = 0;
     ssize_t rd;
-    bool foundOomKill = false;
-    unsigned long underOom = 0;
-    bool foundUnderOom = false;
 
     if (isCgroupV2)
     {
@@ -276,22 +271,42 @@ bool OOMCrash::readCgroup(unsigned long *val)
     }
     else
     {
-        // v1: single numeric value in memory.failcnt
-        if ((rd = getline(&line, &len, fp)) < 0)
+        // v1: parse key-value memory.oom_control.
+        // Prefer 'oom_kill' (kernel >= 4.13, monotonic); fall back to
+        // 'under_oom' (kernel < 4.13, transient — 1 while OOM is active).
+        unsigned long oomKill = 0, underOom = 0;
+        bool foundOomKill = false, foundUnderOom = false;
+
+        while ((rd = getline(&line, &len, fp)) > 0)
         {
-            if (line)
-                free(line);
-            fclose(fp);
-            AI_LOG_ERROR("failed to read cgroup file line (%d - %s)", errno, strerror(errno));
-            return false;
+            unsigned long v;
+            if (sscanf(line, "oom_kill %lu", &v) == 1)
+            {
+                oomKill = v;
+                foundOomKill = true;
+            }
+            else if (sscanf(line, "under_oom %lu", &v) == 1)
+            {
+                underOom = v;
+                foundUnderOom = true;
+            }
         }
-
-        *val = strtoul(line, nullptr, 0);
-
-        fclose(fp);
         free(line);
+        fclose(fp);
 
-        return true;
+        if (foundOomKill)
+        {
+            *val = oomKill;
+            return true;
+        }
+        if (foundUnderOom)
+        {
+            AI_LOG_INFO("'oom_kill' not present (kernel < 4.13), using 'under_oom' value");
+            *val = underOom;
+            return true;
+        }
+        AI_LOG_ERROR("neither 'oom_kill' nor 'under_oom' found in '%s'", path.c_str());
+        return false;
     }
 }
 

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
@@ -20,7 +20,7 @@
 #include "OOMCrashPlugin.h"
 
 #include <map>
-#include <syslog.h>
+#include <unistd.h>
 
 #define FIREBOLT_STATE          "fireboltState"
 #define FIREBOLT_STATE_PREV     "fireboltState_prev"
@@ -148,6 +148,16 @@ bool OOMCrash::postHalt()
     }
 
     AI_LOG_INFO("OOMCrash postHalt hook is running for container with hostname %s", mUtils->getContainerId().c_str());
+
+    // TEMPORARY DIAGNOSTIC: keep this forked child process alive briefly so
+    // journald has time to resolve /proc/<pid>/ and process the AI_LOG
+    // messages above before the child calls _exit(0).  If the AI_LOG lines
+    // now appear reliably in the journal (whereas without this sleep they
+    // were intermittently dropped), it proves the log loss is a journald
+    // PID-resolution race against the short-lived child, not a logging bug.
+    // REMOVE before merging.
+    usleep(200000); // 200 ms
+
     return true;
 }
 
@@ -167,9 +177,12 @@ std::vector<std::string> OOMCrash::getDependencies() const
     std::vector<std::string> dependencies;
     const rt_defs_plugins_oom_crash* pluginConfig = mContainerConfig->rdk_plugins->oomcrash;
 
-    for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+    if (pluginConfig && pluginConfig->depends_on)
     {
-        dependencies.push_back(pluginConfig->depends_on[i]);
+        for (size_t i = 0; i < pluginConfig->depends_on_len; i++)
+        {
+            dependencies.push_back(pluginConfig->depends_on[i]);
+        }
     }
 
     return dependencies;
@@ -394,19 +407,11 @@ bool OOMCrash::checkForOOM()
     unsigned long oomKill = 0;
     bool cgroupRead = readCgroup(&oomKill);
 
-    // Open syslog connection immediately (LOG_NDELAY) so the socket credentials
-    // are captured while this child PID still exists.  Unlike sd_journal_send()
-    // (used by AI_LOG), syslog() embeds the ident and PID in the message text
-    // itself, so journald can process the message even after the child exits.
-    openlog("DobbyDaemon", LOG_PID | LOG_NDELAY, LOG_DAEMON);
-
     if (cgroupRead && oomKill > 0)
     {
         // cgroup counter is authoritative — OOM kill confirmed
         AI_LOG_INFO("oom_control reports OOM (value=%lu) for container '%s'",
                     oomKill, mUtils->getContainerId().c_str());
-        syslog(LOG_WARNING, "OOMCrash: oom_control reports OOM (value=%lu) for container '%s'",
-               oomKill, mUtils->getContainerId().c_str());
     }
     else if (cgroupRead && isMemoryAtLimit())
     {
@@ -417,14 +422,11 @@ bool OOMCrash::checkForOOM()
         AI_LOG_WARN("oom_kill=0 but max memory usage reached limit for container '%s' "
                     "(soft OOM — killed by init due to memory pressure, not by kernel OOM killer)",
                     mUtils->getContainerId().c_str());
-        syslog(LOG_WARNING, "OOMCrash: soft OOM for container '%s' (oom_kill=0, memory at limit)",
-               mUtils->getContainerId().c_str());
     }
     else if (cgroupRead)
     {
         // cgroup read succeeded, counter is 0, and memory didn't hit limit
         AI_LOG_INFO("No OOM kill detected in container '%s'", mUtils->getContainerId().c_str());
-        closelog();
         return false;
     }
     else if (isMemoryAtLimit())
@@ -432,13 +434,10 @@ bool OOMCrash::checkForOOM()
         // cgroup file was unreadable — fall back to high-water-mark heuristic
         AI_LOG_WARN("cgroup unreadable; max memory usage reached limit for container '%s'",
                     mUtils->getContainerId().c_str());
-        syslog(LOG_WARNING, "OOMCrash: cgroup unreadable, memory at limit for container '%s'",
-               mUtils->getContainerId().c_str());
     }
     else
     {
         AI_LOG_INFO("No OOM kill detected in container '%s'", mUtils->getContainerId().c_str());
-        closelog();
         return false;
     }
 
@@ -476,18 +475,13 @@ bool OOMCrash::checkForOOM()
     {
         AI_LOG_WARN("OOM kill detected: container '%s' fireboltState '%s'",
                     mUtils->getContainerId().c_str(), fireboltState.c_str());
-        syslog(LOG_WARNING, "OOMCrash: container '%s' fireboltState '%s'",
-               mUtils->getContainerId().c_str(), fireboltState.c_str());
     }
     else
     {
         AI_LOG_WARN("OOM kill detected: container '%s' (firebolt state unknown)",
                     mUtils->getContainerId().c_str());
-        syslog(LOG_WARNING, "OOMCrash: container '%s' (firebolt state unknown)",
-               mUtils->getContainerId().c_str());
     }
 
-    closelog();
     return true;
 }
 

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
@@ -19,7 +19,10 @@
 
 #include "OOMCrashPlugin.h"
 
+#include <cstdarg>
+#include <fcntl.h>
 #include <map>
+#include <unistd.h>
 
 #define FIREBOLT_STATE          "fireboltState"
 #define FIREBOLT_STATE_PREV     "fireboltState_prev"
@@ -234,7 +237,11 @@ bool OOMCrash::readCgroup(unsigned long *val)
 
         if (!fp)
         {
-            if (errno != ENOENT)
+            if (errno == ENOENT)
+                AI_LOG_WARN("cgroup file '%s' not found — cgroup may have been "
+                            "destroyed before postHalt (race condition)",
+                            path.c_str());
+            else
                 AI_LOG_ERROR("failed to open '%s' (%d - %s)", path.c_str(), errno, strerror(errno));
 
             return false;
@@ -299,11 +306,19 @@ bool OOMCrash::readCgroup(unsigned long *val)
             *val = oomKill;
             return true;
         }
-        if (foundUnderOom)
+        if (foundUnderOom && underOom > 0)
         {
-            AI_LOG_INFO("'oom_kill' not present (kernel < 4.13), using 'under_oom' value");
+            AI_LOG_INFO("'oom_kill' not present (kernel < 4.13), 'under_oom' is active");
             *val = underOom;
             return true;
+        }
+        if (foundUnderOom)
+        {
+            // under_oom is 0 — OOM pressure may have cleared before postHalt.
+            // Return false so checkForOOM() falls through to isMemoryAtLimit().
+            AI_LOG_INFO("'oom_kill' not present (kernel < 4.13), 'under_oom' is 0 "
+                        "(transient flag may have cleared); deferring to memory limit check");
+            return false;
         }
         AI_LOG_ERROR("neither 'oom_kill' nor 'under_oom' found in '%s'", path.c_str());
         return false;
@@ -361,12 +376,17 @@ bool OOMCrash::isMemoryAtLimit()
  *
  *  Detection priority:
  *    1. oom_kill > 0   — from memory.oom_control (v1) or memory.events (v2).
- *                        Authoritative: if readCgroup() succeeds and returns 0,
- *                        the kernel confirms no OOM kill occurred and detection
- *                        stops here (isMemoryAtLimit() is NOT consulted).
- *    2. isMemoryAtLimit() — only reached when readCgroup() itself failed (cgroup
- *                        file unreadable).  Compares max usage against the
- *                        configured limit as a last-resort heuristic.
+ *                        Authoritative: kernel OOM kill confirmed.
+ *    2. oom_kill == 0 but isMemoryAtLimit() — "soft OOM".  When swap is
+ *                        available (memsw.limit > mem.limit), the kernel swaps
+ *                        rather than invoking the OOM killer.  DobbyInit detects
+ *                        allocation failures (failcnt) and kills the app with
+ *                        SIGTERM.  oom_kill stays 0 but max_usage hitting the
+ *                        limit confirms memory pressure caused the death.
+ *    3. oom_kill == 0 and memory not at limit — no OOM, normal termination.
+ *    4. readCgroup() failed + isMemoryAtLimit() — cgroup files unreadable
+ *                        (under_oom=0 on kernel < 4.13, or ENOENT race).
+ *                        Falls back to high-water-mark heuristic.
  *
  * @return true if OOM detected.
  */
@@ -376,15 +396,52 @@ bool OOMCrash::checkForOOM()
     unsigned long oomKill = 0;
     bool cgroupRead = readCgroup(&oomKill);
 
+    // Helper: append a log line to /tmp/oomcrash_<id>.log using direct file I/O.
+    // sd_journal_send() from the forked child is unreliable under memory pressure
+    // (and stderr routes through the same journald socket on systemd services).
+    // Direct file writes use page cache and are far more resilient.
+    const std::string logFile = "/tmp/oomcrash_" + mUtils->getContainerId() + ".log";
+    auto fileLog = [&logFile](const char *fmt, ...)
+    {
+        char buf[256];
+        va_list ap;
+        va_start(ap, fmt);
+        int n = vsnprintf(buf, sizeof(buf), fmt, ap);
+        va_end(ap);
+        if (n > 0)
+        {
+            int fd = open(logFile.c_str(), O_WRONLY | O_CREAT | O_APPEND, 0644);
+            if (fd >= 0)
+            {
+                (void)write(fd, buf, std::min(n, (int)sizeof(buf) - 1));
+                close(fd);
+            }
+        }
+    };
+
     if (cgroupRead && oomKill > 0)
     {
         // cgroup counter is authoritative — OOM kill confirmed
         AI_LOG_INFO("oom_control reports OOM (value=%lu) for container '%s'",
                     oomKill, mUtils->getContainerId().c_str());
+        fileLog("OOMCrash: oom_control reports OOM (value=%lu) for container '%s'\n",
+                oomKill, mUtils->getContainerId().c_str());
+    }
+    else if (cgroupRead && isMemoryAtLimit())
+    {
+        // oom_kill is 0 (kernel OOM killer didn't fire) but memory usage hit
+        // the limit.  This happens when swap is available: the kernel swaps
+        // rather than killing, failcnt increments, and DobbyInit terminates
+        // the app with SIGTERM.  Treat as a "soft OOM".
+        AI_LOG_WARN("oom_kill=0 but max memory usage reached limit for container '%s' "
+                    "(soft OOM — killed by init due to memory pressure, not by kernel OOM killer)",
+                    mUtils->getContainerId().c_str());
+        fileLog("OOMCrash: soft OOM for container '%s' (oom_kill=0, memory at limit)\n",
+                mUtils->getContainerId().c_str());
     }
     else if (cgroupRead)
     {
-        // cgroup read succeeded and counter is 0 — kernel says no OOM kill
+        // cgroup read succeeded, counter is 0, and memory didn't hit limit
         AI_LOG_INFO("No OOM kill detected in container '%s'", mUtils->getContainerId().c_str());
         return false;
     }
@@ -393,6 +450,8 @@ bool OOMCrash::checkForOOM()
         // cgroup file was unreadable — fall back to high-water-mark heuristic
         AI_LOG_WARN("cgroup unreadable; max memory usage reached limit for container '%s'",
                     mUtils->getContainerId().c_str());
+        fileLog("OOMCrash: cgroup unreadable, memory at limit for container '%s'\n",
+                mUtils->getContainerId().c_str());
     }
     else
     {
@@ -434,11 +493,15 @@ bool OOMCrash::checkForOOM()
     {
         AI_LOG_WARN("OOM kill detected: container '%s' fireboltState '%s'",
                     mUtils->getContainerId().c_str(), fireboltState.c_str());
+        fileLog("OOMCrash: container '%s' fireboltState '%s'\n",
+                mUtils->getContainerId().c_str(), fireboltState.c_str());
     }
     else
     {
         AI_LOG_WARN("OOM kill detected: container '%s' (firebolt state unknown)",
                     mUtils->getContainerId().c_str());
+        fileLog("OOMCrash: container '%s' (firebolt state unknown)\n",
+                mUtils->getContainerId().c_str());
     }
 
     return true;

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
@@ -19,10 +19,8 @@
 
 #include "OOMCrashPlugin.h"
 
-#include <cstdarg>
-#include <fcntl.h>
 #include <map>
-#include <unistd.h>
+#include <syslog.h>
 
 #define FIREBOLT_STATE          "fireboltState"
 #define FIREBOLT_STATE_PREV     "fireboltState_prev"
@@ -396,36 +394,19 @@ bool OOMCrash::checkForOOM()
     unsigned long oomKill = 0;
     bool cgroupRead = readCgroup(&oomKill);
 
-    // Helper: append a log line to /tmp/oomcrash_<id>.log using direct file I/O.
-    // sd_journal_send() from the forked child is unreliable under memory pressure
-    // (and stderr routes through the same journald socket on systemd services).
-    // Direct file writes use page cache and are far more resilient.
-    const std::string logFile = "/tmp/oomcrash_" + mUtils->getContainerId() + ".log";
-    auto fileLog = [&logFile](const char *fmt, ...)
-    {
-        char buf[256];
-        va_list ap;
-        va_start(ap, fmt);
-        int n = vsnprintf(buf, sizeof(buf), fmt, ap);
-        va_end(ap);
-        if (n > 0)
-        {
-            int fd = open(logFile.c_str(), O_WRONLY | O_CREAT | O_APPEND, 0644);
-            if (fd >= 0)
-            {
-                (void)write(fd, buf, std::min(n, (int)sizeof(buf) - 1));
-                close(fd);
-            }
-        }
-    };
+    // Open syslog connection immediately (LOG_NDELAY) so the socket credentials
+    // are captured while this child PID still exists.  Unlike sd_journal_send()
+    // (used by AI_LOG), syslog() embeds the ident and PID in the message text
+    // itself, so journald can process the message even after the child exits.
+    openlog("DobbyDaemon", LOG_PID | LOG_NDELAY, LOG_DAEMON);
 
     if (cgroupRead && oomKill > 0)
     {
         // cgroup counter is authoritative — OOM kill confirmed
         AI_LOG_INFO("oom_control reports OOM (value=%lu) for container '%s'",
                     oomKill, mUtils->getContainerId().c_str());
-        fileLog("OOMCrash: oom_control reports OOM (value=%lu) for container '%s'\n",
-                oomKill, mUtils->getContainerId().c_str());
+        syslog(LOG_WARNING, "OOMCrash: oom_control reports OOM (value=%lu) for container '%s'",
+               oomKill, mUtils->getContainerId().c_str());
     }
     else if (cgroupRead && isMemoryAtLimit())
     {
@@ -436,13 +417,14 @@ bool OOMCrash::checkForOOM()
         AI_LOG_WARN("oom_kill=0 but max memory usage reached limit for container '%s' "
                     "(soft OOM — killed by init due to memory pressure, not by kernel OOM killer)",
                     mUtils->getContainerId().c_str());
-        fileLog("OOMCrash: soft OOM for container '%s' (oom_kill=0, memory at limit)\n",
-                mUtils->getContainerId().c_str());
+        syslog(LOG_WARNING, "OOMCrash: soft OOM for container '%s' (oom_kill=0, memory at limit)",
+               mUtils->getContainerId().c_str());
     }
     else if (cgroupRead)
     {
         // cgroup read succeeded, counter is 0, and memory didn't hit limit
         AI_LOG_INFO("No OOM kill detected in container '%s'", mUtils->getContainerId().c_str());
+        closelog();
         return false;
     }
     else if (isMemoryAtLimit())
@@ -450,12 +432,13 @@ bool OOMCrash::checkForOOM()
         // cgroup file was unreadable — fall back to high-water-mark heuristic
         AI_LOG_WARN("cgroup unreadable; max memory usage reached limit for container '%s'",
                     mUtils->getContainerId().c_str());
-        fileLog("OOMCrash: cgroup unreadable, memory at limit for container '%s'\n",
-                mUtils->getContainerId().c_str());
+        syslog(LOG_WARNING, "OOMCrash: cgroup unreadable, memory at limit for container '%s'",
+               mUtils->getContainerId().c_str());
     }
     else
     {
         AI_LOG_INFO("No OOM kill detected in container '%s'", mUtils->getContainerId().c_str());
+        closelog();
         return false;
     }
 
@@ -493,17 +476,18 @@ bool OOMCrash::checkForOOM()
     {
         AI_LOG_WARN("OOM kill detected: container '%s' fireboltState '%s'",
                     mUtils->getContainerId().c_str(), fireboltState.c_str());
-        fileLog("OOMCrash: container '%s' fireboltState '%s'\n",
-                mUtils->getContainerId().c_str(), fireboltState.c_str());
+        syslog(LOG_WARNING, "OOMCrash: container '%s' fireboltState '%s'",
+               mUtils->getContainerId().c_str(), fireboltState.c_str());
     }
     else
     {
         AI_LOG_WARN("OOM kill detected: container '%s' (firebolt state unknown)",
                     mUtils->getContainerId().c_str());
-        fileLog("OOMCrash: container '%s' (firebolt state unknown)\n",
-                mUtils->getContainerId().c_str());
+        syslog(LOG_WARNING, "OOMCrash: container '%s' (firebolt state unknown)",
+               mUtils->getContainerId().c_str());
     }
 
+    closelog();
     return true;
 }
 

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
@@ -330,38 +330,83 @@ bool OOMCrash::readCgroup(unsigned long *val)
  *        limit, indicating the container hit its memory ceiling.
  *
  *  This is used as a fallback OOM indicator on older kernels (< 4.13) where
- *  the oom_kill counter does not exist and under_oom is transient.
- *  memory.max_usage_in_bytes is the high-water mark and persists until the
- *  cgroup is destroyed.
+ *  the oom_kill counter does not exist and under_oom is transient. The
+ *  high-water mark persists until the cgroup is destroyed.
+ *
+ *  cgroups v1: compares memory.max_usage_in_bytes against memory.limit_in_bytes
+ *    (and the memsw equivalents) under /sys/fs/cgroup/memory/<id>.
+ *
+ *  cgroups v2: compares memory.peak against memory.max (and the swap
+ *    equivalents) under /sys/fs/cgroup/<id>, falling back to the
+ *    system.slice scope path - mirroring readCgroup(). A limit file may
+ *    hold the literal "max" (unlimited); such pairs are skipped.
  *
  * @return true if max usage >= limit for memory or memory+swap.
  */
 bool OOMCrash::isMemoryAtLimit()
 {
-    std::string basePath = "/sys/fs/cgroup/memory/" + mUtils->getContainerId();
+    const std::string containerId = mUtils->getContainerId();
 
-    const char *pairs[][2] = {
-        { "/memory.max_usage_in_bytes",      "/memory.limit_in_bytes" },
-        { "/memory.memsw.max_usage_in_bytes", "/memory.memsw.limit_in_bytes" },
+    // Detect cgroups version by checking for the v2 unified hierarchy
+    struct stat st;
+    const bool isCgroupV2 = (stat("/sys/fs/cgroup/cgroup.controllers", &st) == 0);
+
+    // Reads a single value from a cgroup file. Returns false on open/parse
+    // failure or when the file holds the literal "max" (v2 unlimited).
+    auto readValue = [](const std::string &filePath, unsigned long *out) -> bool
+    {
+        FILE *fp = fopen(filePath.c_str(), "r");
+        if (!fp)
+            return false;
+
+        char token[64] = {0};
+        bool ok = (fscanf(fp, "%63s", token) == 1);
+        fclose(fp);
+
+        if (!ok || strcmp(token, "max") == 0)
+            return false;
+
+        char *end = nullptr;
+        unsigned long v = strtoul(token, &end, 10);
+        if (end == token || *end != '\0')
+            return false;
+
+        *out = v;
+        return true;
     };
+
+    std::string basePath;
+    const char *pairs[2][2];
+
+    if (isCgroupV2)
+    {
+        // Resolve the container's cgroup dir in the unified hierarchy, matching
+        // readCgroup()'s direct + system.slice scope fallback.
+        basePath = "/sys/fs/cgroup/" + containerId;
+        if (stat((basePath + "/memory.max").c_str(), &st) != 0)
+        {
+            basePath = "/sys/fs/cgroup/system.slice/dobby-" + containerId + ".scope";
+        }
+
+        // memory.peak      (kernel >= 5.19) vs memory.max
+        // memory.swap.peak (kernel >= 6.5)  vs memory.swap.max
+        pairs[0][0] = "/memory.peak";       pairs[0][1] = "/memory.max";
+        pairs[1][0] = "/memory.swap.peak";  pairs[1][1] = "/memory.swap.max";
+    }
+    else
+    {
+        basePath = "/sys/fs/cgroup/memory/" + containerId;
+
+        pairs[0][0] = "/memory.max_usage_in_bytes";        pairs[0][1] = "/memory.limit_in_bytes";
+        pairs[1][0] = "/memory.memsw.max_usage_in_bytes";  pairs[1][1] = "/memory.memsw.limit_in_bytes";
+    }
 
     for (const auto &pair : pairs)
     {
         unsigned long maxUsage = 0, limit = 0;
-        std::string maxPath  = basePath + pair[0];
-        std::string limPath  = basePath + pair[1];
-
-        FILE *fpMax = fopen(maxPath.c_str(), "r");
-        FILE *fpLim = fopen(limPath.c_str(), "r");
-
-        bool ok = (fpMax && fpLim &&
-                   fscanf(fpMax, "%lu", &maxUsage) == 1 &&
-                   fscanf(fpLim, "%lu", &limit) == 1);
-
-        if (fpMax) fclose(fpMax);
-        if (fpLim) fclose(fpLim);
-
-        if (ok && limit > 0 && maxUsage >= limit)
+        if (readValue(basePath + pair[0], &maxUsage) &&
+            readValue(basePath + pair[1], &limit) &&
+            limit > 0 && maxUsage >= limit)
         {
             AI_LOG_INFO("%s=%lu reached %s=%lu", pair[0]+1, maxUsage, pair[1]+1, limit);
             return true;
@@ -393,14 +438,17 @@ bool OOMCrash::isMemoryAtLimit()
 
 bool OOMCrash::checkForOOM()
 {
-    unsigned long oomKill = 0;
-    bool cgroupRead = readCgroup(&oomKill);
+    unsigned long oomIndicator = 0;
+    bool cgroupRead = readCgroup(&oomIndicator);
 
-    if (cgroupRead && oomKill > 0)
+    if (cgroupRead && oomIndicator > 0)
     {
-        // cgroup counter is authoritative — OOM kill confirmed
-        AI_LOG_INFO("oom_control reports OOM (value=%lu) for container '%s'",
-                    oomKill, mUtils->getContainerId().c_str());
+        // cgroup OOM indicator is authoritative — OOM confirmed. The exact
+        // source depends on the hierarchy/kernel (memory.oom_control oom_kill
+        // or under_oom on v1, memory.events oom_kill on v2), so keep the
+        // wording generic.
+        AI_LOG_INFO("cgroup OOM indicator set (value=%lu) for container '%s'",
+                    oomIndicator, mUtils->getContainerId().c_str());
     }
     else if (cgroupRead && isMemoryAtLimit())
     {

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
@@ -118,7 +118,9 @@ bool OOMCrash::postHalt()
         return false;
     }
 
-    bool oomDetected = checkForOOM();
+    bool oomDetected = false;
+    if (mUtils->exitStatus != 0)
+        oomDetected = checkForOOM();
 
     const char *pathPtr = mContainerConfig->rdk_plugins->oomcrash->data->path;
     const std::string path = pathPtr ? pathPtr : "";
@@ -343,9 +345,13 @@ bool OOMCrash::isMemoryAtLimit()
  * @brief Check for Out of Memory by reading cgroup files.
  *
  *  Detection priority:
- *    1. oom_kill  > 0            (kernel >= 4.13, definitive)
- *    2. under_oom > 0            (kernel <  4.13, transient flag)
- *    3. max_usage_in_bytes >= limit  (all kernels, persistent high-water mark)
+ *    1. oom_kill > 0   — from memory.oom_control (v1) or memory.events (v2).
+ *                        Authoritative: if readCgroup() succeeds and returns 0,
+ *                        the kernel confirms no OOM kill occurred and detection
+ *                        stops here (isMemoryAtLimit() is NOT consulted).
+ *    2. isMemoryAtLimit() — only reached when readCgroup() itself failed (cgroup
+ *                        file unreadable).  Compares max usage against the
+ *                        configured limit as a last-resort heuristic.
  *
  * @return true if OOM detected.
  */
@@ -355,17 +361,23 @@ bool OOMCrash::checkForOOM()
     unsigned long oomKill = 0;
     bool cgroupRead = readCgroup(&oomKill);
 
-    // Priority 1 & 2: oom_kill or under_oom confirmed OOM
     if (cgroupRead && oomKill > 0)
     {
+        // cgroup counter is authoritative — OOM kill confirmed
         AI_LOG_INFO("oom_control reports OOM (value=%lu) for container '%s'",
                     oomKill, mUtils->getContainerId().c_str());
     }
-    // Priority 3: on kernel < 4.13 under_oom may have cleared — check max_usage
+    else if (cgroupRead)
+    {
+        // cgroup read succeeded and counter is 0 — kernel says no OOM kill
+        AI_LOG_INFO("No OOM kill detected in container '%s'", mUtils->getContainerId().c_str());
+        return false;
+    }
     else if (isMemoryAtLimit())
     {
-        AI_LOG_WARN("oom_control did not confirm OOM but max memory usage reached limit "
-                    "for container '%s'", mUtils->getContainerId().c_str());
+        // cgroup file was unreadable — fall back to high-water-mark heuristic
+        AI_LOG_WARN("cgroup unreadable; max memory usage reached limit for container '%s'",
+                    mUtils->getContainerId().c_str());
     }
     else
     {
@@ -374,11 +386,12 @@ bool OOMCrash::checkForOOM()
     }
 
     // OOM kill confirmed - retrieve firebolt state from annotations.
-    // AppService often transitions the app to "background" after the OOM kill
-    // but before postHalt runs.  Since the container exited abnormally, prefer
-    // the previous fireboltState value (which was the state at the time of the
-    // actual OOM kill) over the current value which may have been overwritten
-    // by a post-crash transition.
+    // Both the previous (fireboltState_prev) and current (fireboltState) values
+    // are read.  AppService often transitions the app (e.g. to "background")
+    // after the OOM kill but before postHalt runs, so the current value may
+    // reflect a post-crash transition rather than the state at the time of the
+    // kill.  fireboltState_prev is therefore preferred for the final log; both
+    // are reported so the transition can be observed in the logs.
     std::map<std::string, std::string> annotations = mUtils->getAnnotations();
     std::string fireboltState;
 
@@ -386,8 +399,12 @@ bool OOMCrash::checkForOOM()
     if (prevIt != annotations.end())
     {
         fireboltState = prevIt->second;
-        AI_LOG_INFO("Using previous fireboltState '%s' (current may have been "
-                    "set after OOM kill)", fireboltState.c_str());
+        std::string currentState;
+        auto curIt = annotations.find(FIREBOLT_STATE);
+        if (curIt != annotations.end())
+            currentState = curIt->second;
+        AI_LOG_INFO("Using previous fireboltState '%s' (current '%s' may have been "
+                    "set after OOM kill)", fireboltState.c_str(), currentState.c_str());
     }
     else
     {

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.h
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.h
@@ -57,6 +57,7 @@ public:
 
 private:
     bool readCgroup(unsigned long *val);
+    bool isMemoryAtLimit();
     bool checkForOOM();
     void createFileForOOM();
     

--- a/tests/L2_testing/test_runner/bundle_generation.py
+++ b/tests/L2_testing/test_runner/bundle_generation.py
@@ -85,8 +85,10 @@ def _normalise_config(config):
             mount["options"] = [opt for opt in mount["options"] if not str(opt).startswith("size=")]
 
     # Networking plugin can be auto-disabled depending on environment
+    # OOMCrash plugin is auto-injected by DobbySpecConfig when not present
     if isinstance(cfg.get("rdkPlugins"), dict):
         cfg["rdkPlugins"].pop("networking", None)
+        cfg["rdkPlugins"].pop("oomcrash", None)
 
     return cfg
 


### PR DESCRIPTION
### Description

- OOMCrash plugin is now automatically enabled in DobbySpecConfig for every container, even if not explicitly configured in the app spec. 
- The path field in the plugin schema is no longer required. When omitted, the plugin still detects and logs OOM events but skips crash-file creation.
- Replaced the memory.failcnt-based check with a multi-tier detection strategy using memory.oom_control:
    1. oom_kill > 0 — definitive OOM kill counter (kernel >= 4.13)
    2. under_oom > 0 — transient OOM flag fallback (kernel < 4.13)
    3. max_usage_in_bytes >= limit_in_bytes — persistent high-water-mark fallback (all kernels, catches cases where under_oom has already cleared)

### Test Procedure

- Verify on kernel >= 4.13 (oom_kill counter present)
- Verify on kernel < 4.13 (falls back to under_oom / max_usage)
- Containers with no oomcrash config in their spec still get OOM detection and logging

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)