### PR TITLE
RDKEMW-14901: Add support for cgroup v2

### DIFF
--- a/.github/workflows/L2-tests.yml
+++ b/.github/workflows/L2-tests.yml
@@ -116,19 +116,6 @@ jobs:
          </policy>
          </busconfig>' > "/etc/dbus-1/system.d/org.rdk.dobby.conf"
 
-      - name: Patch OCI templates for cgroupv2 compatibility
-        working-directory: Dobby/bundle/lib/source/templates/
-        run: |
-            # Check if running on cgroupv2
-            if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
-                echo "Detected cgroupv2 - removing swappiness from OCI templates"
-                # Remove the trailing comma from swap line and delete swappiness line
-                sed -i '/"swap": {{MEM_SWAP}},/{s/,//}; /"swappiness": 60/d' OciConfigJson1.0.2-dobby.template
-                sed -i '/"swap": {{MEM_SWAP}},/{s/,//}; /"swappiness": 60/d' OciConfigJsonVM1.0.2-dobby.template
-            else
-                echo "Detected cgroupv1 - keeping swappiness in OCI templates"
-            fi
-
       - name: build Dobby
         run: |
           sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -65,6 +65,8 @@ static const ctemplate::StaticTemplateString MEM_LIMIT =
     STS_INIT(MEM_LIMIT, "MEM_LIMIT");
 static const ctemplate::StaticTemplateString MEM_SWAP =
     STS_INIT(MEM_SWAP, "MEM_SWAP");
+static const ctemplate::StaticTemplateString SWAPPINESS_ENABLED =
+    STS_INIT(SWAPPINESS_ENABLED, "SWAPPINESS_ENABLED");
 
 static const ctemplate::StaticTemplateString CPU_SHARES_ENABLED =
     STS_INIT(CPU_SHARES_ENABLED, "CPU_SHARES_ENABLED");
@@ -636,6 +638,15 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
     {
         // swapLimit not supplied: leave memory+swap unlimited (-1)
         dictionary->SetIntValue(MEM_SWAP, -1);
+    }
+
+    // swappiness is not supported on cgroups v2, only show if on v1
+    {
+        struct stat st;
+        if (stat("/sys/fs/cgroup/cgroup.controllers", &st) != 0)
+        {
+            dictionary->ShowSection(SWAPPINESS_ENABLED);
+        }
     }
 
     if (!(flags & JSON_FLAG_CAPABILITIES))

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -643,7 +643,7 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
     // swappiness is not supported on cgroups v2, only show if on v1
     {
         struct stat st;
-        if (stat("/sys/fs/cgroup/cgroup.controllers", &st) != 0)
+        if (stat("/sys/fs/cgroup/cgroup.controllers", &st) != 0 && errno == ENOENT)
         {
             dictionary->ShowSection(SWAPPINESS_ENABLED);
         }

--- a/bundle/lib/source/DobbyTemplate.cpp
+++ b/bundle/lib/source/DobbyTemplate.cpp
@@ -474,11 +474,11 @@ void DobbyTemplate::setTemplateCpuRtSched()
         if (!mnt->mnt_type || !mnt->mnt_dir || !mnt->mnt_opts)
             continue;
 
-        // On cgroups v2, check for cpu.max under the unified mount
+        // On cgroups v2, the unified hierarchy doesn't expose per-group
+        // rt_runtime_us; RT scheduling is handled differently.
+        // Leave values as 0 → null in template.
         if (strcmp(mnt->mnt_type, "cgroup2") == 0)
         {
-            // v2 doesn't expose per-group rt_runtime_us; RT scheduling is
-            // handled differently. Leave values as 0 → null in template.
             break;
         }
 

--- a/bundle/lib/source/DobbyTemplate.cpp
+++ b/bundle/lib/source/DobbyTemplate.cpp
@@ -474,7 +474,15 @@ void DobbyTemplate::setTemplateCpuRtSched()
         if (!mnt->mnt_type || !mnt->mnt_dir || !mnt->mnt_opts)
             continue;
 
-        // skip non-cgroup mounts
+        // On cgroups v2, check for cpu.max under the unified mount
+        if (strcmp(mnt->mnt_type, "cgroup2") == 0)
+        {
+            // v2 doesn't expose per-group rt_runtime_us; RT scheduling is
+            // handled differently. Leave values as 0 → null in template.
+            break;
+        }
+
+        // skip non-cgroup mounts (v1 path)
         if (strcmp(mnt->mnt_type, "cgroup") != 0)
             continue;
 

--- a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
@@ -328,8 +328,8 @@ static const char* ociJsonTemplate = R"JSON(
             ],
             "memory": {
                 "limit": {{MEM_LIMIT}},
-                "swap": {{MEM_SWAP}},
-                "swappiness": 60
+                "swap": {{MEM_SWAP}}{{#SWAPPINESS_ENABLED}},
+                "swappiness": 60{{/SWAPPINESS_ENABLED}}
             },
             "cpu": {
                 {{#CPU_SHARES_ENABLED}}

--- a/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
+++ b/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
@@ -339,8 +339,8 @@ static const char* ociJsonTemplate = R"JSON(
             ],
             "memory": {
                 "limit": {{MEM_LIMIT}},
-                "swap": {{MEM_SWAP}},
-                "swappiness": 60
+                "swap": {{MEM_SWAP}}{{#SWAPPINESS_ENABLED}},
+                "swappiness": 60{{/SWAPPINESS_ENABLED}}
             },
             "cpu": {
                 {{#CPU_SHARES_ENABLED}}

--- a/daemon/init/source/InitMain.cpp
+++ b/daemon/init/source/InitMain.cpp
@@ -179,6 +179,12 @@ static void closeAllFileDescriptors(int logPipeFd)
 
 #if (AI_BUILD_TYPE == AI_DEBUG)
 
+static bool isCgroupV2()
+{
+    struct stat st;
+    return (stat("/sys/fs/cgroup/cgroup.controllers", &st) == 0);
+}
+
 static bool readCgroup(const std::string &cgroup, unsigned long *val)
 {
     static const std::string base = "/sys/fs/cgroup/";
@@ -214,18 +220,64 @@ static bool readCgroup(const std::string &cgroup, unsigned long *val)
     return true;
 }
 
+static bool readCgroupKeyValue(const std::string &path, const std::string &key, unsigned long *val)
+{
+    FILE *fp = fopen(path.c_str(), "r");
+    if (!fp)
+    {
+        if (errno != ENOENT)
+            LOG_ERR("failed to open '%s' (%d - %s)", path.c_str(), errno, strerror(errno));
+        return false;
+    }
+
+    char* line = nullptr;
+    size_t len = 0;
+    bool found = false;
+
+    while (getline(&line, &len, fp) >= 0)
+    {
+        unsigned long v = 0;
+        char keyBuf[64] = {};
+        if (sscanf(line, "%63s %lu", keyBuf, &v) == 2)
+        {
+            if (key == keyBuf)
+            {
+                *val = v;
+                found = true;
+                break;
+            }
+        }
+    }
+
+    free(line);
+    fclose(fp);
+    return found;
+}
+
 static void checkForOOM(void)
 {
     unsigned long failCnt;
 
-    if (readCgroup("memory/memory.failcnt", &failCnt) && (failCnt > 0))
+    if (isCgroupV2())
     {
-        LOG_ERR("memory allocation failure detected in container, likely OOM (failcnt = %lu)", failCnt);
+        // On cgroups v2, check memory.events for oom_kill count
+        if (readCgroupKeyValue("/sys/fs/cgroup/memory.events", "oom_kill", &failCnt) && (failCnt > 0))
+        {
+            LOG_ERR("memory allocation failure detected in container, likely OOM (oom_kill = %lu)", failCnt);
+        }
     }
-
-    if (readCgroup("gpu/gpu.failcnt", &failCnt) && (failCnt > 0))
+    else
     {
-        LOG_NFO("GPU memory allocation failure detected in container (failcnt = %lu)", failCnt);
+        // On cgroups v1
+        if (readCgroup("memory/memory.failcnt", &failCnt) && (failCnt > 0))
+        {
+            LOG_ERR("memory allocation failure detected in container, likely OOM (failcnt = %lu)", failCnt);
+        }
+
+        if (readCgroup("gpu/gpu.failcnt", &failCnt) && (failCnt > 0))
+        {
+            LOG_NFO("GPU memory allocation failure detected in container (failcnt = %lu)", failCnt);
+        }
     }
 }
 

--- a/daemon/lib/source/DobbyEnv.cpp
+++ b/daemon/lib/source/DobbyEnv.cpp
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <mntent.h>
 #include <limits.h>
+#include <sys/stat.h>
 
 
 
@@ -37,7 +38,8 @@ DobbyEnv::DobbyEnv(const std::shared_ptr<const IDobbySettings>& settings)
     : mWorkspacePath(settings->workspaceDir())
     , mFlashMountPath(settings->persistentDir())
     , mPluginsWorkspacePath(mWorkspacePath + "/dobby/plugins")
-    , mCgroupMountPaths(getCgroupMountPoints())
+    , mCgroupVersion(detectCgroupVersion())
+    , mCgroupMountPaths(getCgroupMountPoints(mCgroupVersion))
     , mPlatformIdent(getPlatformIdent())
 {
     // create a directory within the top level workspace dir for the plugins
@@ -73,6 +75,11 @@ std::string DobbyEnv::cgroupMountPath(Cgroup cgroup) const
         return std::string();
     else
         return it->second;
+}
+
+IDobbyEnv::CgroupVersion DobbyEnv::cgroupVersion() const
+{
+    return mCgroupVersion;
 }
 
 uint16_t DobbyEnv::platformIdent() const
@@ -123,16 +130,42 @@ uint16_t DobbyEnv::getPlatformIdent()
 
 // -----------------------------------------------------------------------------
 /**
+ *  @brief Detects whether the system uses cgroups v1 or v2.
+ *
+ *  Checks for the presence of /sys/fs/cgroup/cgroup.controllers which only
+ *  exists on cgroup v2 (unified hierarchy) systems.
+ *
+ *  @return CgroupVersion::V2 if unified hierarchy is detected, otherwise V1.
+ */
+IDobbyEnv::CgroupVersion DobbyEnv::detectCgroupVersion()
+{
+    struct stat st;
+    if (stat("/sys/fs/cgroup/cgroup.controllers", &st) == 0)
+    {
+        AI_LOG_INFO("detected cgroup v2 support");
+        return IDobbyEnv::CgroupVersion::V2;
+    }
+
+    AI_LOG_INFO("detected cgroup v1 hierarchy");
+    return IDobbyEnv::CgroupVersion::V1;
+}
+
+// -----------------------------------------------------------------------------
+/**
  *  @brief Attempts to get the mount points of the cgroup filesystems
  *
  *  This scans the mount table looking for the cgroups mounts, if this fails
  *  it's pretty fatal.
  *
- *  This is typically the name of the cgroup prefixed with "/sys/fs/cgroup"
+ *  On cgroups v1 this is typically the name of the cgroup prefixed with
+ *  "/sys/fs/cgroup".  On cgroups v2 all controllers are under a single
+ *  unified mount (typically "/sys/fs/cgroup").
+ *
+ *  @param[in]  version   The detected cgroup version.
  *
  *  @return a map of cgroup type to path
  */
-std::map<IDobbyEnv::Cgroup, std::string> DobbyEnv::getCgroupMountPoints()
+std::map<IDobbyEnv::Cgroup, std::string> DobbyEnv::getCgroupMountPoints(CgroupVersion version)
 {
     AI_LOG_FN_ENTRY();
 
@@ -172,25 +205,43 @@ std::map<IDobbyEnv::Cgroup, std::string> DobbyEnv::getCgroupMountPoints()
         if (!mnt->mnt_type || !mnt->mnt_dir || !mnt->mnt_opts)
             continue;
 
-        // skip non-cgroup mounts
-        if (strcmp(mnt->mnt_type, "cgroup") != 0)
-            continue;
-
-        // check for the cgroup type
-        for (const std::pair<const std::string, IDobbyEnv::Cgroup> cgroup : cgroupNames)
+        if (version == CgroupVersion::V2)
         {
-            char* mntopt = hasmntopt(mnt, cgroup.first.c_str());
-            if (!mntopt)
+            // on cgroups v2 look for the unified "cgroup2" mount
+            if (strcmp(mnt->mnt_type, "cgroup2") != 0)
                 continue;
 
-            if (strcmp(mntopt, cgroup.first.c_str()) != 0)
-                continue;
+            AI_LOG_INFO("found cgroup2 unified mount @ '%s'", mnt->mnt_dir);
 
-            AI_LOG_INFO("found cgroup '%s' mounted @ '%s'",
-                        cgroup.first.c_str(), mnt->mnt_dir);
-
-            mounts[cgroup.second] = mnt->mnt_dir;
+            // on v2, all controllers share the same mount path
+            for (const auto& cgroup : cgroupNames)
+            {
+                mounts[cgroup.second] = mnt->mnt_dir;
+            }
             break;
+        }
+        else
+        {
+            // skip non-cgroup mounts (v1)
+            if (strcmp(mnt->mnt_type, "cgroup") != 0)
+                continue;
+
+            // check for the cgroup type
+            for (const std::pair<const std::string, IDobbyEnv::Cgroup> cgroup : cgroupNames)
+            {
+                char* mntopt = hasmntopt(mnt, cgroup.first.c_str());
+                if (!mntopt)
+                    continue;
+
+                if (strcmp(mntopt, cgroup.first.c_str()) != 0)
+                    continue;
+
+                AI_LOG_INFO("found cgroup '%s' mounted @ '%s'",
+                            cgroup.first.c_str(), mnt->mnt_dir);
+
+                mounts[cgroup.second] = mnt->mnt_dir;
+                break;
+            }
         }
     }
 

--- a/daemon/lib/source/DobbyStats.cpp
+++ b/daemon/lib/source/DobbyStats.cpp
@@ -115,6 +115,8 @@ Json::Value DobbyStats::getStats(const ContainerId& id,
 
     Json::Value stats(Json::objectValue);
 
+    const IDobbyEnv::CgroupVersion cgroupVer = env->cgroupVersion();
+
     const std::string cpuCgroupPath(env->cgroupMountPath(IDobbyEnv::Cgroup::CpuAcct));
     if (!cpuCgroupPath.empty())
     {
@@ -126,11 +128,20 @@ Json::Value DobbyStats::getStats(const ContainerId& id,
         stats["processes"] =
             getProcessTree(id, cpuCgroupPath, utils);
 
-        // get the cpu usage values
-        stats["cpu"]["usage"]["total"] =
-            readSingleCgroupValue(id, cpuCgroupPath, "cpuacct.usage");
-        stats["cpu"]["usage"]["percpu"] =
-            readMultipleCgroupValuesJson(id, cpuCgroupPath, "cpuacct.usage_percpu");
+        // get the cpu usage values - file names differ between v1 and v2
+        if (cgroupVer == IDobbyEnv::CgroupVersion::V1)
+        {
+            stats["cpu"]["usage"]["total"] =
+                readSingleCgroupValue(id, cpuCgroupPath, "cpuacct.usage");
+            stats["cpu"]["usage"]["percpu"] =
+                readMultipleCgroupValuesJson(id, cpuCgroupPath, "cpuacct.usage_percpu");
+        }
+        else
+        {
+            // on v2, cpu accounting is under cpu.stat (usage_usec field)
+            stats["cpu"]["usage"]["total"] =
+                readSingleCgroupValue(id, cpuCgroupPath, "cpu.stat");
+        }
     }
 
     // the timestamp value is generally used to calculate the cpu usage, so set
@@ -146,36 +157,66 @@ Json::Value DobbyStats::getStats(const ContainerId& id,
     const std::string memCgroupPath(env->cgroupMountPath(IDobbyEnv::Cgroup::Memory));
     if (!memCgroupPath.empty())
     {
-        // get the userspace memory consumed
-        stats["memory"]["user"]["limit"] =
-            readSingleCgroupValue(id, memCgroupPath, "memory.limit_in_bytes");
-        stats["memory"]["user"]["usage"] =
-            readSingleCgroupValue(id, memCgroupPath, "memory.usage_in_bytes");
-        stats["memory"]["user"]["max"] =
-            readSingleCgroupValue(id, memCgroupPath, "memory.max_usage_in_bytes");
-        stats["memory"]["user"]["failcnt"] =
-            readSingleCgroupValue(id, memCgroupPath, "memory.failcnt");
+        if (cgroupVer == IDobbyEnv::CgroupVersion::V1)
+        {
+            // cgroups v1 memory file names
+            stats["memory"]["user"]["limit"] =
+                readSingleCgroupValue(id, memCgroupPath, "memory.limit_in_bytes");
+            stats["memory"]["user"]["usage"] =
+                readSingleCgroupValue(id, memCgroupPath, "memory.usage_in_bytes");
+            stats["memory"]["user"]["max"] =
+                readSingleCgroupValue(id, memCgroupPath, "memory.max_usage_in_bytes");
+            stats["memory"]["user"]["failcnt"] =
+                readSingleCgroupValue(id, memCgroupPath, "memory.failcnt");
+        }
+        else
+        {
+            // cgroups v2 memory file names
+            stats["memory"]["user"]["limit"] =
+                readSingleCgroupValue(id, memCgroupPath, "memory.max");
+            stats["memory"]["user"]["usage"] =
+                readSingleCgroupValue(id, memCgroupPath, "memory.current");
+            stats["memory"]["user"]["max"] =
+                readSingleCgroupValue(id, memCgroupPath, "memory.peak");
+            // v2 has no direct failcnt; oom_kill count is in memory.events
+            stats["memory"]["user"]["failcnt"] = Json::Value::null;
+        }
     }
 
     const std::string gpuCgroupPath(env->cgroupMountPath(IDobbyEnv::Cgroup::Gpu));
     if (!gpuCgroupPath.empty())
     {
-        // get the gpu memory consumed
-        stats["gpu"]["memory"]["limit"] =
-            readSingleCgroupValue(id, gpuCgroupPath, "gpu.limit_in_bytes");
-        stats["gpu"]["memory"]["usage"] =
-            readSingleCgroupValue(id, gpuCgroupPath, "gpu.usage_in_bytes");
-        stats["gpu"]["memory"]["max"] =
-            readSingleCgroupValue(id, gpuCgroupPath, "gpu.max_usage_in_bytes");
-        stats["gpu"]["memory"]["failcnt"] =
-            readSingleCgroupValue(id, gpuCgroupPath, "gpu.failcnt");
+        // gpu cgroup is a custom controller; only available on v1
+        if (cgroupVer == IDobbyEnv::CgroupVersion::V1)
+        {
+            stats["gpu"]["memory"]["limit"] =
+                readSingleCgroupValue(id, gpuCgroupPath, "gpu.limit_in_bytes");
+            stats["gpu"]["memory"]["usage"] =
+                readSingleCgroupValue(id, gpuCgroupPath, "gpu.usage_in_bytes");
+            stats["gpu"]["memory"]["max"] =
+                readSingleCgroupValue(id, gpuCgroupPath, "gpu.max_usage_in_bytes");
+            stats["gpu"]["memory"]["failcnt"] =
+                readSingleCgroupValue(id, gpuCgroupPath, "gpu.failcnt");
+        }
+        else
+        {
+            AI_LOG_DEBUG("gpu cgroup stats not available on cgroups v2");
+        }
     }
 
 #if defined(RDK)
     const std::string ionCgroupPath(env->cgroupMountPath(IDobbyEnv::Cgroup::Ion));
     if (!ionCgroupPath.empty())
     {
-        stats["ion"]["heaps"] = readIonCgroupHeaps(id, ionCgroupPath);
+        // ion cgroup is a custom controller; only available on v1
+        if (cgroupVer == IDobbyEnv::CgroupVersion::V1)
+        {
+            stats["ion"]["heaps"] = readIonCgroupHeaps(id, ionCgroupPath);
+        }
+        else
+        {
+            AI_LOG_DEBUG("ion cgroup stats not available on cgroups v2");
+        }
     }
 #endif
 

--- a/daemon/lib/source/DobbyStats.cpp
+++ b/daemon/lib/source/DobbyStats.cpp
@@ -139,8 +139,14 @@ Json::Value DobbyStats::getStats(const ContainerId& id,
         else
         {
             // on v2, cpu accounting is under cpu.stat (usage_usec field)
-            stats["cpu"]["usage"]["total"] =
-                readSingleCgroupValue(id, cpuCgroupPath, "cpu.stat");
+            // usage_usec is in microseconds; convert to nanoseconds to match v1
+            Json::Value usec = readCgroupKeyValue(id, cpuCgroupPath, "cpu.stat", "usage_usec");
+            if (usec.isNull())
+                stats["cpu"]["usage"]["total"] = Json::Value::null;
+            else
+                stats["cpu"]["usage"]["total"] =
+                    Json::Value(static_cast<Json::LargestUInt>(usec.asUInt64() * 1000ULL));
+            stats["cpu"]["usage"]["percpu"] = Json::Value::null;
         }
     }
 
@@ -383,6 +389,55 @@ Json::Value DobbyStats::readSingleCgroupValue(const ContainerId& id,
         return Json::Value(-1);
     else
         return Json::Value(static_cast<Json::LargestUInt>(value));
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Reads a named value from a key-value format cgroup file.
+ *
+ *  Cgroups v2 files like cpu.stat use a key-value format with one pair per
+ *  line, e.g.:
+ *      usage_usec 123456
+ *      user_usec 100000
+ *      system_usec 23456
+ *
+ *  @param[in]  id              The string id of the container.
+ *  @param[in]  cgroupMntPath   The path to the cgroup mount point.
+ *  @param[in]  cgroupfileName  The name of the cgroup file.
+ *  @param[in]  key             The key whose value to extract.
+ *
+ *  @return The value as a json integer, or null if not found.
+ */
+Json::Value DobbyStats::readCgroupKeyValue(const ContainerId& id,
+                                           const std::string& cgroupMntPath,
+                                           const std::string& cgroupfileName,
+                                           const std::string& key)
+{
+    char buf[4096];
+
+    if (readCgroupFile(id, cgroupMntPath, cgroupfileName, buf, sizeof(buf)) <= 0)
+        return Json::Value::null;
+
+    // Parse line by line looking for "key value"
+    char* saveptr = nullptr;
+    char* line = strtok_r(buf, "\n", &saveptr);
+    while (line)
+    {
+        char keyBuf[64] = {};
+        unsigned long long value = 0;
+        if (sscanf(line, "%63s %llu", keyBuf, &value) == 2)
+        {
+            if (key == keyBuf)
+            {
+                if (value == ULONG_LONG_MAX)
+                    return Json::Value(-1);
+                return Json::Value(static_cast<Json::LargestUInt>(value));
+            }
+        }
+        line = strtok_r(nullptr, "\n", &saveptr);
+    }
+
+    return Json::Value::null;
 }
 
 // -----------------------------------------------------------------------------

--- a/daemon/lib/source/DobbyStats.cpp
+++ b/daemon/lib/source/DobbyStats.cpp
@@ -377,6 +377,11 @@ Json::Value DobbyStats::readSingleCgroupValue(const ContainerId& id,
     if (!token)
         return Json::Value::null;
 
+    // cgroups v2 files like memory.max can contain the literal "max" meaning
+    // unlimited; represent as -1 to match v1's ULONG_LONG_MAX convention
+    if (strcmp(token, "max") == 0)
+        return Json::Value(-1);
+
     unsigned long long value = strtoull(token, nullptr, 0);
     if ((value == 0) && (errno == EINVAL))
     {

--- a/daemon/lib/source/include/DobbyEnv.h
+++ b/daemon/lib/source/include/DobbyEnv.h
@@ -57,16 +57,20 @@ public:
 
     std::string cgroupMountPath(Cgroup cgroup) const override;
 
+    CgroupVersion cgroupVersion() const override;
+
     uint16_t platformIdent() const override;
 
 private:
-    static std::map<IDobbyEnv::Cgroup, std::string> getCgroupMountPoints();
+    static CgroupVersion detectCgroupVersion();
+    static std::map<IDobbyEnv::Cgroup, std::string> getCgroupMountPoints(CgroupVersion version);
     static uint16_t getPlatformIdent();
 
 private:
     const std::string mWorkspacePath;
     const std::string mFlashMountPath;
     const std::string mPluginsWorkspacePath;
+    const CgroupVersion mCgroupVersion;
     const std::map<IDobbyEnv::Cgroup, std::string> mCgroupMountPaths;
     const uint16_t mPlatformIdent;
 };

--- a/daemon/lib/source/include/DobbyStats.h
+++ b/daemon/lib/source/include/DobbyStats.h
@@ -88,6 +88,11 @@ private:
                                              const std::string &cgroupMntPath,
                                              const std::string &cgroupfileName);
 
+    static Json::Value readCgroupKeyValue(const ContainerId &id,
+                                          const std::string &cgroupMntPath,
+                                          const std::string &cgroupfileName,
+                                          const std::string &key);
+
     static std::vector<int64_t> readMultipleCgroupValues(const ContainerId &id,
                                                          const std::string &cgroupMntPath,
                                                          const std::string &cgroupfileName);

--- a/openspec/specs/proposals/cgroupv2-support.md
+++ b/openspec/specs/proposals/cgroupv2-support.md
@@ -1,0 +1,139 @@
+# Proposal: Cgroups v2 Support for Dobby
+
+**Ticket**: RDKEMW-14901  
+**Status**: Implemented 
+
+## Summary
+
+Add cgroups v2 (unified hierarchy) support to Dobby plugins and daemon components. All hardcoded cgroups v1 paths are now guarded by proper version detection checks, allowing Dobby to run correctly on modern kernels that default to cgroups v2.
+
+## Problem Statement
+
+The Linux kernel is migrating to cgroups v2 (unified hierarchy) as the default. While `crun` already supports both v1 and v2, several Dobby plugins and daemon components contained hardcoded cgroups v1 paths and file names that break on cgroups v2 systems:
+
+- Hardcoded paths like `/sys/fs/cgroup/memory/<id>/memory.failcnt`
+- Mount table scans that only matched `mnt_type == "cgroup"` (missing `"cgroup2"`)
+- v1-only control file names (`memory.limit_in_bytes`, `cpuacct.usage`, etc.)
+- OCI template with unconditional `"swappiness": 60` (not supported on v2)
+
+## Detection Strategy
+
+All locations use `stat("/sys/fs/cgroup/cgroup.controllers")` — if the file exists, the system is running cgroups v2. This is the same method already used in the project's CI workflow.
+
+## Changes Implemented
+
+### 1. IDobbyEnv Interface (`utils/include/IDobbyEnv.h`)
+
+- Added `CgroupVersion` enum: `{ V1, V2 }`
+- Added pure virtual `cgroupVersion()` method
+
+### 2. DobbyEnv (`daemon/lib/source/DobbyEnv.cpp`, `daemon/lib/source/include/DobbyEnv.h`)
+
+- Added `detectCgroupVersion()` — checks for `/sys/fs/cgroup/cgroup.controllers`
+- Updated `getCgroupMountPoints(CgroupVersion)`:
+  - On v1: scans `/proc/mounts` for `mnt_type == "cgroup"` per-controller mounts
+  - On v2: scans for `mnt_type == "cgroup2"`, maps all controllers to the single unified path
+- Added `mCgroupVersion` member initialized at construction
+
+### 3. DobbyStats (`daemon/lib/source/DobbyStats.cpp`)
+
+Branches on `cgroupVersion()` for file names:
+
+| Metric | v1 file | v2 file |
+|--------|---------|---------|
+| Memory limit | `memory.limit_in_bytes` | `memory.max` |
+| Memory usage | `memory.usage_in_bytes` | `memory.current` |
+| Memory peak | `memory.max_usage_in_bytes` | `memory.peak` |
+| Memory fail count | `memory.failcnt` | N/A (null) |
+| CPU usage | `cpuacct.usage` | `cpu.stat` |
+| GPU/ION stats | v1 controller files | Skipped (not available on v2) |
+
+### 4. DobbyInit (`daemon/init/source/InitMain.cpp`)
+
+- Added `isCgroupV2()` helper
+- Added `readCgroupKeyValue()` for parsing v2's key-value format files
+- `checkForOOM()` reads `memory.events` `oom_kill` field on v2, `memory/memory.failcnt` on v1
+
+### 5. OOMCrash Plugin (`rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp`)
+
+- `readCgroup()` detects v1/v2 at runtime
+- On v2: reads `memory.events`, parses `oom_kill` count
+- Includes fallback to `system.slice/dobby-<id>.scope/` path (common with systemd on v2)
+- On v1: reads `memory.failcnt` as before
+
+### 6. GPU Plugin (`rdkPlugins/GPU/source/GpuPlugin.cpp`)
+
+- `getGpuCgroupMountPoint()` detects v2 early and returns empty string with a warning
+- The `gpu` custom cgroup controller does not exist in v2's unified hierarchy
+- Plugin gracefully degrades — container still starts, just without GPU memory limits
+
+### 7. IONMemory Plugin (`rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp`)
+
+- `findIonCGroupMountPoint()` detects v2 early and returns empty string with a warning
+- The `ion` custom cgroup controller does not exist in v2's unified hierarchy
+- Plugin gracefully degrades — container still starts, just without ION memory limits
+
+### 8. DobbyTemplate (`bundle/lib/source/DobbyTemplate.cpp`)
+
+- `setTemplateCpuRtSched()` now recognizes `"cgroup2"` mounts
+- On v2, breaks out of loop early (RT scheduling handled differently), values default to `null`
+
+### 9. OCI Templates
+
+**Files:**
+- `bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template`
+- `bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template`
+
+`"swappiness": 60` is now gated behind a `{{#SWAPPINESS_ENABLED}}` template section.
+
+### 10. DobbySpecConfig (`bundle/lib/source/DobbySpecConfig.cpp`)
+
+- Added `SWAPPINESS_ENABLED` template variable
+- Section is shown only when cgroups v1 is detected (v2 does not support swappiness)
+
+### 11. Test Mocks
+
+- `tests/L1_testing/mocks/DobbyEnv.h` — added `cgroupVersion()` to mock interface
+- `tests/L1_testing/mocks/DobbyEnvMock.h` — added `MOCK_METHOD` for `cgroupVersion()`
+- `tests/L1_testing/mocks/DobbyEnvMock.cpp` — added delegation to impl
+
+## Key Differences: cgroups v1 vs v2
+
+| Aspect | v1 (legacy) | v2 (unified) |
+|--------|-------------|--------------|
+| Mount type | `cgroup` | `cgroup2` |
+| Hierarchy | Per-controller (`/sys/fs/cgroup/memory/`, etc.) | Single tree (`/sys/fs/cgroup/`) |
+| Memory limit | `memory.limit_in_bytes` | `memory.max` |
+| Memory usage | `memory.usage_in_bytes` | `memory.current` |
+| Memory fail count | `memory.failcnt` | `memory.events` (`oom_kill` field) |
+| Swap limit | `memory.memsw.limit_in_bytes` | `memory.swap.max` |
+| Swappiness | `memory.swappiness` | Not supported |
+| CPU usage | `cpuacct.usage` | `cpu.stat` (`usage_usec` field) |
+| Detection | N/A | `/sys/fs/cgroup/cgroup.controllers` exists |
+
+## Graceful Degradation
+
+- **GPU/ION plugins**: Custom cgroup controllers don't exist in v2. These plugins log a warning and allow the container to start without resource limits.
+- **OOMCrash**: Falls back to `system.slice/dobby-<id>.scope/` path for systemd-managed v2 hierarchies.
+- **DobbyStats**: Reports `null` for unavailable metrics rather than failing.
+- **Backward compatibility**: All v1 paths remain functional. Changes only add v2 branches alongside existing v1 code.
+
+## Files Modified
+
+| File | Type of change |
+|------|---------------|
+| `utils/include/IDobbyEnv.h` | Interface addition |
+| `daemon/lib/source/include/DobbyEnv.h` | Header update |
+| `daemon/lib/source/DobbyEnv.cpp` | Detection + mount scanning |
+| `daemon/lib/source/DobbyStats.cpp` | v1/v2 branching |
+| `daemon/init/source/InitMain.cpp` | v1/v2 branching |
+| `rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp` | v1/v2 branching |
+| `rdkPlugins/GPU/source/GpuPlugin.cpp` | v2 early return |
+| `rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp` | v2 early return |
+| `bundle/lib/source/DobbyTemplate.cpp` | v2 awareness |
+| `bundle/lib/source/DobbySpecConfig.cpp` | Conditional swappiness |
+| `bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template` | Template section guard |
+| `bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template` | Template section guard |
+| `tests/L1_testing/mocks/DobbyEnv.h` | Mock update |
+| `tests/L1_testing/mocks/DobbyEnvMock.h` | Mock update |
+| `tests/L1_testing/mocks/DobbyEnvMock.cpp` | Mock update |

--- a/rdkPlugins/GPU/source/GpuPlugin.cpp
+++ b/rdkPlugins/GPU/source/GpuPlugin.cpp
@@ -67,6 +67,13 @@ bool GpuPlugin::createRuntime()
     // sanity check we have a gpu cgroup dir
     if (cgroupDirPath.empty())
     {
+        // On cgroups v2 the gpu controller is unavailable; degrade gracefully
+        struct stat st;
+        if (stat("/sys/fs/cgroup/cgroup.controllers", &st) == 0)
+        {
+            AI_LOG_WARN("gpu cgroup not available on cgroups v2, skipping");
+            return true;
+        }
         AI_LOG_ERROR_EXIT("missing gpu cgroup directory");
         return false;
     }
@@ -111,6 +118,13 @@ bool GpuPlugin::postStop()
     // sanity check we have a gpu cgroup dir
     if (cgroupDirPath.empty())
     {
+        // On cgroups v2 the gpu controller is unavailable; nothing to clean up
+        struct stat st;
+        if (stat("/sys/fs/cgroup/cgroup.controllers", &st) == 0)
+        {
+            AI_LOG_FN_EXIT();
+            return true;
+        }
         AI_LOG_ERROR_EXIT("missing gpu cgroup directory");
         return false;
     }

--- a/rdkPlugins/GPU/source/GpuPlugin.cpp
+++ b/rdkPlugins/GPU/source/GpuPlugin.cpp
@@ -165,13 +165,23 @@ std::vector<std::string> GpuPlugin::getDependencies() const
  *  This scans the mount table looking for the cgroups mount, if this fails
  *  it's pretty fatal.
  *
- *  This is typically "/sys/fs/cgroup/gpu".
+ *  On cgroups v1 this is typically "/sys/fs/cgroup/gpu".
+ *  On cgroups v2 the gpu custom controller is not available (returns empty).
  *
- *  @return a string to the gpu cgroup path.
+ *  @return a string to the gpu cgroup path, or empty if not found.
  */
 std::string GpuPlugin::getGpuCgroupMountPoint()
 {
     AI_LOG_FN_ENTRY();
+
+    // On cgroups v2 there is no separate gpu cgroup controller
+    struct stat st;
+    if (stat("/sys/fs/cgroup/cgroup.controllers", &st) == 0)
+    {
+        AI_LOG_WARN("gpu cgroup controller not available on cgroups v2");
+        AI_LOG_FN_EXIT();
+        return std::string();
+    }
 
     std::string mountPoint;
 

--- a/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
+++ b/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
@@ -97,6 +97,14 @@ bool IonMemoryPlugin::createRuntime()
     // sanity check we have an ION cgroup dir
     if (cgroupDirPath.empty())
     {
+        // On cgroups v2 the ion controller is unavailable; degrade gracefully
+        struct stat st;
+        if (stat("/sys/fs/cgroup/cgroup.controllers", &st) == 0)
+        {
+            AI_LOG_WARN("ion cgroup not available on cgroups v2, skipping");
+            AI_LOG_FN_EXIT();
+            return true;
+        }
         AI_LOG_ERROR_EXIT("missing cgroup directory");
         return false;
     }
@@ -150,6 +158,13 @@ bool IonMemoryPlugin::postStop()
     // sanity check we have a cgroup dir
     if (cgroupDirPath.empty())
     {
+        // On cgroups v2 the ion controller is unavailable; nothing to clean up
+        struct stat st;
+        if (stat("/sys/fs/cgroup/cgroup.controllers", &st) == 0)
+        {
+            AI_LOG_FN_EXIT();
+            return true;
+        }
         AI_LOG_ERROR_EXIT("missing cgroup directory");
         return false;
     }

--- a/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
+++ b/rdkPlugins/IONMemory/source/IonMemoryPlugin.cpp
@@ -180,14 +180,24 @@ bool IonMemoryPlugin::postStop()
 /**
  *  @brief Attempts to get the mount points of the ION cgroup filesystem.
  *
- *  This scans the mount table looking for the cgroups mounts. This is typically
- *  the name of the cgroup prefixed with "/sys/fs/cgroup"
+ *  This scans the mount table looking for the cgroups mounts. On cgroups v1
+ *  this is typically the name of the cgroup prefixed with "/sys/fs/cgroup".
+ *  On cgroups v2 the ION custom controller is not available (returns empty).
  *
  *  @return path to the ION cgroup mount, or empty string if failed to find it.
  */
 std::string IonMemoryPlugin::findIonCGroupMountPoint() const
 {
     AI_LOG_FN_ENTRY();
+
+    // On cgroups v2 there is no separate ion cgroup controller
+    struct stat st;
+    if (stat("/sys/fs/cgroup/cgroup.controllers", &st) == 0)
+    {
+        AI_LOG_WARN("ion cgroup controller not available on cgroups v2");
+        AI_LOG_FN_EXIT();
+        return std::string();
+    }
 
     // try and open /proc/mounts for scanning the current mount table
     FILE *procMounts = setmntent("/proc/mounts", "r");

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
@@ -173,7 +173,13 @@ std::vector<std::string> OOMCrash::getDependencies() const
 }
 
 /**
- * @brief Read cgroup file.
+ * @brief Read cgroup file to detect OOM.
+ *
+ *  On cgroups v1 reads memory.failcnt from
+ *  /sys/fs/cgroup/memory/<id>/memory.failcnt.
+ *
+ *  On cgroups v2 reads the oom_kill field from
+ *  /sys/fs/cgroup/<id>/memory.events.
  *
  *  @param[out]  val      gives the number of times that the cgroup limit was exceeded.
  *
@@ -182,36 +188,84 @@ std::vector<std::string> OOMCrash::getDependencies() const
 
 bool OOMCrash::readCgroup(unsigned long *val)
 {
-    std::string path = "/sys/fs/cgroup/memory/" + mUtils->getContainerId() + "/memory.failcnt";
+    const std::string containerId = mUtils->getContainerId();
+
+    // Detect cgroups version by checking for the v2 unified hierarchy
+    struct stat st;
+    const bool isCgroupV2 = (stat("/sys/fs/cgroup/cgroup.controllers", &st) == 0);
+
+    std::string path;
+    if (isCgroupV2)
+    {
+        // On cgroups v2, OOM events are in memory.events under the container's
+        // cgroup directory within the unified hierarchy
+        path = "/sys/fs/cgroup/" + containerId + "/memory.events";
+    }
+    else
+    {
+        // On cgroups v1, use the legacy per-controller path
+        path = "/sys/fs/cgroup/memory/" + containerId + "/memory.failcnt";
+    }
 
     FILE *fp = fopen(path.c_str(), "r");
     if (!fp)
     {
-        if (errno != ENOENT)
-            AI_LOG_ERROR("failed to open '%s' (%d - %s)", path.c_str(), errno, strerror(errno));
+        // On v2 the container may be scoped under system.slice
+        if (isCgroupV2 && errno == ENOENT)
+        {
+            path = "/sys/fs/cgroup/system.slice/dobby-" + containerId + ".scope/memory.events";
+            fp = fopen(path.c_str(), "r");
+        }
 
-        return false;
+        if (!fp)
+        {
+            if (errno != ENOENT)
+                AI_LOG_ERROR("failed to open '%s' (%d - %s)", path.c_str(), errno, strerror(errno));
+
+            return false;
+        }
     }
 
     char* line = nullptr;
     size_t len = 0;
     ssize_t rd;
 
-    if ((rd = getline(&line, &len, fp)) < 0)
+    if (isCgroupV2)
     {
-        if (line)
-            free(line);
+        // memory.events is a key-value file, look for "oom_kill <N>"
+        *val = 0;
+        while ((rd = getline(&line, &len, fp)) >= 0)
+        {
+            unsigned long v = 0;
+            if (sscanf(line, "oom_kill %lu", &v) == 1)
+            {
+                *val = v;
+                break;
+            }
+        }
+        free(line);
         fclose(fp);
-        AI_LOG_ERROR("failed to read cgroup file line (%d - %s)", errno, strerror(errno));
-        return false;
+        return true;
     }
+    else
+    {
+        // v1: single numeric value in memory.failcnt
+        if ((rd = getline(&line, &len, fp)) < 0)
+        {
+            if (line)
+                free(line);
+            fclose(fp);
+            AI_LOG_ERROR("failed to read cgroup file line (%d - %s)", errno, strerror(errno));
+            return false;
+        }
 
-    *val = strtoul(line, nullptr, 0);
+        *val = strtoul(line, nullptr, 0);
 
-    fclose(fp);
-    free(line);
+        fclose(fp);
+        free(line);
 
-    return true;
+        return true;
+    }
 }
 
 /**

--- a/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
+++ b/rdkPlugins/OOMCrash/source/OOMCrashPlugin.cpp
@@ -233,6 +233,7 @@ bool OOMCrash::readCgroup(unsigned long *val)
     if (isCgroupV2)
     {
         // memory.events is a key-value file, look for "oom_kill <N>"
+        bool found = false;
         *val = 0;
         while ((rd = getline(&line, &len, fp)) >= 0)
         {
@@ -240,11 +241,17 @@ bool OOMCrash::readCgroup(unsigned long *val)
             if (sscanf(line, "oom_kill %lu", &v) == 1)
             {
                 *val = v;
+                found = true;
                 break;
             }
         }
         free(line);
         fclose(fp);
+        if (!found)
+        {
+            AI_LOG_ERROR("'oom_kill' key not found in '%s'", path.c_str());
+            return false;
+        }
         return true;
     }
     else

--- a/tests/L1_testing/mocks/DobbyEnv.h
+++ b/tests/L1_testing/mocks/DobbyEnv.h
@@ -35,6 +35,7 @@ public:
     virtual std::string pluginsWorkspacePath() const = 0;
     virtual uint16_t platformIdent() const = 0;
     virtual std::string cgroupMountPath(IDobbyEnv::Cgroup cgroup) const = 0;
+    virtual IDobbyEnv::CgroupVersion cgroupVersion() const = 0;
 };
 
 class DobbyEnv :  public IDobbyEnv{
@@ -53,6 +54,7 @@ public:
     std::string pluginsWorkspacePath() const override;
     uint16_t platformIdent() const override;
     std::string cgroupMountPath(Cgroup cgroup) const override;
+    CgroupVersion cgroupVersion() const override;
 
 };
 

--- a/tests/L1_testing/mocks/DobbyEnvMock.cpp
+++ b/tests/L1_testing/mocks/DobbyEnvMock.cpp
@@ -74,3 +74,10 @@ std::string DobbyEnv::cgroupMountPath(IDobbyEnv::Cgroup cgroup) const
    return impl->cgroupMountPath(cgroup);
 }
 
+IDobbyEnv::CgroupVersion DobbyEnv::cgroupVersion() const
+{
+   EXPECT_NE(impl, nullptr);
+
+   return impl->cgroupVersion();
+}
+

--- a/tests/L1_testing/mocks/DobbyEnvMock.h
+++ b/tests/L1_testing/mocks/DobbyEnvMock.h
@@ -32,6 +32,7 @@ public:
     MOCK_METHOD(std::string, pluginsWorkspacePath, (), (const,override));
     MOCK_METHOD(uint16_t, platformIdent, (), (const,override));
     MOCK_METHOD(std::string ,cgroupMountPath, (IDobbyEnv::Cgroup cgroup), (const,override));
+    MOCK_METHOD(IDobbyEnv::CgroupVersion, cgroupVersion, (), (const,override));
 
 private:
     const std::shared_ptr<const IDobbySettings> mSettings;

--- a/utils/include/IDobbyEnv.h
+++ b/utils/include/IDobbyEnv.h
@@ -112,15 +112,31 @@ public:
     enum class Cgroup
         { Freezer, Memory, Cpu, CpuAcct, CpuSet, Devices, Gpu, NetCls, Blkio, Ion };
 
+    enum class CgroupVersion
+        { V1, V2 };
+
     // -------------------------------------------------------------------------
     /**
      *  @brief Returns the absolute path to the cgroup mount point for the
      *  given cgroup
      *
-     *  This is typically "/sys/fs/cgroup/<cgroup>"
+     *  On cgroups v1 this is typically "/sys/fs/cgroup/<controller>".
+     *  On cgroups v2 (unified) this is the single unified mount, typically
+     *  "/sys/fs/cgroup".
      *
      */
     virtual std::string cgroupMountPath(Cgroup cgroup) const = 0;
+
+    // -------------------------------------------------------------------------
+    /**
+     *  @brief Returns the detected cgroup version (V1 or V2)
+     *
+     *  On cgroups v2 systems all controllers are under a single unified
+     *  hierarchy. Plugins should use this to select the correct file names
+     *  when reading/writing cgroup control files.
+     *
+     */
+    virtual CgroupVersion cgroupVersion() const = 0;
 
 };
 


### PR DESCRIPTION
### Description
Add cgroups v2 (unified hierarchy) support to Dobby plugins and daemon components. All hardcoded cgroups v1 paths are now guarded by proper version detection checks, allowing Dobby to run correctly on modern kernels that default to cgroups v2.

### Test Procedure
- On cgroup v1 device: verify containers start/stop normally, GPU/ION limits apply, OOM detection works via [memory.failcnt](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), swappiness appears in generated OCI config
- On cgroup v2 system: verify containers start/stop normally, GPU/ION plugins log warnings and degrade gracefully, OOM detection works via [memory.events](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) oom_kill field, swappiness is absent from OCI config
- Ensure whether both L1 and L2 tests pass 

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)