### PR TITLE
RDKEMW-16534: Set memory+swap to be unlimited if swap limit is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The table below lists the supported top-level fields. Fields marked **mandatory*
 | `args` | array | Yes | Command and arguments to run inside the container. |
 | `user` | object | Yes | `uid` and `gid` the container process runs as. |
 | `memLimit` | integer | Yes | Memory limit in bytes (`memory.limit_in_bytes`). Values below 256 KiB are accepted but will only generate a warning and may not be effective. |
-| `swapLimit` | integer | No | Swap+memory limit in bytes (`memory.memsw.limit_in_bytes`). Must be ≥ `memLimit`. Defaults to `memLimit` (no extra swap). |
+| `swapLimit` | integer | No | Swap+memory limit in bytes (`memory.memsw.limit_in_bytes`). Must be ≥ `memLimit`. Defaults to unlimited (-1) when absent. |
 | `env` | array | No | Environment variables in `"KEY=VALUE"` format. |
 | `cwd` | string | No | Working directory inside the container. |
 | `console` | object | No | Console log settings: `path` and `limit` (bytes). |
@@ -168,7 +168,7 @@ The table below lists the supported top-level fields. Fields marked **mandatory*
 }
 ```
 
-`swapLimit` sets the combined memory+swap ceiling enforced by the kernel cgroup (`memory.memsw.limit_in_bytes`). When omitted, swap is capped at the same value as `memLimit`, effectively disabling extra swap for the container.
+`swapLimit` sets the combined memory+swap ceiling enforced by the kernel cgroup (`memory.memsw.limit_in_bytes`). When omitted, memory+swap is unlimited (-1), allowing the container to use as much swap as the system provides.
 
 ## DobbyTool
 This is a simple command line tool that is used for debugging purporses. It connects to the Dobby daemon over dbus and allows for debugging and testing containers.

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -634,12 +634,8 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
 
     if (!(flags & JSON_FLAG_SWAPLIMIT))
     {
-        // swapLimit not supplied: default swap to memLimit (no extra swap)
-        const Json::Value& memLimitVal = mSpec["memLimit"];
-        if (memLimitVal.isIntegral())
-        {
-            dictionary->SetIntValue(MEM_SWAP, memLimitVal.asUInt());
-        }
+        // swapLimit not supplied: leave memory+swap unlimited (-1)
+        dictionary->SetIntValue(MEM_SWAP, -1);
     }
 
     if (!(flags & JSON_FLAG_CAPABILITIES))
@@ -1300,8 +1296,7 @@ bool DobbySpecConfig::processMemLimit(const Json::Value& value,
  *
  *  When present, this value is used as the cgroup memory.memsw.limit_in_bytes,
  *  allowing swap to be configured independently of the memory limit.  When
- *  absent the swap limit defaults to the same value as memLimit (i.e. no
- *  extra swap beyond the memory limit).
+ *  absent the swap limit is set to -1 (unlimited).
  *
  *  The kernel requires swap >= memLimit, so an error is returned if the
  *  supplied value is smaller than the memLimit already set.

--- a/tests/L1_testing/tests/DobbySpecConfigTest/DobbySpecConfigTest.cpp
+++ b/tests/L1_testing/tests/DobbySpecConfigTest/DobbySpecConfigTest.cpp
@@ -175,14 +175,13 @@ protected:
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 /**
- * When 'swapLimit' is absent, MEM_SWAP must default to the same value as
- * MEM_LIMIT (no extra swap beyond the memory limit).
+ * When 'swapLimit' is absent, MEM_SWAP must default to -1 (unlimited).
  */
-TEST_F(DobbySpecConfigTest, SwapLimit_DefaultsToMemLimit)
+TEST_F(DobbySpecConfigTest, SwapLimit_DefaultsToUnlimited)
 {
     auto cfg = makeConfig(kSpecMemOnly);
     EXPECT_TRUE(cfg->isValid());
-    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=2998272 SWAP=2998272");
+    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=2998272 SWAP=-1");
 }
 
 /**

--- a/tests/L2_testing/test_runner/swap_limit_tests.py
+++ b/tests/L2_testing/test_runner/swap_limit_tests.py
@@ -17,13 +17,17 @@
 
 import test_utils
 
+# Use "unlimited" as a sentinel to indicate the swap cgroup value should be
+# much larger than memLimit (kernel reports its page-aligned max when unset).
+UNLIMITED = "unlimited"
+
 tests = [
     test_utils.Test(
         "Swap limit default",
-        "swap_limit_default",
-        str(2998272),
+        "ram",
+        UNLIMITED,
         "Starts a container with only memLimit set and verifies that "
-        "memory.memsw.limit_in_bytes equals memLimit (no extra swap)"),
+        "memory.memsw.limit_in_bytes is unlimited (much larger than memLimit)"),
     test_utils.Test(
         "Swap limit override",
         "swap_limit",
@@ -79,9 +83,13 @@ def validate_swap_limit(container_id, expected_swap):
     is treated as a skip rather than a failure so CI does not break on
     platforms where 'swapaccount=1' has not been set on the kernel cmdline.
 
+    If expected_swap is the UNLIMITED sentinel, the test passes when the
+    reported value is significantly larger than any reasonable memLimit
+    (indicating the kernel has no swap ceiling set).
+
     Parameters:
         container_id (str): container whose log to inspect
-        expected_swap (str): expected value as a decimal string
+        expected_swap (str): expected value as a decimal string, or UNLIMITED
 
     Returns:
         (bool, str): (passed, message)
@@ -96,6 +104,20 @@ def validate_swap_limit(container_id, expected_swap):
         return True, "Skipped – swap accounting not available on this platform"
 
     actual = log.strip()
+
+    if expected_swap == UNLIMITED:
+        # When swap is unlimited the kernel reports a very large page-aligned
+        # value (e.g. 9223372036854771712 on 64-bit).  We consider any value
+        # above 1 TiB (1099511627776) as effectively unlimited.
+        try:
+            actual_val = int(actual)
+        except ValueError:
+            return False, "Could not parse swap value '%s' as integer" % actual
+        if actual_val > 1099511627776:
+            return True, "Test passed (swap unlimited: %s)" % actual
+        return (False,
+                "Swap limit for '%s' should be unlimited but got %s"
+                % (container_id, actual))
 
     if actual == expected_swap:
         return True, "Test passed"

--- a/tests/L2_testing/test_runner/swap_limit_tests.py
+++ b/tests/L2_testing/test_runner/swap_limit_tests.py
@@ -24,7 +24,7 @@ UNLIMITED = "unlimited"
 tests = [
     test_utils.Test(
         "Swap limit default",
-        "ram",
+        "swap_limit_default",
         UNLIMITED,
         "Starts a container with only memLimit set and verifies that "
         "memory.memsw.limit_in_bytes is unlimited (much larger than memLimit)"),


### PR DESCRIPTION
### Description
If swap limit is not set explicitly, set memory+swap to be unlimited by default

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)