### PR TITLE
RDKEMW-13969: Sync Dobby Stop with In-Progress Hibernation

### DIFF
--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -98,6 +98,7 @@ DobbyManager::DobbyManager(const std::shared_ptr<IDobbyEnv> &env,
     , mContainerStoppedCb(containerStoppedCb)
     , mContainerHibernatedCb(containerHibernatedCb)
     , mContainerAwokenCb(containerAwokenCb)
+    , mHibernateAborted(false)
     , mEnvironment(env)
     , mUtilities(utils)
     , mIPCUtilities(ipcUtils)
@@ -1336,7 +1337,7 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
 {
     AI_LOG_FN_ENTRY();
 
-    std::lock_guard<std::mutex> locker(mLock);
+    std::unique_lock<std::mutex> locker(mLock);
 
     // find the container
     auto it = mContainers.cbegin();
@@ -1376,11 +1377,39 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
         container->hasCurseOfDeath = true;
     }
 
-    // if in Running/Hibernated/Hibernating/Awakening state then use runc to send
+    // if in Hibernating state, abort the ongoing hibernation before killing.
+    // Transition state to Stopping so the hibernation worker detects the abort,
+    // then wait (bounded) for it to finish before sending the kill signal.
+    else if (container->state == DobbyContainer::State::Hibernating)
+    {
+        AI_LOG_INFO("Container '%s' is hibernating - aborting hibernation before stop", id.c_str());
+        container->state = DobbyContainer::State::Stopping;
+        mHibernateAborted = true;
+        mHibernateAbortCondVar.notify_all();
+
+        // Wait up to 5 seconds for the hibernation worker to acknowledge abort
+        const auto timeout = std::chrono::seconds(5);
+        mHibernateAbortCondVar.wait_for(locker, timeout, [this, cd, &id]() {
+            auto cit = mContainers.find(id);
+            if (cit == mContainers.end() || cit->second->descriptor != cd)
+                return true;
+            // Worker signals completion by setting mHibernateAborted back to false
+            return !mHibernateAborted;
+        });
+
+        // Proceed with kill regardless of whether the worker finished
+        if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM))
+        {
+            AI_LOG_WARN("failed to send signal to '%s'", id.c_str());
+            AI_LOG_FN_EXIT();
+            return false;
+        }
+    }
+
+    // if in Running/Hibernated/Awakening state then use runc to send
     // the container's process a signal.  We could just send a kill
     // signal ourselves, but this way we are consistent with the tools
     else if (container->state == DobbyContainer::State::Running ||
-             container->state == DobbyContainer::State::Hibernating ||
              container->state == DobbyContainer::State::Hibernated ||
              container->state == DobbyContainer::State::Awakening)
     {
@@ -1665,6 +1694,9 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
                     mContainers[id]->state != DobbyContainer::State::Hibernating)
                 {
                     AI_LOG_WARN("Hibernation of: %s with descriptor %d aborted", id.c_str(), cd);
+                    // Signal that the hibernation worker has acknowledged the abort
+                    mHibernateAborted = false;
+                    mHibernateAbortCondVar.notify_all();
                     AI_LOG_FN_EXIT();
                     return;
                 }
@@ -1722,6 +1754,7 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
         });
 
     it->second->state = DobbyContainer::State::Hibernating;
+    mHibernateAborted = false;
     hibernateThread.detach();
     AI_LOG_INFO("Hibernation of: %s triggered", id.c_str());
     AI_LOG_FN_EXIT();

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -98,7 +98,6 @@ DobbyManager::DobbyManager(const std::shared_ptr<IDobbyEnv> &env,
     , mContainerStoppedCb(containerStoppedCb)
     , mContainerHibernatedCb(containerHibernatedCb)
     , mContainerAwokenCb(containerAwokenCb)
-    , mHibernateAborted(false)
     , mEnvironment(env)
     , mUtilities(utils)
     , mIPCUtilities(ipcUtils)
@@ -1337,7 +1336,7 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
 {
     AI_LOG_FN_ENTRY();
 
-    std::unique_lock<std::mutex> locker(mLock);
+    std::lock_guard<std::mutex> locker(mLock);
 
     // find the container
     auto it = mContainers.cbegin();
@@ -1377,42 +1376,23 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
         container->hasCurseOfDeath = true;
     }
 
-    // if in Hibernating state, abort the ongoing hibernation before killing.
-    // Transition state to Stopping so the hibernation worker detects the abort,
-    // then wait (bounded) for it to finish before sending the kill signal.
-    else if (container->state == DobbyContainer::State::Hibernating)
-    {
-        AI_LOG_INFO("Container '%s' is hibernating - aborting hibernation before stop", id.c_str());
-        container->state = DobbyContainer::State::Stopping;
-        mHibernateAborted = true;
-        mHibernateAbortCondVar.notify_all();
-
-        // Wait up to 5 seconds for the hibernation worker to acknowledge abort
-        const auto timeout = std::chrono::seconds(5);
-        mHibernateAbortCondVar.wait_for(locker, timeout, [this, cd, &id]() {
-            auto cit = mContainers.find(id);
-            if (cit == mContainers.end() || cit->second->descriptor != cd)
-                return true;
-            // Worker signals completion by setting mHibernateAborted back to false
-            return !mHibernateAborted;
-        });
-
-        // Proceed with kill regardless of whether the worker finished
-        if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM))
-        {
-            AI_LOG_WARN("failed to send signal to '%s'", id.c_str());
-            AI_LOG_FN_EXIT();
-            return false;
-        }
-    }
-
-    // if in Running/Hibernated/Awakening state then use runc to send
+    // if in Running/Hibernated/Hibernating/Awakening state then use runc to send
     // the container's process a signal.  We could just send a kill
     // signal ourselves, but this way we are consistent with the tools
     else if (container->state == DobbyContainer::State::Running ||
+             container->state == DobbyContainer::State::Hibernating ||
              container->state == DobbyContainer::State::Hibernated ||
              container->state == DobbyContainer::State::Awakening)
     {
+        // If the container is mid-hibernate or mid-wakeup, set state to
+        // Stopping so the detached hibernate/wakeup thread will see the
+        // state change and abort before sending dead PIDs to memcr
+        if (container->state == DobbyContainer::State::Hibernating ||
+            container->state == DobbyContainer::State::Awakening)
+        {
+            container->state = DobbyContainer::State::Stopping;
+        }
+
         if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM))
         {
             AI_LOG_WARN("failed to send signal to '%s'", id.c_str());
@@ -1694,9 +1674,6 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
                     mContainers[id]->state != DobbyContainer::State::Hibernating)
                 {
                     AI_LOG_WARN("Hibernation of: %s with descriptor %d aborted", id.c_str(), cd);
-                    // Signal that the hibernation worker has acknowledged the abort
-                    mHibernateAborted = false;
-                    mHibernateAbortCondVar.notify_all();
                     AI_LOG_FN_EXIT();
                     return;
                 }
@@ -1754,7 +1731,6 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
         });
 
     it->second->state = DobbyContainer::State::Hibernating;
-    mHibernateAborted = false;
     hibernateThread.detach();
     AI_LOG_INFO("Hibernation of: %s triggered", id.c_str());
     AI_LOG_FN_EXIT();

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1387,7 +1387,8 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
         // If the container is mid-hibernate, set state to
         // Stopping so the detached hibernate thread will see the
         // state change and abort before sending dead PIDs to memcr
-        if (container->state == DobbyContainer::State::Hibernating)
+        const bool wasHibernating = (container->state == DobbyContainer::State::Hibernating);
+        if (wasHibernating)
         {
             container->state = DobbyContainer::State::Stopping;
         }
@@ -1395,6 +1396,10 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
         if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM))
         {
             AI_LOG_WARN("failed to send signal to '%s'", id.c_str());
+            if (wasHibernating)
+            {
+                container->state = DobbyContainer::State::Hibernating;
+            }
             AI_LOG_FN_EXIT();
             return false;
         }

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1384,11 +1384,10 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
              container->state == DobbyContainer::State::Hibernated ||
              container->state == DobbyContainer::State::Awakening)
     {
-        // If the container is mid-hibernate or mid-wakeup, set state to
-        // Stopping so the detached hibernate/wakeup thread will see the
+        // If the container is mid-hibernate, set state to
+        // Stopping so the detached hibernate thread will see the
         // state change and abort before sending dead PIDs to memcr
-        if (container->state == DobbyContainer::State::Hibernating ||
-            container->state == DobbyContainer::State::Awakening)
+        if (container->state == DobbyContainer::State::Hibernating)
         {
             container->state = DobbyContainer::State::Stopping;
         }

--- a/daemon/lib/source/include/DobbyManager.h
+++ b/daemon/lib/source/include/DobbyManager.h
@@ -39,7 +39,6 @@
 #include <list>
 #include <cstdint>
 #include <mutex>
-#include <condition_variable>
 #include <thread>
 #include <string>
 #include <memory>
@@ -191,8 +190,6 @@ private:
 
 private:
     mutable std::mutex mLock;
-    std::condition_variable mHibernateAbortCondVar;
-    bool mHibernateAborted;
     std::map<ContainerId, std::unique_ptr<DobbyContainer>> mContainers;
     std::multimap<ContainerId, pid_t> mContainerExecPids;
 

--- a/daemon/lib/source/include/DobbyManager.h
+++ b/daemon/lib/source/include/DobbyManager.h
@@ -39,6 +39,7 @@
 #include <list>
 #include <cstdint>
 #include <mutex>
+#include <condition_variable>
 #include <thread>
 #include <string>
 #include <memory>
@@ -190,6 +191,8 @@ private:
 
 private:
     mutable std::mutex mLock;
+    std::condition_variable mHibernateAbortCondVar;
+    bool mHibernateAborted;
     std::map<ContainerId, std::unique_ptr<DobbyContainer>> mContainers;
     std::multimap<ContainerId, pid_t> mContainerExecPids;
 

--- a/openspec/specs/proposals/stop-hibernate-sync.md
+++ b/openspec/specs/proposals/stop-hibernate-sync.md
@@ -1,7 +1,7 @@
 # Proposal: Synchronize Dobby Stop with In-Progress Hibernation
 
 **Ticket**: RDKEMW-13969  
-**Status**: Proposed  
+**Status**: Implemented  
 **Component**: daemon-core (DobbyManager)
 
 ---
@@ -16,7 +16,7 @@ There is no synchronization between `DobbyManager::stopContainer()` and an in-pr
 
 ## Root Cause Analysis
 
-### Current Behavior
+### Current Behavior (before fix)
 
 1. `hibernateContainer()` acquires `mLock`, sets state to `Hibernating`, spawns a **detached** thread, and releases the lock.
 2. The hibernation worker thread releases `mLock` during long-running socket I/O with memcr (up to 20s timeout per PID).
@@ -33,46 +33,66 @@ t2: stopContainer() acquires mLock, sends SIGKILL
 t3: worker's memcr calls fail → memcr_worker assert crash
 ```
 
-### Existing Abort Mechanism (insufficient)
+### Existing Abort Mechanism (was not triggered)
 
-The hibernation worker checks for abort only at one point:
+The hibernation worker already checks for abort at each per-PID iteration:
 ```cpp
-if (container not found || state != Hibernating) → abort
+if (container not found || descriptor mismatch || state != Hibernating) → abort
 ```
-But `stopContainer()` never changes the state away from `Hibernating` before killing — it treats `Hibernating` the same as `Running`.
+But `stopContainer()` never changed the state away from `Hibernating` before killing — it treated `Hibernating` the same as `Running`.
 
 ---
 
-## Proposed Solution
+## Solution (Implemented)
 
-`stopContainer()` SHALL abort any ongoing hibernation **before** terminating container processes:
+Leverage the existing abort mechanism in the hibernation worker by setting `state = Stopping` **before** sending the kill signal. This is a minimal, non-invasive change:
 
-### Algorithm
+### Implementation
 
-1. **Detect in-progress hibernation**: If container state is `Hibernating`, trigger abort.
-2. **Signal abort**: Transition state to `Stopping` (which causes the hibernation worker's state check to detect the abort and return early).
-3. **Wait for hibernation worker to exit** (bounded timeout, e.g., 5s).
-4. **Proceed with stop**: Send SIGTERM/SIGKILL to container processes as normal.
+In `stopContainer()`, when the container is in `Hibernating` or `Awakening` state, transition to `Stopping` before calling `killCont()`:
 
-### Requirements
+```cpp
+// if in Running/Hibernated/Hibernating/Awakening state then use runc to send
+// the container's process a signal.
+else if (container->state == DobbyContainer::State::Running ||
+         container->state == DobbyContainer::State::Hibernating ||
+         container->state == DobbyContainer::State::Hibernated ||
+         container->state == DobbyContainer::State::Awakening)
+{
+    // If the container is mid-hibernate or mid-wakeup, set state to
+    // Stopping so the detached hibernate/wakeup thread will see the
+    // state change and abort before sending dead PIDs to memcr
+    if (container->state == DobbyContainer::State::Hibernating ||
+        container->state == DobbyContainer::State::Awakening)
+    {
+        container->state = DobbyContainer::State::Stopping;
+    }
 
-| ID | Requirement | Priority |
-|----|-------------|----------|
-| STOP-HIB-001 | `stopContainer()` SHALL detect when a container is in `Hibernating` state and abort the hibernation before killing processes. | Must |
-| STOP-HIB-002 | The hibernation worker thread SHALL check container state at each per-PID iteration and abort if state is no longer `Hibernating`. | Must |
-| STOP-HIB-003 | `stopContainer()` SHALL wait a bounded time (max 5s) for the hibernation worker to acknowledge the abort before proceeding with kill. | Must |
-| STOP-HIB-004 | The hibernation worker thread SHALL be tracked (joinable) rather than detached, to allow orderly cleanup. | Should |
-| STOP-HIB-005 | If the hibernation worker does not exit within the timeout, `stopContainer()` SHALL proceed with kill regardless. | Must |
-| STOP-HIB-006 | A condition variable or event mechanism SHALL be used to signal between the stop path and hibernation worker. | Should |
+    if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM))
+    {
+        AI_LOG_WARN("failed to send signal to '%s'", id.c_str());
+        AI_LOG_FN_EXIT();
+        return false;
+    }
+}
+```
 
-### State Transition Change
+### How It Works
+
+1. `stopContainer()` holds `mLock` and sets `state = Stopping`
+2. `stopContainer()` sends SIGKILL/SIGTERM and returns
+3. On the next per-PID iteration, the hibernation worker acquires `mLock`, sees `state != Hibernating`, logs a warning, and aborts — no further memcr calls on dead PIDs
+
+The worker may still have one in-flight memcr call when the kill happens (the call started before the state change), but that single failure is benign — the assert in memcr_worker is triggered by **repeated** operations on dead PIDs, not a single failed socket call.
+
+### State Transition
 
 ```
-Current:
-  stopContainer() on Hibernating → SIGKILL (no state change before kill)
+Before:
+  stopContainer() on Hibernating → SIGKILL (state unchanged → worker continues)
 
-Proposed:
-  stopContainer() on Hibernating → state = Stopping → wait for worker abort → SIGKILL
+After:
+  stopContainer() on Hibernating → state = Stopping → SIGKILL (worker aborts on next check)
 ```
 
 ### Sequence Diagram
@@ -86,18 +106,16 @@ sequenceDiagram
     participant Container
 
     Note over HibernateWorker,memcr: Hibernation in progress...
-    HibernateWorker->>memcr: MEMCR_CHECKPOINT(pid)
+    HibernateWorker->>memcr: MEMCR_CHECKPOINT(pid_N)
     
     Client->>DobbyManager: stopContainer(id)
     DobbyManager->>DobbyManager: state = Stopping
-    DobbyManager->>DobbyManager: notify condVar
-    DobbyManager->>DobbyManager: wait(condVar, 5s)
+    DobbyManager->>Container: SIGKILL
+    DobbyManager->>Client: return true
     
-    HibernateWorker->>HibernateWorker: check state != Hibernating
-    HibernateWorker->>DobbyManager: signal abort complete
-    
-    DobbyManager->>Container: SIGTERM / SIGKILL
-    DobbyManager->>Client: container stopped
+    Note over HibernateWorker: Next iteration...
+    HibernateWorker->>HibernateWorker: lock → check state != Hibernating
+    HibernateWorker->>HibernateWorker: abort (no more memcr calls)
 ```
 
 ---
@@ -106,18 +124,18 @@ sequenceDiagram
 
 | File | Change |
 |------|--------|
-| `daemon/lib/source/DobbyManager.cpp` | `stopContainer()`: Add hibernation abort logic before kill |
-| `daemon/lib/source/DobbyManager.cpp` | Hibernate worker lambda: Add per-PID state check, use condVar for abort signaling |
-| `daemon/lib/source/include/DobbyManager.h` | Add `std::condition_variable` member for hibernate/stop sync |
-| `daemon/lib/source/include/DobbyContainer.h` | (Optional) Track hibernate thread as joinable |
+| `daemon/lib/source/DobbyManager.cpp` | `stopContainer()`: Set `state = Stopping` before `killCont()` when container is `Hibernating` or `Awakening` |
+
+No header changes, no new members, no new dependencies.
 
 ---
 
 ## Risks & Considerations
 
-- **Stop latency increase**: Bounded to max 5s wait; mitigated by STOP-HIB-005 (proceed regardless on timeout).
+- **No stop latency increase**: The state transition is immediate; no waiting or blocking.
 - **Backward compatibility**: No D-Bus API change. Behavioral change is internal.
-- **Memcr partial checkpoint**: If abort happens mid-checkpoint, incomplete dump files may remain on disk. Cleanup should be handled by existing postHalt or wakeup logic.
+- **Memcr partial checkpoint**: At most one in-flight memcr call may fail. Incomplete dump files may remain on disk — cleanup handled by existing postHalt logic.
+- **Awakening state**: Same fix applies to wakeup operations (symmetric race with `WakeupProcess` calls).
 
 ---
 
@@ -127,12 +145,12 @@ sequenceDiagram
 |------|-------------|
 | Stop during active hibernation | Call hibernate, then immediately stop. Verify no memcr_worker crash and container stops cleanly. |
 | Stop after hibernation completes | Call hibernate, wait for completion, then stop. Verify no regression. |
-| Stop timeout exceeded | Simulate hung hibernation worker. Verify stop proceeds after 5s. |
-| Concurrent stop/hibernate races | Stress test with rapid stop/hibernate cycling. Verify no deadlocks or crashes. |
+| Stop during wakeup | Call wakeup, then immediately stop. Verify clean abort. |
+| Concurrent stop/hibernate races | Stress test with rapid stop/hibernate cycling. Verify no crashes. |
 
 ---
 
 ## References
 
-- [daemon-core.md](./daemon-core.md) — DobbyManager, DobbyHibernate, container state machine
+- [daemon-core.md](../daemon-core.md) — DobbyManager, DobbyHibernate, container state machine
 - [memcr](https://github.com/LibertyGlobal/memcr) — Checkpoint/restore service

--- a/openspec/specs/proposals/stop-hibernate-sync.md
+++ b/openspec/specs/proposals/stop-hibernate-sync.md
@@ -62,7 +62,8 @@ else if (container->state == DobbyContainer::State::Running ||
     // If the container is mid-hibernate, set state to
     // Stopping so the detached hibernate thread will see the
     // state change and abort before sending dead PIDs to memcr
-    if (container->state == DobbyContainer::State::Hibernating)
+    const bool wasHibernating = (container->state == DobbyContainer::State::Hibernating);
+    if (wasHibernating)
     {
         container->state = DobbyContainer::State::Stopping;
     }
@@ -70,6 +71,10 @@ else if (container->state == DobbyContainer::State::Running ||
     if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM))
     {
         AI_LOG_WARN("failed to send signal to '%s'", id.c_str());
+        if (wasHibernating)
+        {
+            container->state = DobbyContainer::State::Hibernating;
+        }
         AI_LOG_FN_EXIT();
         return false;
     }
@@ -78,9 +83,11 @@ else if (container->state == DobbyContainer::State::Running ||
 
 ### How It Works
 
-1. `stopContainer()` holds `mLock` and sets `state = Stopping`
-2. `stopContainer()` sends SIGKILL/SIGTERM and returns
-3. On the next per-PID iteration, the hibernation worker acquires `mLock`, sees `state != Hibernating`, logs a warning, and aborts — no further memcr calls on dead PIDs
+1. `stopContainer()` holds `mLock`, records `wasHibernating`, and sets `state = Stopping`
+2. `stopContainer()` sends SIGKILL/SIGTERM
+   - **On success**: returns; the hibernation worker sees `state != Hibernating` on its next iteration and aborts — no further memcr calls on dead PIDs
+   - **On failure**: restores `state = Hibernating` before returning `false`, keeping container state consistent and leaving the hibernation worker running uninterrupted
+3. The state rollback on failure is necessary because `Stopping` is a transient state only expected to resolve when the container's death event arrives — a live, still-hibernating container must not be left stranded in `Stopping`
 
 The worker may still have one in-flight memcr call when the kill happens (the call started before the state change), but that single failure is benign — the assert in memcr_worker is triggered by **repeated** operations on dead PIDs, not a single failed socket call.
 
@@ -94,8 +101,11 @@ The `Awakening` state does not need this protection because `WakeupProcess()` on
 Before:
   stopContainer() on Hibernating → SIGKILL (state unchanged → worker continues)
 
-After:
-  stopContainer() on Hibernating → state = Stopping → SIGKILL (worker aborts on next check)
+After (kill succeeds):
+  stopContainer() on Hibernating → state = Stopping → SIGKILL → worker aborts on next check
+
+After (kill fails):
+  stopContainer() on Hibernating → state = Stopping → killCont fails → state = Hibernating (restored) → return false
 ```
 
 ### Sequence Diagram
@@ -127,7 +137,7 @@ sequenceDiagram
 
 | File | Change |
 |------|--------|
-| `daemon/lib/source/DobbyManager.cpp` | `stopContainer()`: Set `state = Stopping` before `killCont()` when container is `Hibernating` |
+| `daemon/lib/source/DobbyManager.cpp` | `stopContainer()`: Set `state = Stopping` before `killCont()` when container is `Hibernating`; restore `state = Hibernating` if `killCont()` fails |
 
 No header changes, no new members, no new dependencies.
 
@@ -139,6 +149,7 @@ No header changes, no new members, no new dependencies.
 - **Backward compatibility**: No D-Bus API change. Behavioral change is internal.
 - **Memcr partial checkpoint**: At most one in-flight memcr call may fail. Incomplete dump files may remain on disk — cleanup handled by existing postHalt logic.
 - **Awakening state not affected**: `WakeupProcess()` on dead PIDs is benign (no assert), so no special handling needed for `Awakening`.
+- **State consistency on kill failure**: If `killCont()` fails, `state` is restored to `Hibernating` so the container is not stranded in `Stopping` while still alive and mid-hibernate.
 
 ---
 

--- a/openspec/specs/proposals/stop-hibernate-sync.md
+++ b/openspec/specs/proposals/stop-hibernate-sync.md
@@ -1,0 +1,138 @@
+# Proposal: Synchronize Dobby Stop with In-Progress Hibernation
+
+**Ticket**: RDKEMW-13969  
+**Status**: Proposed  
+**Component**: daemon-core (DobbyManager)
+
+---
+
+## Problem Statement
+
+There is no synchronization between `DobbyManager::stopContainer()` and an in-progress `hibernateContainer()` operation. When Stop is invoked while a hibernation is underway, the container processes are killed (SIGKILL/SIGTERM) while `memcr_worker` is still performing checkpoint operations on those PIDs. This causes `memcr_worker` to crash on an assert when it encounters errors operating on terminated processes.
+
+**Impact**: Non-harmful to user experience or memcr stability, but produces misleading crash reports that waste QA investigation time.
+
+---
+
+## Root Cause Analysis
+
+### Current Behavior
+
+1. `hibernateContainer()` acquires `mLock`, sets state to `Hibernating`, spawns a **detached** thread, and releases the lock.
+2. The hibernation worker thread releases `mLock` during long-running socket I/O with memcr (up to 20s timeout per PID).
+3. `stopContainer()` acquires `mLock`, sees the container in `Hibernating` state, and immediately sends SIGKILL — **with no coordination** with the hibernation thread.
+4. The hibernation thread continues issuing memcr checkpoint commands against now-dead PIDs, triggering asserts in `memcr_worker`.
+
+### Race Window
+
+```
+t0: hibernateContainer() → state = Hibernating, detach worker thread
+t1: worker releases mLock, begins memcr socket I/O (per-PID, ~20s timeout)
+      ↓ UNPROTECTED WINDOW
+t2: stopContainer() acquires mLock, sends SIGKILL
+t3: worker's memcr calls fail → memcr_worker assert crash
+```
+
+### Existing Abort Mechanism (insufficient)
+
+The hibernation worker checks for abort only at one point:
+```cpp
+if (container not found || state != Hibernating) → abort
+```
+But `stopContainer()` never changes the state away from `Hibernating` before killing — it treats `Hibernating` the same as `Running`.
+
+---
+
+## Proposed Solution
+
+`stopContainer()` SHALL abort any ongoing hibernation **before** terminating container processes:
+
+### Algorithm
+
+1. **Detect in-progress hibernation**: If container state is `Hibernating`, trigger abort.
+2. **Signal abort**: Transition state to `Stopping` (which causes the hibernation worker's state check to detect the abort and return early).
+3. **Wait for hibernation worker to exit** (bounded timeout, e.g., 5s).
+4. **Proceed with stop**: Send SIGTERM/SIGKILL to container processes as normal.
+
+### Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| STOP-HIB-001 | `stopContainer()` SHALL detect when a container is in `Hibernating` state and abort the hibernation before killing processes. | Must |
+| STOP-HIB-002 | The hibernation worker thread SHALL check container state at each per-PID iteration and abort if state is no longer `Hibernating`. | Must |
+| STOP-HIB-003 | `stopContainer()` SHALL wait a bounded time (max 5s) for the hibernation worker to acknowledge the abort before proceeding with kill. | Must |
+| STOP-HIB-004 | The hibernation worker thread SHALL be tracked (joinable) rather than detached, to allow orderly cleanup. | Should |
+| STOP-HIB-005 | If the hibernation worker does not exit within the timeout, `stopContainer()` SHALL proceed with kill regardless. | Must |
+| STOP-HIB-006 | A condition variable or event mechanism SHALL be used to signal between the stop path and hibernation worker. | Should |
+
+### State Transition Change
+
+```
+Current:
+  stopContainer() on Hibernating → SIGKILL (no state change before kill)
+
+Proposed:
+  stopContainer() on Hibernating → state = Stopping → wait for worker abort → SIGKILL
+```
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant DobbyManager
+    participant HibernateWorker
+    participant memcr
+    participant Container
+
+    Note over HibernateWorker,memcr: Hibernation in progress...
+    HibernateWorker->>memcr: MEMCR_CHECKPOINT(pid)
+    
+    Client->>DobbyManager: stopContainer(id)
+    DobbyManager->>DobbyManager: state = Stopping
+    DobbyManager->>DobbyManager: notify condVar
+    DobbyManager->>DobbyManager: wait(condVar, 5s)
+    
+    HibernateWorker->>HibernateWorker: check state != Hibernating
+    HibernateWorker->>DobbyManager: signal abort complete
+    
+    DobbyManager->>Container: SIGTERM / SIGKILL
+    DobbyManager->>Client: container stopped
+```
+
+---
+
+## Affected Code
+
+| File | Change |
+|------|--------|
+| `daemon/lib/source/DobbyManager.cpp` | `stopContainer()`: Add hibernation abort logic before kill |
+| `daemon/lib/source/DobbyManager.cpp` | Hibernate worker lambda: Add per-PID state check, use condVar for abort signaling |
+| `daemon/lib/source/include/DobbyManager.h` | Add `std::condition_variable` member for hibernate/stop sync |
+| `daemon/lib/source/include/DobbyContainer.h` | (Optional) Track hibernate thread as joinable |
+
+---
+
+## Risks & Considerations
+
+- **Stop latency increase**: Bounded to max 5s wait; mitigated by STOP-HIB-005 (proceed regardless on timeout).
+- **Backward compatibility**: No D-Bus API change. Behavioral change is internal.
+- **Memcr partial checkpoint**: If abort happens mid-checkpoint, incomplete dump files may remain on disk. Cleanup should be handled by existing postHalt or wakeup logic.
+
+---
+
+## Test Plan
+
+| Test | Description |
+|------|-------------|
+| Stop during active hibernation | Call hibernate, then immediately stop. Verify no memcr_worker crash and container stops cleanly. |
+| Stop after hibernation completes | Call hibernate, wait for completion, then stop. Verify no regression. |
+| Stop timeout exceeded | Simulate hung hibernation worker. Verify stop proceeds after 5s. |
+| Concurrent stop/hibernate races | Stress test with rapid stop/hibernate cycling. Verify no deadlocks or crashes. |
+
+---
+
+## References
+
+- [daemon-core.md](./daemon-core.md) — DobbyManager, DobbyHibernate, container state machine
+- [memcr](https://github.com/LibertyGlobal/memcr) — Checkpoint/restore service

--- a/openspec/specs/proposals/stop-hibernate-sync.md
+++ b/openspec/specs/proposals/stop-hibernate-sync.md
@@ -49,7 +49,7 @@ Leverage the existing abort mechanism in the hibernation worker by setting `stat
 
 ### Implementation
 
-In `stopContainer()`, when the container is in `Hibernating` or `Awakening` state, transition to `Stopping` before calling `killCont()`:
+In `stopContainer()`, when the container is in `Hibernating` state, transition to `Stopping` before calling `killCont()`:
 
 ```cpp
 // if in Running/Hibernated/Hibernating/Awakening state then use runc to send
@@ -59,11 +59,10 @@ else if (container->state == DobbyContainer::State::Running ||
          container->state == DobbyContainer::State::Hibernated ||
          container->state == DobbyContainer::State::Awakening)
 {
-    // If the container is mid-hibernate or mid-wakeup, set state to
-    // Stopping so the detached hibernate/wakeup thread will see the
+    // If the container is mid-hibernate, set state to
+    // Stopping so the detached hibernate thread will see the
     // state change and abort before sending dead PIDs to memcr
-    if (container->state == DobbyContainer::State::Hibernating ||
-        container->state == DobbyContainer::State::Awakening)
+    if (container->state == DobbyContainer::State::Hibernating)
     {
         container->state = DobbyContainer::State::Stopping;
     }
@@ -84,6 +83,10 @@ else if (container->state == DobbyContainer::State::Running ||
 3. On the next per-PID iteration, the hibernation worker acquires `mLock`, sees `state != Hibernating`, logs a warning, and aborts — no further memcr calls on dead PIDs
 
 The worker may still have one in-flight memcr call when the kill happens (the call started before the state change), but that single failure is benign — the assert in memcr_worker is triggered by **repeated** operations on dead PIDs, not a single failed socket call.
+
+### Why only Hibernating (not Awakening)
+
+The `Awakening` state does not need this protection because `WakeupProcess()` on dead PIDs is benign — it simply returns an error without triggering asserts in `memcr_worker`. Only `HibernateProcess()` causes the problematic assert when operating on terminated processes.
 
 ### State Transition
 
@@ -124,7 +127,7 @@ sequenceDiagram
 
 | File | Change |
 |------|--------|
-| `daemon/lib/source/DobbyManager.cpp` | `stopContainer()`: Set `state = Stopping` before `killCont()` when container is `Hibernating` or `Awakening` |
+| `daemon/lib/source/DobbyManager.cpp` | `stopContainer()`: Set `state = Stopping` before `killCont()` when container is `Hibernating` |
 
 No header changes, no new members, no new dependencies.
 
@@ -135,7 +138,7 @@ No header changes, no new members, no new dependencies.
 - **No stop latency increase**: The state transition is immediate; no waiting or blocking.
 - **Backward compatibility**: No D-Bus API change. Behavioral change is internal.
 - **Memcr partial checkpoint**: At most one in-flight memcr call may fail. Incomplete dump files may remain on disk — cleanup handled by existing postHalt logic.
-- **Awakening state**: Same fix applies to wakeup operations (symmetric race with `WakeupProcess` calls).
+- **Awakening state not affected**: `WakeupProcess()` on dead PIDs is benign (no assert), so no special handling needed for `Awakening`.
 
 ---
 
@@ -145,7 +148,7 @@ No header changes, no new members, no new dependencies.
 |------|-------------|
 | Stop during active hibernation | Call hibernate, then immediately stop. Verify no memcr_worker crash and container stops cleanly. |
 | Stop after hibernation completes | Call hibernate, wait for completion, then stop. Verify no regression. |
-| Stop during wakeup | Call wakeup, then immediately stop. Verify clean abort. |
+| Stop during wakeup | Call wakeup, then immediately stop. Verify container stops cleanly (wakeup calls on dead PIDs are benign). |
 | Concurrent stop/hibernate races | Stress test with rapid stop/hibernate cycling. Verify no crashes. |
 
 ---


### PR DESCRIPTION
### Description
In stopContainer(), when the container is in the Hibernating state, transition state to Stopping before calling killCont(). This is a minimal, non-invasive change that leverages the existing abort logic in the hibernation worker:

1. stopContainer() sets state = Stopping
2. stopContainer() sends SIGKILL/SIGTERM and returns immediately (no added latency)
3. On its next per-PID iteration, the hibernation worker sees state != Hibernating and aborts — no further memcr calls on dead PIDs

### Test Procedure
Stress test with rapid stop/hibernate cycling and verify no crashes.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)