### PR TITLE
RDKEMW-17605: Fix invalid JSON in OCI config when capabilities are specified on RDK builds

### DIFF
--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -2627,12 +2627,10 @@ bool DobbySpecConfig::processCapabilities(const Json::Value& value,
                                            EXTRA_CAPS_SECTION);
     }
 
-#if !defined(RDK)
     // allow the containered apps to inherit any file base capabilities, this
     // is needed if wanting to execute programs that have the file capabilities
     // that match the capabilities we've given the container
     dictionary->SetValue(NO_NEW_PRIVS, "false");
-#endif // !defined(RDK)
 
     return true;
 }

--- a/openspec/specs/bundle-configuration.md
+++ b/openspec/specs/bundle-configuration.md
@@ -87,6 +87,7 @@ _Not applicable — bundle creation is a one-time setup operation per container 
 ## Security
 - Config recovery mechanism prevents container launch with corrupted configurations.
 - UID/GID mapping support enables user namespace isolation.
+- `noNewPrivileges` is always set in the generated OCI config.json: `true` when no capabilities are requested, `false` when capabilities are present (required for file-based capability inheritance through execve on all platforms).
 
 ## Versioning & Compatibility
 - OCI version `1.0.2` for standard bundles, `1.0.2-dobby` for extended bundles.

--- a/tests/L1_testing/tests/DobbySpecConfigTest/DobbySpecConfigTest.cpp
+++ b/tests/L1_testing/tests/DobbySpecConfigTest/DobbySpecConfigTest.cpp
@@ -80,9 +80,23 @@ static const char* kSpecSwapBelowLimit = R"({
     "swapLimit": 2998272
 })";
 
+// ── Spec with capabilities ────────────────────────────────────────────────────
+
+static const char* kSpecWithCapabilities = R"({
+    "version": "1.0",
+    "args": ["/bin/true"],
+    "user": { "uid": 1000, "gid": 1000 },
+    "memLimit": 2998272,
+    "capabilities": ["CAP_NET_RAW"]
+})";
+
 // ── Inline ctemplate for reading MEM_LIMIT / MEM_SWAP back from the dict ─────
 static const char* kMemTemplateName = "test_swap_memory";
 static const char* kMemTemplateStr  = "LIMIT={{MEM_LIMIT}} SWAP={{MEM_SWAP}}";
+
+// ── Inline ctemplate for reading NO_NEW_PRIVS back from the dict ─────────────
+static const char* kPrivsTemplateName = "test_no_new_privs";
+static const char* kPrivsTemplateStr  = "NO_NEW_PRIVS={{NO_NEW_PRIVS}}";
 
 // ── Fixture ───────────────────────────────────────────────────────────────────
 
@@ -138,6 +152,12 @@ protected:
             kMemTemplateName,
             kMemTemplateStr,
             ctemplate::DO_NOT_STRIP);
+
+        // Register template for reading NO_NEW_PRIVS.
+        ctemplate::StringToTemplateCache(
+            kPrivsTemplateName,
+            kPrivsTemplateStr,
+            ctemplate::DO_NOT_STRIP);
     }
 
     void TearDown() override
@@ -165,6 +185,19 @@ protected:
         std::string out;
         ctemplate::ExpandTemplate(
             kMemTemplateName,
+            ctemplate::DO_NOT_STRIP,
+            cfg.mDictionary,
+            &out);
+        return out;
+    }
+
+    // Expand the NO_NEW_PRIVS template against the config's dictionary.
+    // Returns e.g. "NO_NEW_PRIVS=true" or "NO_NEW_PRIVS=false".
+    std::string expandPrivsTemplate(DobbySpecConfig& cfg)
+    {
+        std::string out;
+        ctemplate::ExpandTemplate(
+            kPrivsTemplateName,
             ctemplate::DO_NOT_STRIP,
             cfg.mDictionary,
             &out);
@@ -227,4 +260,29 @@ TEST_F(DobbySpecConfigTest, SwapLimit_NonIntegral_Fails)
     ctemplate::TemplateDictionary dict("test_nonint");
     Json::Value badSwap("not-a-number");
     EXPECT_FALSE(cfg->processSwapLimit(badSwap, &dict));
+}
+
+// ── noNewPrivileges tests ─────────────────────────────────────────────────────
+
+/**
+ * When 'capabilities' are specified in the spec, NO_NEW_PRIVS must be set to
+ * "false" so that file-based capability inheritance works through execve.
+ * This was previously broken on RDK builds (RDKEMW-17605).
+ */
+TEST_F(DobbySpecConfigTest, Capabilities_SetsNoNewPrivsFalse)
+{
+    auto cfg = makeConfig(kSpecWithCapabilities);
+    EXPECT_TRUE(cfg->isValid());
+    EXPECT_EQ(expandPrivsTemplate(*cfg), "NO_NEW_PRIVS=false");
+}
+
+/**
+ * When no 'capabilities' field is present, NO_NEW_PRIVS must default to "true"
+ * (the secure default — disallow privilege escalation).
+ */
+TEST_F(DobbySpecConfigTest, NoCapabilities_SetsNoNewPrivsTrue)
+{
+    auto cfg = makeConfig(kSpecMemOnly);
+    EXPECT_TRUE(cfg->isValid());
+    EXPECT_EQ(expandPrivsTemplate(*cfg), "NO_NEW_PRIVS=true");
 }


### PR DESCRIPTION
### Description
Removed the #if !defined(RDK) / #endif guards so that noNewPrivileges is unconditionally set to "false" when capabilities are present, regardless of platform. This ensures:
- The generated OCI config.json is always valid JSON on all platforms.
- File-based capability inheritance through execve works correctly — containers can execute binaries that have file capabilities matching the granted container capabilities.

### Test Procedure

- Verify containers with capabilities produce valid [config.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on RDK builds.
- Verify noNewPrivileges is false when capabilities are specified, true otherwise.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)