### PR TITLE
RDKEMW-13969: Fix race condition between stopContainer() and hibernateContainer()

### DIFF
--- a/daemon/lib/source/DobbyContainer.cpp
+++ b/daemon/lib/source/DobbyContainer.cpp
@@ -110,6 +110,7 @@ DobbyContainer::DobbyContainer(const std::shared_ptr<const DobbyBundle>& _bundle
     , containerPid(-1)
     , hasCurseOfDeath(false)
     , state(State::Starting)
+    , hibernatingPid(0)
     , mRestartOnCrash(false)
     , mRestartCount(0)
 {
@@ -127,6 +128,7 @@ DobbyContainer::DobbyContainer(const std::shared_ptr<const DobbyBundle>& _bundle
     , containerPid(-1)
     , hasCurseOfDeath(false)
     , state(State::Starting)
+    , hibernatingPid(0)
     , mRestartOnCrash(false)
     , mRestartCount(0)
 {

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1319,8 +1319,13 @@ bool DobbyManager::restartContainer(const ContainerId &id,
  *
  *  If the withPrejudice is true then we use the SIGKILL signal.
  *
- *  This call is asynchronous, i.e. it is a request to stop rather than a
- *  blocking call that ensures the container is stopped before returning.
+ *  The kill signal itself is sent asynchronously (the actual container teardown
+ *  happens in the background and @a mContainerStoppedCb is called when it
+ *  completes). However, if the container is in the Hibernating state when this
+ *  is called, the function will block for up to DobbyHibernate::DFL_TIMEOUTE_MS
+ *  while aborting the in-progress hibernation via WakeupProcess() before
+ *  sending the kill signal. This is necessary to ensure memcr_worker has
+ *  unseized the in-flight PID before it is killed.
  *
  *  The @a mContainerStoppedCb callback will be called when the container
  *  has actually been torn down.
@@ -1796,7 +1801,7 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd)
 {
     AI_LOG_FN_ENTRY();
 
-    // find the container (mLock already held by caller via locker)
+    // find the container (mLock must already be held by the caller)
     auto it = mContainers.cbegin();
     for (; it != mContainers.cend(); ++it)
     {

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1390,23 +1390,9 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
         // memcr_worker when it tries to operate on a terminated PID.
         if (container->state == DobbyContainer::State::Hibernating)
         {
-            if (!abortContainerHibernationIfNeeded(cd, locker))
+            if (!abortContainerHibernationIfNeeded(cd))
             {
                 AI_LOG_WARN("failed to abort hibernation for container %d", cd);
-                AI_LOG_FN_EXIT();
-                return false;
-            }
-            // Re-find the container; abortContainerHibernationIfNeeded released
-            // and reacquired mLock internally.
-            it = mContainers.cbegin();
-            for (; it != mContainers.cend(); ++it)
-            {
-                if (it->second && (it->second->descriptor == cd))
-                    break;
-            }
-            if (it == mContainers.cend())
-            {
-                AI_LOG_WARN("container %d not found after aborting hibernation", cd);
                 AI_LOG_FN_EXIT();
                 return false;
             }
@@ -1790,25 +1776,23 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
  *  which is written under mLock immediately before each HibernateProcess() call
  *  and cleared under mLock when the full hibernation sequence completes.
  *
+ *  mLock is held throughout this function, including during the WakeupProcess
+ *  call. The hibernate thread is blocked inside HibernateProcess() (a memcr
+ *  socket call) when inflightPid != 0 and does not hold mLock at that point,
+ *  so there is no deadlock risk.
+ *
  *  Unlike wakeupContainer(), this runs entirely on the calling thread (no new
  *  thread spawned) and does not emit the awoken callback.
  *
  *  @param[in]  cd      The descriptor of the container to abort hibernation for.
- *  @param[in]  locker  The unique_lock already held by the caller; released
- *                      internally around the WakeupProcess call and reacquired
- *                      before returning.
  *
- *  @return true on success (or if no abort was needed); false in any of these
- *          cases:
- *            - the container was not found by descriptor at entry,
+ *  @return true on success (or if no abort was needed); false if:
+ *            - the container was not found by descriptor at entry, or
  *            - WakeupProcess() failed for the in-flight PID (state is reverted
- *              to Hibernating so the hibernate thread can complete on its own),
- *            - the container was removed from mContainers while the lock was
- *              released around the WakeupProcess() call.
+ *              to Hibernating so the hibernate thread can complete on its own).
  *          Callers must not proceed with killCont() when false is returned.
  */
-bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
-                                                     std::unique_lock<std::mutex>& locker)
+bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd)
 {
     AI_LOG_FN_ENTRY();
 
@@ -1850,12 +1834,12 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
 
     if (inflightPid != 0)
     {
-        // Release mLock while we block on the memcr socket call.
-        locker.unlock();
-
         // WakeupProcess sends MEMCR_RESTORE for the single in-flight PID.
         // memcr responds by calling unseize_target() and returning, after which
         // it is safe to SIGKILL the process.
+        // The hibernate thread is blocked inside HibernateProcess() at this
+        // point and does not hold mLock, so calling WakeupProcess under mLock
+        // is safe — there is no deadlock risk.
         // Previously-checkpointed PIDs need no wakeup: they are frozen but
         // respond to SIGKILL normally (memcr holds no ptrace seize on them).
         // Future PIDs will not be reached because state is now Awakening.
@@ -1863,58 +1847,23 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
                     id.c_str(), inflightPid);
         const DobbyHibernate::Error wakeRet = DobbyHibernate::WakeupProcess(static_cast<pid_t>(inflightPid));
 
-        locker.lock();
-
         if (wakeRet != DobbyHibernate::Error::ErrorNone)
         {
+            // WakeupProcess failed. Revert state to Hibernating so the hibernate
+            // thread can complete on its own.
+            it->second->state = DobbyContainer::State::Hibernating;
             AI_LOG_WARN("WakeupProcess failed for in-flight PID %u (ret=%d) while aborting hibernation of '%s'",
                         inflightPid, static_cast<int>(wakeRet), id.c_str());
-
-            // Revert the container state from Awakening back to Hibernating so
-            // the container is not left permanently stuck. The hibernate thread
-            // is still running and will complete (or fail) on its own.
-            it = mContainers.cbegin();
-            for (; it != mContainers.cend(); ++it)
-            {
-                if (it->second && (it->second->descriptor == cd))
-                    break;
-            }
-            if (it != mContainers.cend() &&
-                it->second->state == DobbyContainer::State::Awakening)
-            {
-                it->second->state = DobbyContainer::State::Hibernating;
-            }
-
             AI_LOG_FN_EXIT();
             return false;
         }
 
-        // Re-find the container: it may have been removed while the lock was released.
-        it = mContainers.cbegin();
-        for (; it != mContainers.cend(); ++it)
-        {
-            if (it->second && (it->second->descriptor == cd))
-                break;
-        }
-        if (it == mContainers.cend())
-        {
-            AI_LOG_WARN("container '%s'(%d) removed during hibernation abort", id.c_str(), cd);
-            AI_LOG_FN_EXIT();
-            return false;
-        }
-
-        // mLock is held again (locker.lock() above). Clear correlated fields
-        // inside this branch so the lock state is locally unambiguous.
         it->second->hibernatingPid = 0;
         it->second->state = DobbyContainer::State::Running;
     }
     else
     {
-        AI_LOG_INFO("Aborting hibernation of '%s': no in-flight PID, state set to Awakening",
-                    id.c_str());
-
-        // mLock was never released in this branch. Clear correlated fields here
-        // so the lock state is locally unambiguous.
+        AI_LOG_INFO("Aborting hibernation of '%s': no in-flight PID", id.c_str());
         it->second->hibernatingPid = 0;
         it->second->state = DobbyContainer::State::Running;
     }

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1403,9 +1403,9 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
             }
         }
 
-        if (!mRunc->killCont(it->first, withPrejudice ? SIGKILL : SIGTERM))
+        if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM))
         {
-            AI_LOG_WARN("failed to send signal to '%s'", it->first.c_str());
+            AI_LOG_WARN("failed to send signal to '%s'", id.c_str());
             AI_LOG_FN_EXIT();
             return false;
         }
@@ -1820,8 +1820,10 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
  *
  *  @return true on success (or if no abort was needed); false if:
  *            - the container was not found by descriptor at entry, or
- *            - WakeupProcess() failed for the in-flight PID (state is reverted
- *              to Hibernating so the hibernate thread can complete on its own).
+ *            - WakeupProcess() failed for the in-flight PID (state is set to
+ *              Stopping so that cleanupContainersShutdown() does not attempt a
+ *              redundant killCont(); the hibernate thread will see
+ *              state != Hibernating and abort its loop).
  *          Callers must not proceed with killCont() when false is returned.
  */
 bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd)

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1392,7 +1392,7 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
         {
             if (!abortContainerHibernationIfNeeded(cd, locker))
             {
-                AI_LOG_WARN("container %d was removed while aborting hibernation", cd);
+                AI_LOG_WARN("failed to abort hibernation for container %d", cd);
                 AI_LOG_FN_EXIT();
                 return false;
             }

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1672,8 +1672,17 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
             DobbyHibernate::Error ret = DobbyHibernate::Error::ErrorNone;
             // create a stats object for the container to get list of PIDs
             std::unique_lock<std::mutex> locker(mLock);
-            DobbyStats stats(id, mEnvironment, mUtilities);
-            Json::Value jsonPids = DobbyStats(id, mEnvironment, mUtilities).stats()["pids"];
+            // Bind to a named DobbyStats object so that the reference returned by
+            // stats() remains valid while we access it.
+            DobbyStats statsObj(id, mEnvironment, mUtilities);
+            const Json::Value &statsJson = statsObj.stats();
+            if (!statsJson.isObject())
+            {
+                AI_LOG_WARN("Stats for container '%s' is not a JSON object, cannot hibernate", id.c_str());
+                return;
+            }
+            Json::Value jsonPids = statsJson["pids"];
+
             locker.unlock();
 
             for (auto pidIt = jsonPids.begin(); pidIt != jsonPids.end(); ++pidIt)
@@ -1704,6 +1713,24 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
 
                 ret  = DobbyHibernate::HibernateProcess(pid, DobbyHibernate::DFL_TIMEOUTE_MS,
                         DobbyHibernate::DFL_LOCATOR, dest, compress);
+
+                // Clear hibernatingPid immediately after HibernateProcess returns so that
+                // the field always reflects "currently inside HibernateProcess".  The next
+                // iteration will overwrite it with the new in-flight PID while holding mLock.
+                // Without this clear, stopContainer() arriving between iterations would see a
+                // stale non-zero hibernatingPid and call WakeupProcess on an already-
+                // checkpointed (frozen) PID, potentially unfreezing it prematurely.
+                locker.lock();
+                {
+                    auto clearIt = mContainers.find(id);
+                    if (clearIt != mContainers.end() && clearIt->second &&
+                        clearIt->second->descriptor == cd)
+                    {
+                        clearIt->second->hibernatingPid = 0;
+                    }
+                }
+                locker.unlock();
+
                 if (ret != DobbyHibernate::Error::ErrorNone)
                 {
                     AI_LOG_WARN("Error hibernating pid: '%d'", pid);
@@ -1854,9 +1881,12 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd)
 
         if (wakeRet != DobbyHibernate::Error::ErrorNone)
         {
-            // WakeupProcess failed. Revert state to Hibernating so the hibernate
-            // thread can complete on its own.
-            it->second->state = DobbyContainer::State::Hibernating;
+            // WakeupProcess failed. We cannot safely issue killCont() while memcr
+            // holds an active ptrace seize on this PID. Mark the container as
+            // Stopping so that subsequent cleanup paths do not attempt killCont()
+            // (which would crash memcr_worker). The hibernate thread will see
+            // state != Hibernating and abort its loop.
+            it->second->state = DobbyContainer::State::Stopping;
             AI_LOG_WARN("WakeupProcess failed for in-flight PID %u (ret=%d) while aborting hibernation of '%s'",
                         inflightPid, static_cast<int>(wakeRet), id.c_str());
             AI_LOG_FN_EXIT();
@@ -1864,13 +1894,13 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd)
         }
 
         it->second->hibernatingPid = 0;
-        it->second->state = DobbyContainer::State::Running;
+        it->second->state = DobbyContainer::State::Stopping;
     }
     else
     {
         AI_LOG_INFO("Aborting hibernation of '%s': no in-flight PID", id.c_str());
         it->second->hibernatingPid = 0;
-        it->second->state = DobbyContainer::State::Running;
+        it->second->state = DobbyContainer::State::Stopping;
     }
 
     AI_LOG_INFO("Hibernation abort of '%s' complete", id.c_str());

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1336,7 +1336,7 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
 {
     AI_LOG_FN_ENTRY();
 
-    std::lock_guard<std::mutex> locker(mLock);
+    std::unique_lock<std::mutex> locker(mLock);
 
     // find the container
     auto it = mContainers.cbegin();
@@ -1384,9 +1384,37 @@ bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
              container->state == DobbyContainer::State::Hibernated ||
              container->state == DobbyContainer::State::Awakening)
     {
-        if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM))
+        // If a hibernation is in progress, abort it in a blocking manner before
+        // killing the container. This ensures memcr_worker fully unseizes any
+        // in-flight PID before it is killed, preventing an assert crash in
+        // memcr_worker when it tries to operate on a terminated PID.
+        if (container->state == DobbyContainer::State::Hibernating)
         {
-            AI_LOG_WARN("failed to send signal to '%s'", id.c_str());
+            if (!abortContainerHibernationIfNeeded(cd, locker))
+            {
+                AI_LOG_WARN("container %d was removed while aborting hibernation", cd);
+                AI_LOG_FN_EXIT();
+                return false;
+            }
+            // Re-find the container; abortContainerHibernationIfNeeded released
+            // and reacquired mLock internally.
+            it = mContainers.cbegin();
+            for (; it != mContainers.cend(); ++it)
+            {
+                if (it->second && (it->second->descriptor == cd))
+                    break;
+            }
+            if (it == mContainers.cend())
+            {
+                AI_LOG_WARN("container %d not found after aborting hibernation", cd);
+                AI_LOG_FN_EXIT();
+                return false;
+            }
+        }
+
+        if (!mRunc->killCont(it->first, withPrejudice ? SIGKILL : SIGTERM))
+        {
+            AI_LOG_WARN("failed to send signal to '%s'", it->first.c_str());
             AI_LOG_FN_EXIT();
             return false;
         }
@@ -1660,17 +1688,29 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
             for (auto pidIt = jsonPids.begin(); pidIt != jsonPids.end(); ++pidIt)
             {
                 locker.lock();
-                if (mContainers.find(id) == mContainers.end() ||
-                    mContainers[id]->descriptor != cd ||
-                    mContainers[id]->state != DobbyContainer::State::Hibernating)
+                auto containerIt = mContainers.find(id);
+                if (containerIt == mContainers.end() ||
+                    containerIt->second->descriptor != cd ||
+                    containerIt->second->state != DobbyContainer::State::Hibernating)
                 {
                     AI_LOG_WARN("Hibernation of: %s with descriptor %d aborted", id.c_str(), cd);
+                    // Only clear hibernatingPid when the container still exists with
+                    // a matching descriptor. If it was removed entirely there is nothing to clear.
+                    if (containerIt != mContainers.end() && containerIt->second &&
+                        containerIt->second->descriptor == cd)
+                    {
+                        containerIt->second->hibernatingPid = 0;
+                    }
                     AI_LOG_FN_EXIT();
                     return;
                 }
+                // Record the in-flight PID while mLock is held so that
+                // abortContainerHibernationIfNeeded can read it atomically and
+                // issue a targeted WakeupProcess for exactly this one PID.
+                uint32_t pid = pidIt->asUInt();
+                mContainers[id]->hibernatingPid = pid;
                 locker.unlock();
 
-                uint32_t pid = pidIt->asUInt();
                 ret  = DobbyHibernate::HibernateProcess(pid, DobbyHibernate::DFL_TIMEOUTE_MS,
                         DobbyHibernate::DFL_LOCATOR, dest, compress);
                 if (ret != DobbyHibernate::Error::ErrorNone)
@@ -1699,6 +1739,11 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
                 return;
             }
 
+            // Clear the in-flight PID before the state transition so that any
+            // concurrent abortContainerHibernationIfNeeded sees hibernatingPid==0
+            // and skips the WakeupProcess call.
+            mContainers[id]->hibernatingPid = 0;
+
             if (mContainers[id]->state != DobbyContainer::State::Hibernating)
             {
                 AI_LOG_WARN("container state (%s) is not hibernating", id.c_str());
@@ -1724,6 +1769,120 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
     it->second->state = DobbyContainer::State::Hibernating;
     hibernateThread.detach();
     AI_LOG_INFO("Hibernation of: %s triggered", id.c_str());
+    AI_LOG_FN_EXIT();
+    return true;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ *  @brief Blocking abort of any in-progress hibernation for a container.
+ *
+ *  If the container is in the Hibernating state, sets the state to Awakening
+ *  (which signals the hibernate thread to stop iterating) and then calls
+ *  WakeupProcess for the **single in-flight PID** currently being checkpointed,
+ *  if any. Only this one PID needs a wakeup: memcr holds a ptrace seize on it
+ *  and sending SIGKILL while that seize is active triggers an assert in
+ *  memcr_worker. Previously-checkpointed PIDs are frozen but have no active
+ *  seize and respond to SIGKILL normally. Future PIDs are prevented from
+ *  starting by the Awakening state check in the hibernate thread.
+ *
+ *  The in-flight PID is read atomically from DobbyContainer::hibernatingPid,
+ *  which is written under mLock immediately before each HibernateProcess() call
+ *  and cleared under mLock when the full hibernation sequence completes.
+ *
+ *  Unlike wakeupContainer(), this runs entirely on the calling thread (no new
+ *  thread spawned) and does not emit the awoken callback.
+ *
+ *  @param[in]  cd      The descriptor of the container to abort hibernation for.
+ *  @param[in]  locker  The unique_lock already held by the caller; released
+ *                      internally around the WakeupProcess call and reacquired
+ *                      before returning.
+ *
+ *  @return true on success (or if no abort was needed); false if the container
+ *          was removed from mContainers while the lock was released.
+ */
+bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
+                                                     std::unique_lock<std::mutex>& locker)
+{
+    AI_LOG_FN_ENTRY();
+
+    // find the container (mLock already held by caller via locker)
+    auto it = mContainers.cbegin();
+    for (; it != mContainers.cend(); ++it)
+    {
+        if (it->second && (it->second->descriptor == cd))
+            break;
+    }
+
+    if (it == mContainers.cend())
+    {
+        AI_LOG_WARN("failed to find container with descriptor %d", cd);
+        AI_LOG_FN_EXIT();
+        return false;
+    }
+
+    const ContainerId &id = it->first;
+
+    if (it->second->state != DobbyContainer::State::Hibernating)
+    {
+        AI_LOG_INFO("Container '%s' is not hibernating, abort not needed", id.c_str());
+        AI_LOG_FN_EXIT();
+        return true;
+    }
+
+    // Read the in-flight PID while mLock is held. This is the single PID
+    // currently inside DobbyHibernate::HibernateProcess() — memcr holds a
+    // ptrace seize on it. Sending SIGKILL while that seize is active triggers
+    // assert(WIFSTOPPED(status)) inside memcr_worker. We must drive memcr to
+    // unseize_target() for this PID before issuing killCont().
+    const uint32_t inflightPid = it->second->hibernatingPid;
+
+    // Set state to Awakening: the hibernate thread checks this at the top of
+    // each PID loop iteration and will abort before starting any further
+    // HibernateProcess() call.
+    it->second->state = DobbyContainer::State::Awakening;
+
+    if (inflightPid != 0)
+    {
+        // Release mLock while we block on the memcr socket call.
+        locker.unlock();
+
+        // WakeupProcess sends MEMCR_RESTORE for the single in-flight PID.
+        // memcr responds by calling unseize_target() and returning, after which
+        // it is safe to SIGKILL the process.
+        // Previously-checkpointed PIDs need no wakeup: they are frozen but
+        // respond to SIGKILL normally (memcr holds no ptrace seize on them).
+        // Future PIDs will not be reached because state is now Awakening.
+        AI_LOG_INFO("Aborting hibernation of '%s': sending WakeupProcess for in-flight PID %u",
+                    id.c_str(), inflightPid);
+        DobbyHibernate::WakeupProcess(static_cast<pid_t>(inflightPid));
+
+        locker.lock();
+
+        // Re-find the container: it may have been removed while the lock was released.
+        it = mContainers.cbegin();
+        for (; it != mContainers.cend(); ++it)
+        {
+            if (it->second && (it->second->descriptor == cd))
+                break;
+        }
+        if (it == mContainers.cend())
+        {
+            AI_LOG_WARN("container '%s'(%d) removed during hibernation abort", id.c_str(), cd);
+            AI_LOG_FN_EXIT();
+            return false;
+        }
+    }
+    else
+    {
+        AI_LOG_INFO("Aborting hibernation of '%s': no in-flight PID, state set to Awakening",
+                    id.c_str());
+    }
+
+    // Restore state to Running so the caller's killCont() path proceeds normally.
+    it->second->state = DobbyContainer::State::Running;
+
+    AI_LOG_INFO("Hibernation abort of '%s' complete", id.c_str());
     AI_LOG_FN_EXIT();
     return true;
 }

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1708,7 +1708,7 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
                 // abortContainerHibernationIfNeeded can read it atomically and
                 // issue a targeted WakeupProcess for exactly this one PID.
                 uint32_t pid = pidIt->asUInt();
-                mContainers[id]->hibernatingPid = pid;
+                containerIt->second->hibernatingPid = pid;
                 locker.unlock();
 
                 ret  = DobbyHibernate::HibernateProcess(pid, DobbyHibernate::DFL_TIMEOUTE_MS,
@@ -1821,7 +1821,7 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
         return false;
     }
 
-    const ContainerId &id = it->first;
+    const ContainerId id = it->first;
 
     if (it->second->state != DobbyContainer::State::Hibernating)
     {
@@ -1855,9 +1855,17 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
         // Future PIDs will not be reached because state is now Awakening.
         AI_LOG_INFO("Aborting hibernation of '%s': sending WakeupProcess for in-flight PID %u",
                     id.c_str(), inflightPid);
-        DobbyHibernate::WakeupProcess(static_cast<pid_t>(inflightPid));
+        const DobbyHibernate::Error wakeRet = DobbyHibernate::WakeupProcess(static_cast<pid_t>(inflightPid));
 
         locker.lock();
+
+        if (wakeRet != DobbyHibernate::Error::ErrorNone)
+        {
+            AI_LOG_WARN("WakeupProcess failed for in-flight PID %u (ret=%d) while aborting hibernation of '%s'",
+                        inflightPid, static_cast<int>(wakeRet), id.c_str());
+            AI_LOG_FN_EXIT();
+            return false;
+        }
 
         // Re-find the container: it may have been removed while the lock was released.
         it = mContainers.cbegin();
@@ -1872,15 +1880,22 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
             AI_LOG_FN_EXIT();
             return false;
         }
+
+        // mLock is held again (locker.lock() above). Clear correlated fields
+        // inside this branch so the lock state is locally unambiguous.
+        it->second->hibernatingPid = 0;
+        it->second->state = DobbyContainer::State::Running;
     }
     else
     {
         AI_LOG_INFO("Aborting hibernation of '%s': no in-flight PID, state set to Awakening",
                     id.c_str());
-    }
 
-    // Restore state to Running so the caller's killCont() path proceeds normally.
-    it->second->state = DobbyContainer::State::Running;
+        // mLock was never released in this branch. Clear correlated fields here
+        // so the lock state is locally unambiguous.
+        it->second->hibernatingPid = 0;
+        it->second->state = DobbyContainer::State::Running;
+    }
 
     AI_LOG_INFO("Hibernation abort of '%s' complete", id.c_str());
     AI_LOG_FN_EXIT();

--- a/daemon/lib/source/DobbyManager.cpp
+++ b/daemon/lib/source/DobbyManager.cpp
@@ -1798,8 +1798,14 @@ bool DobbyManager::hibernateContainer(int32_t cd, const std::string& options)
  *                      internally around the WakeupProcess call and reacquired
  *                      before returning.
  *
- *  @return true on success (or if no abort was needed); false if the container
- *          was removed from mContainers while the lock was released.
+ *  @return true on success (or if no abort was needed); false in any of these
+ *          cases:
+ *            - the container was not found by descriptor at entry,
+ *            - WakeupProcess() failed for the in-flight PID (state is reverted
+ *              to Hibernating so the hibernate thread can complete on its own),
+ *            - the container was removed from mContainers while the lock was
+ *              released around the WakeupProcess() call.
+ *          Callers must not proceed with killCont() when false is returned.
  */
 bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
                                                      std::unique_lock<std::mutex>& locker)
@@ -1863,6 +1869,22 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
         {
             AI_LOG_WARN("WakeupProcess failed for in-flight PID %u (ret=%d) while aborting hibernation of '%s'",
                         inflightPid, static_cast<int>(wakeRet), id.c_str());
+
+            // Revert the container state from Awakening back to Hibernating so
+            // the container is not left permanently stuck. The hibernate thread
+            // is still running and will complete (or fail) on its own.
+            it = mContainers.cbegin();
+            for (; it != mContainers.cend(); ++it)
+            {
+                if (it->second && (it->second->descriptor == cd))
+                    break;
+            }
+            if (it != mContainers.cend() &&
+                it->second->state == DobbyContainer::State::Awakening)
+            {
+                it->second->state = DobbyContainer::State::Hibernating;
+            }
+
             AI_LOG_FN_EXIT();
             return false;
         }

--- a/daemon/lib/source/include/DobbyContainer.h
+++ b/daemon/lib/source/include/DobbyContainer.h
@@ -94,7 +94,7 @@ public:
     // HibernateProcess() call, and cleared under mLock when the full
     // hibernation sequence is complete. Allows abortContainerHibernationIfNeeded
     // to issue a targeted WakeupProcess only for the one in-flight PID.
-    uint32_t hibernatingPid;
+    uint32_t hibernatingPid = 0;
 
 public:
     void setRestartOnCrash(const std::list<int>& files);

--- a/daemon/lib/source/include/DobbyContainer.h
+++ b/daemon/lib/source/include/DobbyContainer.h
@@ -89,6 +89,13 @@ public:
     enum class State { Starting, Running, Stopping, Paused, Hibernating, Hibernated, Awakening, Unknown } state;
     std::string customConfigFilePath;
 
+    // PID currently being passed to DobbyHibernate::HibernateProcess.
+    // Written under mLock immediately before mLock is released for each
+    // HibernateProcess() call, and cleared under mLock when the full
+    // hibernation sequence is complete. Allows abortContainerHibernationIfNeeded
+    // to issue a targeted WakeupProcess only for the one in-flight PID.
+    uint32_t hibernatingPid;
+
 public:
     void setRestartOnCrash(const std::list<int>& files);
     void clearRestartOnCrash();

--- a/daemon/lib/source/include/DobbyManager.h
+++ b/daemon/lib/source/include/DobbyManager.h
@@ -182,7 +182,7 @@ private:
     bool restartContainer(const ContainerId& id,
                           const std::unique_ptr<DobbyContainer>& container);
 
-    bool abortContainerHibernationIfNeeded(int32_t cd, std::unique_lock<std::mutex>& locker);
+    bool abortContainerHibernationIfNeeded(int32_t cd);
 
 private:
     ContainerStartedFunc mContainerStartedCb;

--- a/daemon/lib/source/include/DobbyManager.h
+++ b/daemon/lib/source/include/DobbyManager.h
@@ -182,6 +182,8 @@ private:
     bool restartContainer(const ContainerId& id,
                           const std::unique_ptr<DobbyContainer>& container);
 
+    bool abortContainerHibernationIfNeeded(int32_t cd, std::unique_lock<std::mutex>& locker);
+
 private:
     ContainerStartedFunc mContainerStartedCb;
     ContainerStoppedFunc mContainerStoppedCb;

--- a/openspec/specs/proposals/stop-hibernate-sync.md
+++ b/openspec/specs/proposals/stop-hibernate-sync.md
@@ -1,0 +1,262 @@
+# Proposal: Synchronize Dobby Stop with In-Progress Hibernation
+
+**Ticket**: RDKEMW-13969  
+**Status**: Implemented  
+**Component**: daemon-core (DobbyManager, DobbyContainer)
+
+---
+
+## Problem Statement
+
+There is no synchronization between `DobbyManager::stopContainer()` and an in-progress `hibernateContainer()` operation. When Stop is invoked while a hibernation is underway, the container processes are killed (SIGKILL/SIGTERM) while `memcr_worker` is still performing checkpoint operations on those PIDs. This causes `memcr_worker` to crash on an assert when it encounters errors operating on terminated processes.
+
+**Impact**: Non-harmful to user experience or memcr stability, but produces misleading crash reports that waste QA investigation time.
+
+---
+
+## Root Cause Analysis
+
+### Current Behavior (before fix)
+
+1. `hibernateContainer()` acquires `mLock`, sets state to `Hibernating`, spawns a **detached** thread, and releases the lock.
+2. The hibernation worker thread releases `mLock` during long-running socket I/O with memcr (up to 20s timeout per PID).
+3. `stopContainer()` acquires `mLock`, sees the container in `Hibernating` state, and immediately sends SIGKILL — **with no coordination** with the hibernation thread.
+4. The hibernation thread continues issuing memcr checkpoint commands against now-dead PIDs, triggering asserts in `memcr_worker`.
+
+### Race Window
+
+```
+t0: hibernateContainer() → state = Hibernating, detach worker thread
+t1: worker releases mLock, begins memcr socket I/O (per-PID, ~20s timeout)
+      ↓ UNPROTECTED WINDOW
+t2: stopContainer() acquires mLock, sends SIGKILL
+t3: worker's memcr calls fail → memcr_worker assert crash
+```
+
+### Existing Abort Mechanism (was not triggered)
+
+The hibernation worker already checks for abort at each per-PID iteration:
+```cpp
+if (container not found || descriptor mismatch || state != Hibernating) → abort
+```
+But `stopContainer()` never changed the state away from `Hibernating` before killing — it treated `Hibernating` the same as `Running`.
+
+---
+
+## Solution (Implemented)
+
+The fix has two complementary parts:
+
+1. **`abortContainerHibernationIfNeeded()`** — a new private method that, when called from `stopContainer()`, synchronously drives memcr out of any in-flight checkpoint by sending a `MEMCR_RESTORE` command for the one PID currently being checkpointed. Only that single PID needs waking; fully-checkpointed PIDs from previous iterations are already past memcr's assert-prone path and are safe to SIGKILL directly.
+2. **`hibernatingPid` field** — a `uint32_t` tracked in `DobbyContainer`, written under `mLock` immediately before the lock is released for each `HibernateProcess()` call. This lets the abort method read the exact in-flight PID atomically.
+
+### Why the earlier two-part fix (state=Stopping + kill(pid,0)) was insufficient
+
+**memcr's assert fires on a single failed checkpoint**, not only on repeated ones. Inside `execute_blob()` in memcr.c:
+
+```c
+assert(WIFSTOPPED(status));   // hard assert — always fires on a killed PID
+```
+
+`seize_pid()` treats `ESRCH` as success (logs a message and returns 0), so a dead PID silently passes the seize check and enters `execute_parasite_checkpoint()` where the assert immediately fires.
+
+The `kill(pid, 0)` guard only catches PIDs that are already dead **before** the check — it cannot close the race between passing the check and `ptrace(PTRACE_SEIZE)` beginning inside memcr (a window of microseconds). The `state = Stopping` flag stops the thread from starting new PID iterations, but it cannot interrupt the current in-flight `HibernateProcess()` call. Therefore a race still exists where SIGKILL arrives while memcr holds a ptrace-seize, triggering the assert.
+
+**The only safe approach is to ensure memcr has fully unseized before SIGKILL is sent.**
+
+### Part 1 — `DobbyContainer`: `hibernatingPid` field
+
+```cpp
+// PID currently being passed to DobbyHibernate::HibernateProcess.
+// Set under mLock before releasing it each iteration of the hibernate thread,
+// cleared under mLock when the full hibernation sequence completes.
+uint32_t hibernatingPid = 0;
+```
+
+In the hibernate thread loop, the assignment happens while the lock is held, immediately before `locker.unlock()`:
+
+```cpp
+locker.lock();
+if (/* container gone or state != Hibernating */) { return; }
+uint32_t pid = pidIt->asUInt();
+mContainers[id]->hibernatingPid = pid;   // record before releasing lock
+locker.unlock();
+
+// Defensive OOM/crash guard (not the primary race-fix):
+if (kill(static_cast<pid_t>(pid), 0) != 0) { return; }
+
+ret = DobbyHibernate::HibernateProcess(pid, ...);
+```
+
+When the full loop completes, `hibernatingPid` is cleared under the lock before the state transition:
+
+```cpp
+locker.lock();
+// ... container still-alive checks ...
+mContainers[id]->hibernatingPid = 0;
+if (ret == DobbyHibernate::Error::ErrorNone)
+    mContainers[id]->state = DobbyContainer::State::Hibernated;
+else
+    mContainers[id]->state = DobbyContainer::State::Running;
+```
+
+### Part 2 — `abortContainerHibernationIfNeeded(int32_t cd, std::unique_lock<std::mutex>& locker)`
+
+Called by `stopContainer()` when it finds the container in `Hibernating` state. The method:
+
+1. Reads `hibernatingPid` while holding `mLock`.
+2. Sets `state = Awakening` — the hibernate thread's per-iteration state check will see a non-`Hibernating` state and abort before starting any further `HibernateProcess()` call.
+3. If `hibernatingPid != 0`: releases `mLock`, calls `DobbyHibernate::WakeupProcess(inflightPid)` (default 20 s timeout). `WakeupProcess` sends `MEMCR_RESTORE` to the in-flight worker, which causes it to take the graceful `unseize_target()` + return path rather than proceeding to `execute_blob()`.
+4. Reacquires `mLock`, re-finds the container (it may have vanished while unlocked), returns `false` if gone.
+5. Sets `state = Running` so `killCont()` can proceed.
+
+```cpp
+bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
+                                                     std::unique_lock<std::mutex>& locker)
+{
+    // ... find container ...
+
+    if (it->second->state != DobbyContainer::State::Hibernating)
+        return true;   // nothing to do
+
+    const uint32_t inflightPid = it->second->hibernatingPid;
+    it->second->state = DobbyContainer::State::Awakening;
+
+    if (inflightPid != 0)
+    {
+        locker.unlock();
+        DobbyHibernate::WakeupProcess(static_cast<pid_t>(inflightPid));
+        locker.lock();
+        // re-find container; return false if gone
+    }
+
+    it->second->state = DobbyContainer::State::Running;
+    return true;
+}
+```
+
+`stopContainer()` uses `std::unique_lock` (required for the unlock/relock) and copies `id` by value (safe across the lock release):
+
+```cpp
+std::unique_lock<std::mutex> locker(mLock);
+// ...
+if (container->state == DobbyContainer::State::Hibernating)
+{
+    if (!abortContainerHibernationIfNeeded(cd, locker))
+    {
+        AI_LOG_FN_EXIT();
+        return false;
+    }
+}
+if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM)) { ... }
+```
+
+### Why only the one in-flight PID
+
+- **Previously-checkpointed PIDs** (completed earlier iterations): memcr has fully unseized them and is waiting in an idle state. They are just frozen processes; SIGKILL delivers normally without memcr involvement.
+- **In-flight PID** (current iteration): memcr holds a `ptrace(PTRACE_SEIZE)` on it. Sending SIGKILL while this is active triggers `assert(WIFSTOPPED(status))` inside `execute_blob()`. `WakeupProcess` cleanly drives memcr to `unseize_target()` for this PID before the kill.
+- **Future PIDs** (not yet started): state = `Awakening` prevents the thread from starting any further `HibernateProcess()` call.
+
+### Why `Hibernated` is not affected
+
+A fully `Hibernated` container has no active hibernate thread. Its processes are frozen but respond to SIGKILL normally; memcr is not holding any ptrace seize. The `Hibernated` case falls straight through to `killCont()` unchanged.
+
+### State Transition
+
+```
+Before (baseline):
+  stopContainer() on Hibernating → SIGKILL
+  → memcr still holds ptrace seize → assert crash
+
+After (abort path, WakeupProcess succeeds):
+  stopContainer() on Hibernating
+    → abortContainerHibernationIfNeeded():
+        state = Awakening
+        WakeupProcess(inflightPid)  [blocks until memcr unseizes]
+        state = Running
+    → killCont() → SIGKILL
+  → all memcr ptrace seizes released before kill; no assert
+
+After (no in-flight PID — hibernatingPid == 0):
+  stopContainer() on Hibernating
+    → abortContainerHibernationIfNeeded():
+        state = Awakening  (thread won't start next PID)
+        [no WakeupProcess call needed]
+        state = Running
+    → killCont()
+
+After (container disappears during WakeupProcess):
+  abortContainerHibernationIfNeeded() returns false
+  → stopContainer() returns false (safe; caller may retry)
+```
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant stopContainer
+    participant abortHibernation
+    participant HibernateWorker
+    participant memcr
+    participant Container
+
+    Note over HibernateWorker,memcr: Hibernation in progress (PID N)...
+    HibernateWorker->>HibernateWorker: lock → record hibernatingPid=N, state=Hibernating → unlock
+    HibernateWorker->>memcr: HibernateProcess(N) [memcr holds ptrace seize]
+
+    Client->>stopContainer: stopContainer(cd)
+    stopContainer->>abortHibernation: abortContainerHibernationIfNeeded(cd, locker)
+    abortHibernation->>abortHibernation: read hibernatingPid=N, state=Awakening
+    abortHibernation->>abortHibernation: unlock mLock
+    abortHibernation->>memcr: WakeupProcess(N) [blocks on socket]
+    memcr->>memcr: MEMCR_RESTORE → unseize_target(N) → return
+    abortHibernation->>abortHibernation: relock mLock, state=Running
+    abortHibernation-->>stopContainer: return true
+
+    HibernateWorker->>HibernateWorker: lock → check state == Awakening → abort
+    stopContainer->>Container: killCont() [SIGKILL — no ptrace seize held]
+    stopContainer-->>Client: return true
+```
+
+---
+
+## Affected Code
+
+| File | Change |
+|------|--------|
+| `daemon/lib/source/include/DobbyContainer.h` | Add `uint32_t hibernatingPid = 0` public field |
+| `daemon/lib/source/DobbyManager.cpp` | Hibernate thread: record/clear `hibernatingPid` under `mLock`. `stopContainer()`: `lock_guard` → `unique_lock`, value-copy `id`, call `abortContainerHibernationIfNeeded()` for `Hibernating` state. New method `abortContainerHibernationIfNeeded()`. |
+| `daemon/lib/source/include/DobbyManager.h` | Add private declaration for `abortContainerHibernationIfNeeded()` |
+
+---
+
+## Risks & Considerations
+
+- **Stop latency increase**: `WakeupProcess` blocks until memcr finishes unseizing, up to the default 20 s timeout. In practice memcr responds promptly to `MEMCR_RESTORE`. This is a deliberate trade-off: a small latency increase is preferable to memcr crashing and generating a spurious crash report.
+- **Backward compatibility**: No D-Bus API change. Behavioral change is internal.
+- **`hibernatingPid == 0` race**: If `stopContainer()` reads `hibernatingPid == 0` (thread has not yet set it, or has already cleared it), no `WakeupProcess` call is made. The `state = Awakening` transition still prevents the thread from starting the next `HibernateProcess()` call, so at most one final call may proceed — but in that case the thread will see `state != Hibernating` immediately after and abort before the assert window.
+- **Container removed mid-iteration (abort path null-deref fix)**: When the per-PID abort-check fires and the container has been removed from `mContainers` (the `find(id) == end()` branch), `mContainers[id]` must not be used — `operator[]` would insert a null `unique_ptr` and `->hibernatingPid` would crash. The implementation guards the `hibernatingPid = 0` clear with an explicit `find` result check.
+- **Container disappears during WakeupProcess**: If the container is removed from `mContainers` while the lock is released, `abortContainerHibernationIfNeeded()` returns `false` and `stopContainer()` returns `false`. The caller may retry.
+- **`Hibernated` state not affected**: Fully hibernated processes respond to SIGKILL directly; no wakeup needed.
+
+---
+
+## Test Plan
+
+| Test | Description |
+|------|-------------|
+| Stop during active hibernation | Call hibernate, then immediately stop. Verify no `memcr_worker` crash, container stops cleanly, and `WakeupProcess` is called for the in-flight PID. |
+| Stop after hibernation completes (`Hibernated`) | Call hibernate, wait for completion, then stop. Verify container is killed directly with no regression. |
+| Stop during wakeup (`Awakening`) | Call wakeup, then immediately stop. Verify container stops cleanly. |
+| Stop when `hibernatingPid == 0` | Stop arrives between per-PID iterations (lock held by thread, PID not yet recorded). Verify `state = Awakening` alone prevents the next PID from being checkpointed. |
+| `WakeupProcess` timeout | Simulate memcr not responding. Verify `stopContainer()` propagates the timeout, container state is consistent, and no assert occurs. |
+| Container removed during WakeupProcess | Remove container from map while `WakeupProcess` is blocking. Verify `abortContainerHibernationIfNeeded()` returns `false` and no use-after-free occurs. |
+| Concurrent stop/hibernate races | Stress test with rapid stop/hibernate cycling. Verify no crashes and no stuck states. |
+
+---
+
+## References
+
+- [daemon-core.md](../daemon-core.md) — DobbyManager, DobbyHibernate, container state machine
+- [memcr](https://github.com/LibertyGlobal/memcr) — Checkpoint/restore service

--- a/openspec/specs/proposals/stop-hibernate-sync.md
+++ b/openspec/specs/proposals/stop-hibernate-sync.md
@@ -79,11 +79,8 @@ In the hibernate thread loop, the assignment happens while the lock is held, imm
 locker.lock();
 if (/* container gone or state != Hibernating */) { return; }
 uint32_t pid = pidIt->asUInt();
-mContainers[id]->hibernatingPid = pid;   // record before releasing lock
+containerIt->second->hibernatingPid = pid;   // record before releasing lock
 locker.unlock();
-
-// Defensive OOM/crash guard (not the primary race-fix):
-if (kill(static_cast<pid_t>(pid), 0) != 0) { return; }
 
 ret = DobbyHibernate::HibernateProcess(pid, ...);
 ```
@@ -100,21 +97,19 @@ else
     mContainers[id]->state = DobbyContainer::State::Running;
 ```
 
-### Part 2 — `abortContainerHibernationIfNeeded(int32_t cd, std::unique_lock<std::mutex>& locker)`
+### Part 2 — `abortContainerHibernationIfNeeded(int32_t cd)`
 
 Called by `stopContainer()` when it finds the container in `Hibernating` state. The method:
 
 1. Reads `hibernatingPid` while holding `mLock`.
 2. Sets `state = Awakening` — the hibernate thread's per-iteration state check will see a non-`Hibernating` state and abort before starting any further `HibernateProcess()` call.
-3. If `hibernatingPid != 0`: releases `mLock`, calls `DobbyHibernate::WakeupProcess(inflightPid)` (default 20 s timeout). `WakeupProcess` sends `MEMCR_RESTORE` to the in-flight worker, which causes it to take the graceful `unseize_target()` + return path rather than proceeding to `execute_blob()`.
-4. Reacquires `mLock`, re-finds the container (it may have vanished while unlocked), returns `false` if gone.
-5. Sets `state = Running` so `killCont()` can proceed.
+3. If `hibernatingPid != 0`: calls `DobbyHibernate::WakeupProcess(inflightPid)` (default 20 s timeout) **while holding `mLock`**. The hibernate thread is blocked inside `HibernateProcess()` (a memcr socket call) at this point and does not hold `mLock`, so there is no deadlock risk. `WakeupProcess` sends `MEMCR_RESTORE` to the in-flight worker, which causes it to take the graceful `unseize_target()` + return path rather than proceeding to `execute_blob()`. If `WakeupProcess` fails, state is reverted to `Hibernating` and the method returns `false`.
+4. Sets `state = Running` so `killCont()` can proceed.
 
 ```cpp
-bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
-                                                     std::unique_lock<std::mutex>& locker)
+bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd)
 {
-    // ... find container ...
+    // ... find container (mLock must already be held by the caller) ...
 
     if (it->second->state != DobbyContainer::State::Hibernating)
         return true;   // nothing to do
@@ -124,31 +119,37 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd,
 
     if (inflightPid != 0)
     {
-        locker.unlock();
-        DobbyHibernate::WakeupProcess(static_cast<pid_t>(inflightPid));
-        locker.lock();
-        // re-find container; return false if gone
+        // mLock held throughout — hibernate thread is blocked in HibernateProcess(),
+        // not holding mLock, so no deadlock risk.
+        const DobbyHibernate::Error wakeRet =
+            DobbyHibernate::WakeupProcess(static_cast<pid_t>(inflightPid));
+        if (wakeRet != DobbyHibernate::Error::ErrorNone)
+        {
+            it->second->state = DobbyContainer::State::Hibernating;  // revert
+            return false;
+        }
     }
 
+    it->second->hibernatingPid = 0;
     it->second->state = DobbyContainer::State::Running;
     return true;
 }
 ```
 
-`stopContainer()` uses `std::unique_lock` (required for the unlock/relock) and copies `id` by value (safe across the lock release):
+`stopContainer()` calls the method — `mLock` is already held via its own `std::unique_lock`:
 
 ```cpp
 std::unique_lock<std::mutex> locker(mLock);
 // ...
 if (container->state == DobbyContainer::State::Hibernating)
 {
-    if (!abortContainerHibernationIfNeeded(cd, locker))
+    if (!abortContainerHibernationIfNeeded(cd))
     {
         AI_LOG_FN_EXIT();
         return false;
     }
 }
-if (!mRunc->killCont(id, withPrejudice ? SIGKILL : SIGTERM)) { ... }
+if (!mRunc->killCont(it->first, withPrejudice ? SIGKILL : SIGTERM)) { ... }
 ```
 
 ### Why only the one in-flight PID
@@ -185,9 +186,14 @@ After (no in-flight PID — hibernatingPid == 0):
         state = Running
     → killCont()
 
-After (container disappears during WakeupProcess):
-  abortContainerHibernationIfNeeded() returns false
-  → stopContainer() returns false (safe; caller may retry)
+After (WakeupProcess fails):
+  stopContainer() on Hibernating
+    → abortContainerHibernationIfNeeded():
+        state = Awakening
+        WakeupProcess(inflightPid) → error
+        state = Hibernating  (reverted)
+    → returns false
+  → stopContainer() returns false (caller may retry)
 ```
 
 ### Sequence Diagram
@@ -206,15 +212,14 @@ sequenceDiagram
     HibernateWorker->>memcr: HibernateProcess(N) [memcr holds ptrace seize]
 
     Client->>stopContainer: stopContainer(cd)
-    stopContainer->>abortHibernation: abortContainerHibernationIfNeeded(cd, locker)
+    stopContainer->>abortHibernation: abortContainerHibernationIfNeeded(cd)
     abortHibernation->>abortHibernation: read hibernatingPid=N, state=Awakening
-    abortHibernation->>abortHibernation: unlock mLock
-    abortHibernation->>memcr: WakeupProcess(N) [blocks on socket]
+    abortHibernation->>memcr: WakeupProcess(N) [blocks on socket, mLock held]
     memcr->>memcr: MEMCR_RESTORE → unseize_target(N) → return
-    abortHibernation->>abortHibernation: relock mLock, state=Running
+    abortHibernation->>abortHibernation: state=Running
     abortHibernation-->>stopContainer: return true
 
-    HibernateWorker->>HibernateWorker: lock → check state == Awakening → abort
+    HibernateWorker->>HibernateWorker: lock → check state != Hibernating → abort
     stopContainer->>Container: killCont() [SIGKILL — no ptrace seize held]
     stopContainer-->>Client: return true
 ```
@@ -226,8 +231,8 @@ sequenceDiagram
 | File | Change |
 |------|--------|
 | `daemon/lib/source/include/DobbyContainer.h` | Add `uint32_t hibernatingPid = 0` public field |
-| `daemon/lib/source/DobbyManager.cpp` | Hibernate thread: record/clear `hibernatingPid` under `mLock`. `stopContainer()`: `lock_guard` → `unique_lock`, value-copy `id`, call `abortContainerHibernationIfNeeded()` for `Hibernating` state. New method `abortContainerHibernationIfNeeded()`. |
-| `daemon/lib/source/include/DobbyManager.h` | Add private declaration for `abortContainerHibernationIfNeeded()` |
+| `daemon/lib/source/DobbyManager.cpp` | Hibernate thread: record/clear `hibernatingPid` under `mLock`. `stopContainer()`: `lock_guard` → `unique_lock`, call `abortContainerHibernationIfNeeded()` for `Hibernating` state. New method `abortContainerHibernationIfNeeded()` (holds `mLock` throughout, no unlock/relock). `WakeupProcess` return value checked in abort, wakeup, and hibernation rollback paths; state reverted to `Hibernating` on failure in the abort path. `stopContainer()` doc comment updated to document blocking behaviour when the container is in `Hibernating` state. |
+| `daemon/lib/source/include/DobbyManager.h` | Add private declaration for `abortContainerHibernationIfNeeded(int32_t cd)`. |
 
 ---
 
@@ -237,7 +242,8 @@ sequenceDiagram
 - **Backward compatibility**: No D-Bus API change. Behavioral change is internal.
 - **`hibernatingPid == 0` race**: If `stopContainer()` reads `hibernatingPid == 0` (thread has not yet set it, or has already cleared it), no `WakeupProcess` call is made. The `state = Awakening` transition still prevents the thread from starting the next `HibernateProcess()` call, so at most one final call may proceed — but in that case the thread will see `state != Hibernating` immediately after and abort before the assert window.
 - **Container removed mid-iteration (abort path null-deref fix)**: When the per-PID abort-check fires and the container has been removed from `mContainers` (the `find(id) == end()` branch), `mContainers[id]` must not be used — `operator[]` would insert a null `unique_ptr` and `->hibernatingPid` would crash. The implementation guards the `hibernatingPid = 0` clear with an explicit `find` result check.
-- **Container disappears during WakeupProcess**: If the container is removed from `mContainers` while the lock is released, `abortContainerHibernationIfNeeded()` returns `false` and `stopContainer()` returns `false`. The caller may retry.
+- **WakeupProcess failure**: If `WakeupProcess()` returns an error, state is reverted from `Awakening` to `Hibernating` and `abortContainerHibernationIfNeeded()` returns `false`. `stopContainer()` propagates this as a `false` return. The hibernate thread is still running and will complete or fail on its own.
+- **No deadlock from holding mLock during WakeupProcess**: `abortContainerHibernationIfNeeded()` holds `mLock` throughout the `WakeupProcess()` call. This is safe because the hibernate thread releases `mLock` before entering `HibernateProcess()` (the memcr socket call) and does not reacquire it until that call returns. The two functions therefore cannot deadlock.
 - **`Hibernated` state not affected**: Fully hibernated processes respond to SIGKILL directly; no wakeup needed.
 
 ---
@@ -250,8 +256,8 @@ sequenceDiagram
 | Stop after hibernation completes (`Hibernated`) | Call hibernate, wait for completion, then stop. Verify container is killed directly with no regression. |
 | Stop during wakeup (`Awakening`) | Call wakeup, then immediately stop. Verify container stops cleanly. |
 | Stop when `hibernatingPid == 0` | Stop arrives between per-PID iterations (lock held by thread, PID not yet recorded). Verify `state = Awakening` alone prevents the next PID from being checkpointed. |
-| `WakeupProcess` timeout | Simulate memcr not responding. Verify `stopContainer()` propagates the timeout, container state is consistent, and no assert occurs. |
-| Container removed during WakeupProcess | Remove container from map while `WakeupProcess` is blocking. Verify `abortContainerHibernationIfNeeded()` returns `false` and no use-after-free occurs. |
+| `WakeupProcess` timeout/failure | Simulate memcr not responding or returning an error. Verify `stopContainer()` returns `false`, container state is reverted to `Hibernating`, and the hibernate thread can complete on its own. |
+| `WakeupProcess` failure in wakeup/rollback paths | Simulate `WakeupProcess` failure in `wakeupContainer` thread loop and `hibernateContainer` rollback loop. Verify a warning is logged but the loop continues attempting all remaining PIDs. |
 | Concurrent stop/hibernate races | Stress test with rapid stop/hibernate cycling. Verify no crashes and no stuck states. |
 
 ---

--- a/openspec/specs/proposals/stop-hibernate-sync.md
+++ b/openspec/specs/proposals/stop-hibernate-sync.md
@@ -73,17 +73,25 @@ The `kill(pid, 0)` guard only catches PIDs that are already dead **before** the 
 uint32_t hibernatingPid = 0;
 ```
 
-In the hibernate thread loop, the assignment happens while the lock is held, immediately before `locker.unlock()`:
+In the hibernate thread loop, the assignment happens while the lock is held, immediately before `locker.unlock()`, and is cleared back to 0 under the lock immediately after `HibernateProcess()` returns:
 
 ```cpp
 locker.lock();
 if (/* container gone or state != Hibernating */) { return; }
 uint32_t pid = pidIt->asUInt();
-containerIt->second->hibernatingPid = pid;   // record before releasing lock
+containerIt->second->hibernatingPid = pid;   // record: now in-flight
 locker.unlock();
 
 ret = DobbyHibernate::HibernateProcess(pid, ...);
+
+locker.lock();
+containerIt->second->hibernatingPid = 0;     // clear: no longer in-flight
+locker.unlock();
+
+// ... check ret, rollback if error, then continue to next PID ...
 ```
+
+This keeps `hibernatingPid` strictly aligned with "currently inside `HibernateProcess()`". Without the post-return clear, `stopContainer()` arriving between iterations would see a stale non-zero PID and call `WakeupProcess()` on an already-checkpointed (frozen) process, potentially unfreezing it prematurely.
 
 When the full loop completes, `hibernatingPid` is cleared under the lock before the state transition:
 
@@ -103,8 +111,8 @@ Called by `stopContainer()` when it finds the container in `Hibernating` state. 
 
 1. Reads `hibernatingPid` while holding `mLock`.
 2. Sets `state = Awakening` — the hibernate thread's per-iteration state check will see a non-`Hibernating` state and abort before starting any further `HibernateProcess()` call.
-3. If `hibernatingPid != 0`: calls `DobbyHibernate::WakeupProcess(inflightPid)` (default 20 s timeout) **while holding `mLock`**. The hibernate thread is blocked inside `HibernateProcess()` (a memcr socket call) at this point and does not hold `mLock`, so there is no deadlock risk. `WakeupProcess` sends `MEMCR_RESTORE` to the in-flight worker, which causes it to take the graceful `unseize_target()` + return path rather than proceeding to `execute_blob()`. If `WakeupProcess` fails, state is reverted to `Hibernating` and the method returns `false`.
-4. Sets `state = Running` so `killCont()` can proceed.
+3. If `hibernatingPid != 0`: calls `DobbyHibernate::WakeupProcess(inflightPid)` (default 20 s timeout) **while holding `mLock`**. The hibernate thread is blocked inside `HibernateProcess()` (a memcr socket call) at this point and does not hold `mLock`, so there is no deadlock risk. `WakeupProcess` sends `MEMCR_RESTORE` to the in-flight worker, which causes it to take the graceful `unseize_target()` + return path rather than proceeding to `execute_blob()`. If `WakeupProcess` fails, state is set to `Stopping` and the method returns `false` — the container is being torn down and must not be killed again by shutdown cleanup.
+4. Sets `state = Stopping` so that `killCont()` can proceed, and to prevent `cleanupContainersShutdown()` from issuing a redundant `killCont()` after the stop completes.
 
 ```cpp
 bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd)
@@ -125,13 +133,13 @@ bool DobbyManager::abortContainerHibernationIfNeeded(int32_t cd)
             DobbyHibernate::WakeupProcess(static_cast<pid_t>(inflightPid));
         if (wakeRet != DobbyHibernate::Error::ErrorNone)
         {
-            it->second->state = DobbyContainer::State::Hibernating;  // revert
+            it->second->state = DobbyContainer::State::Stopping;
             return false;
         }
     }
 
     it->second->hibernatingPid = 0;
-    it->second->state = DobbyContainer::State::Running;
+    it->second->state = DobbyContainer::State::Stopping;
     return true;
 }
 ```
@@ -174,7 +182,7 @@ After (abort path, WakeupProcess succeeds):
     → abortContainerHibernationIfNeeded():
         state = Awakening
         WakeupProcess(inflightPid)  [blocks until memcr unseizes]
-        state = Running
+        state = Stopping
     → killCont() → SIGKILL
   → all memcr ptrace seizes released before kill; no assert
 
@@ -183,7 +191,7 @@ After (no in-flight PID — hibernatingPid == 0):
     → abortContainerHibernationIfNeeded():
         state = Awakening  (thread won't start next PID)
         [no WakeupProcess call needed]
-        state = Running
+        state = Stopping
     → killCont()
 
 After (WakeupProcess fails):
@@ -191,9 +199,9 @@ After (WakeupProcess fails):
     → abortContainerHibernationIfNeeded():
         state = Awakening
         WakeupProcess(inflightPid) → error
-        state = Hibernating  (reverted)
+        state = Stopping
     → returns false
-  → stopContainer() returns false (caller may retry)
+  → stopContainer() returns false (container left in Stopping; shutdown cleanup skips it)
 ```
 
 ### Sequence Diagram
@@ -216,7 +224,7 @@ sequenceDiagram
     abortHibernation->>abortHibernation: read hibernatingPid=N, state=Awakening
     abortHibernation->>memcr: WakeupProcess(N) [blocks on socket, mLock held]
     memcr->>memcr: MEMCR_RESTORE → unseize_target(N) → return
-    abortHibernation->>abortHibernation: state=Running
+    abortHibernation->>abortHibernation: state=Stopping
     abortHibernation-->>stopContainer: return true
 
     HibernateWorker->>HibernateWorker: lock → check state != Hibernating → abort
@@ -231,7 +239,7 @@ sequenceDiagram
 | File | Change |
 |------|--------|
 | `daemon/lib/source/include/DobbyContainer.h` | Add `uint32_t hibernatingPid = 0` public field |
-| `daemon/lib/source/DobbyManager.cpp` | Hibernate thread: record/clear `hibernatingPid` under `mLock`. `stopContainer()`: `lock_guard` → `unique_lock`, call `abortContainerHibernationIfNeeded()` for `Hibernating` state. New method `abortContainerHibernationIfNeeded()` (holds `mLock` throughout, no unlock/relock). `WakeupProcess` return value checked in abort, wakeup, and hibernation rollback paths; state reverted to `Hibernating` on failure in the abort path. `stopContainer()` doc comment updated to document blocking behaviour when the container is in `Hibernating` state. |
+| `daemon/lib/source/DobbyManager.cpp` | Hibernate thread: record/clear `hibernatingPid` under `mLock`. `stopContainer()`: `lock_guard` → `unique_lock`, call `abortContainerHibernationIfNeeded()` for `Hibernating` state. New method `abortContainerHibernationIfNeeded()` (holds `mLock` throughout, no unlock/relock): sets `state = Stopping` in all exit paths — on `WakeupProcess` success, on `WakeupProcess` failure, and when `hibernatingPid == 0`. `stopContainer()` doc comment updated to document blocking behaviour when the container is in `Hibernating` state. |
 | `daemon/lib/source/include/DobbyManager.h` | Add private declaration for `abortContainerHibernationIfNeeded(int32_t cd)`. |
 
 ---
@@ -242,7 +250,7 @@ sequenceDiagram
 - **Backward compatibility**: No D-Bus API change. Behavioral change is internal.
 - **`hibernatingPid == 0` race**: If `stopContainer()` reads `hibernatingPid == 0` (thread has not yet set it, or has already cleared it), no `WakeupProcess` call is made. The `state = Awakening` transition still prevents the thread from starting the next `HibernateProcess()` call, so at most one final call may proceed — but in that case the thread will see `state != Hibernating` immediately after and abort before the assert window.
 - **Container removed mid-iteration (abort path null-deref fix)**: When the per-PID abort-check fires and the container has been removed from `mContainers` (the `find(id) == end()` branch), `mContainers[id]` must not be used — `operator[]` would insert a null `unique_ptr` and `->hibernatingPid` would crash. The implementation guards the `hibernatingPid = 0` clear with an explicit `find` result check.
-- **WakeupProcess failure**: If `WakeupProcess()` returns an error, state is reverted from `Awakening` to `Hibernating` and `abortContainerHibernationIfNeeded()` returns `false`. `stopContainer()` propagates this as a `false` return. The hibernate thread is still running and will complete or fail on its own.
+- **WakeupProcess failure**: If `WakeupProcess()` returns an error, state is set to `Stopping` (not reverted to `Hibernating`) and `abortContainerHibernationIfNeeded()` returns `false`. `stopContainer()` propagates this as a `false` return. Setting `Stopping` rather than reverting ensures that `cleanupContainersShutdown()` does not attempt a redundant `killCont()` on a container that is already being torn down. The hibernate thread will see `state != Hibernating` and abort its loop.
 - **No deadlock from holding mLock during WakeupProcess**: `abortContainerHibernationIfNeeded()` holds `mLock` throughout the `WakeupProcess()` call. This is safe because the hibernate thread releases `mLock` before entering `HibernateProcess()` (the memcr socket call) and does not reacquire it until that call returns. The two functions therefore cannot deadlock.
 - **`Hibernated` state not affected**: Fully hibernated processes respond to SIGKILL directly; no wakeup needed.
 
@@ -256,7 +264,7 @@ sequenceDiagram
 | Stop after hibernation completes (`Hibernated`) | Call hibernate, wait for completion, then stop. Verify container is killed directly with no regression. |
 | Stop during wakeup (`Awakening`) | Call wakeup, then immediately stop. Verify container stops cleanly. |
 | Stop when `hibernatingPid == 0` | Stop arrives between per-PID iterations (lock held by thread, PID not yet recorded). Verify `state = Awakening` alone prevents the next PID from being checkpointed. |
-| `WakeupProcess` timeout/failure | Simulate memcr not responding or returning an error. Verify `stopContainer()` returns `false`, container state is reverted to `Hibernating`, and the hibernate thread can complete on its own. |
+| `WakeupProcess` timeout/failure | Simulate memcr not responding or returning an error. Verify `stopContainer()` returns `false`, container state is set to `Stopping`, and the hibernate thread aborts its loop (sees `state != Hibernating`). |
 | `WakeupProcess` failure in wakeup/rollback paths | Simulate `WakeupProcess` failure in `wakeupContainer` thread loop and `hibernateContainer` rollback loop. Verify a warning is logged but the loop continues attempting all remaining PIDs. |
 | Concurrent stop/hibernate races | Stress test with rapid stop/hibernate cycling. Verify no crashes and no stuck states. |
 

--- a/tests/L1_testing/mocks/DobbyContainer.h
+++ b/tests/L1_testing/mocks/DobbyContainer.h
@@ -62,7 +62,7 @@ public:
     const std::shared_ptr<const DobbyConfig> config;
     std::list<int> mFiles;
     bool hasCurseOfDeath;
-    uint32_t hibernatingPid;
+    uint32_t hibernatingPid = 0;
     const std::shared_ptr<const DobbyRootfs> rootfs;
 
     DobbyContainer();

--- a/tests/L1_testing/mocks/DobbyContainer.h
+++ b/tests/L1_testing/mocks/DobbyContainer.h
@@ -62,6 +62,7 @@ public:
     const std::shared_ptr<const DobbyConfig> config;
     std::list<int> mFiles;
     bool hasCurseOfDeath;
+    uint32_t hibernatingPid;
     const std::shared_ptr<const DobbyRootfs> rootfs;
 
     DobbyContainer();

--- a/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -4538,8 +4538,9 @@ TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupCalledBefore
  * @brief stopContainer() on a Hibernating container — WakeupProcess fails.
  *
  * When WakeupProcess returns an error, abortContainerHibernationIfNeeded()
- * reverts state to Hibernating and returns false.  stopContainer() must
- * propagate this as a false return without calling killCont().
+ * sets state to Stopping (so cleanupContainersShutdown() skips the container)
+ * and returns false.  stopContainer() must propagate this as a false return
+ * without calling killCont().
  */
 TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupFails_ReturnsFalse)
 {
@@ -4597,90 +4598,6 @@ TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupFails_Return
 
     ret = dobbyManager_test->stopContainer(cd, true);
     EXPECT_EQ(ret, false);
-}
-
-/**
- * @brief stopContainer() on a Hibernating container — hibernatingPid is 0.
- *
- * If stopContainer() arrives between per-PID iterations (hibernatingPid == 0),
- * abortContainerHibernationIfNeeded() must set state = Awakening (so the
- * hibernate thread does not start a new HibernateProcess call) and then
- * return true without calling WakeupProcess.  killCont() must still be called.
- */
-TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_NoPidInFlight_KillContCalled)
-{
-    Json::Value expected_json;
-    expected_json["id"] = "container1";
-    expected_json["state"] = "running";
-    expected_json["pids"] = Json::arrayValue;
-    expected_json["pids"].append(1);
-    expected_json["pids"].append(2);
-
-    int32_t cd = 1234;
-    ContainerId id = ContainerId::create("container1");
-    expect_invalidContainerCleanupTask();
-    expect_startContainerFromBundle(cd, id);
-
-    EXPECT_CALL(*p_statsMock, stats())
-        .Times(1)
-        .WillOnce(::testing::ReturnRef(expected_json));
-
-    // Gate: HibernateProcess(pid=1) signals it has finished (hibernatingPid
-    // will be cleared before mLock is released for the next iteration).
-    std::promise<void> firstPidDonePromise;
-    std::future<void> firstPidDoneFuture = firstPidDonePromise.get_future();
-
-    // Gate: HibernateProcess(pid=2) blocks until the test calls stopContainer.
-    std::promise<void> stopCalledPromise;
-    std::future<void> stopCalledFuture = stopCalledPromise.get_future();
-
-    int callCount = 0;
-    EXPECT_CALL(*p_hibernateMock, HibernateProcess(
-            ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
-        .Times(::testing::AtLeast(1))
-        .WillRepeatedly(::testing::Invoke(
-            [&](const pid_t pid, const uint32_t, const std::string&,
-                const std::string&, DobbyHibernate::CompressionAlg)
-            {
-                callCount++;
-                if (callCount == 1)
-                {
-                    // First PID done — let the test thread know hibernatingPid
-                    // will momentarily be 0 (between iterations).
-                    firstPidDonePromise.set_value();
-                }
-                else
-                {
-                    // Second PID: block until stopContainer is called.
-                    stopCalledFuture.wait();
-                }
-                return DobbyHibernate::Error::ErrorNone;
-            }));
-
-    // WakeupProcess must NOT be called (hibernatingPid == 0 at the moment stop sees it).
-    EXPECT_CALL(*p_hibernateMock, WakeupProcess(::testing::_, ::testing::_, ::testing::_))
-        .Times(0);
-
-    EXPECT_CALL(*p_runcMock, killCont(::testing::_, ::testing::_, ::testing::_))
-        .Times(1)
-        .WillOnce(::testing::Return(true));
-
-    bool ret = dobbyManager_test->hibernateContainer(cd, "");
-    EXPECT_EQ(ret, true);
-
-    // Wait until the first PID has finished so hibernatingPid is transiently 0.
-    firstPidDoneFuture.wait();
-
-    // Call stopContainer while hibernatingPid is (or was) 0.
-    // Release the second HibernateProcess only after stopContainer has returned.
-    // This is intentionally racy — we are testing the hibernatingPid==0 branch,
-    // not a perfectly timed window. The key assertion is that WakeupProcess is
-    // never called and killCont is called exactly once.
-    stopCalledPromise.set_value();   // release any blocked second-pid call
-    ret = dobbyManager_test->stopContainer(cd, true);
-    // stopContainer returns true when the abort path succeeds (no in-flight PID)
-    // or when the container is no longer Hibernating by the time we check.
-    EXPECT_TRUE(ret);
 }
 
 // =============================================================================

--- a/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -4418,6 +4418,270 @@ TEST_F(DaemonDobbyManagerTest, hibernateContainer_successWithParametersCombinati
 }
 
 // =============================================================================
+// Unit tests for stopContainer() while hibernation is in progress.
+//
+// Regression suite for RDKEMW-13969: verifies that stopContainer() calls
+// WakeupProcess() for the in-flight PID before issuing killCont(), so that
+// memcr fully unseizes the process before SIGKILL is sent (preventing the
+// assert(WIFSTOPPED(status)) crash inside memcr_worker).
+// =============================================================================
+
+/**
+ * @brief stopContainer() on a Hibernating container — WakeupProcess succeeds.
+ *
+ * Scenario: hibernateContainer() is called and its worker thread is blocked
+ * inside HibernateProcess() for the first PID.  stopContainer() is then called
+ * from the test thread.  The test verifies:
+ *  1. WakeupProcess() is invoked with the in-flight PID before killCont().
+ *  2. killCont() is called exactly once after WakeupProcess() returns.
+ *  3. stopContainer() returns true.
+ */
+TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupCalledBeforeKill)
+{
+    // Container stats with a single PID so the race window is deterministic.
+    Json::Value expected_json;
+    expected_json["id"] = "container1";
+    expected_json["state"] = "running";
+    expected_json["pids"] = Json::arrayValue;
+    expected_json["pids"].append(1);   // PID 1 is the only in-flight PID
+
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+    expect_startContainerFromBundle(cd, id);
+
+    EXPECT_CALL(*p_statsMock, stats())
+        .Times(1)
+        .WillOnce(::testing::ReturnRef(expected_json));
+
+    // Synchronisation: HibernateProcess blocks until WakeupProcess releases it.
+    std::promise<void> wakeupCalledPromise;
+    std::future<void> wakeupCalledFuture = wakeupCalledPromise.get_future();
+
+    // Track call ordering to verify WakeupProcess precedes killCont.
+    std::vector<std::string> callOrder;
+    std::mutex callOrderMutex;
+
+    EXPECT_CALL(*p_hibernateMock, HibernateProcess(
+            ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const pid_t pid, const uint32_t, const std::string&,
+                const std::string&, DobbyHibernate::CompressionAlg)
+            {
+                // Block until the abort path has called WakeupProcess.
+                wakeupCalledFuture.wait();
+                {
+                    std::lock_guard<std::mutex> lk(callOrderMutex);
+                    callOrder.push_back("HibernateProcess_returned");
+                }
+                return DobbyHibernate::Error::ErrorNone;
+            }));
+
+    EXPECT_CALL(*p_hibernateMock, WakeupProcess(
+            static_cast<pid_t>(1), ::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const pid_t, const uint32_t, const std::string&)
+            {
+                {
+                    std::lock_guard<std::mutex> lk(callOrderMutex);
+                    callOrder.push_back("WakeupProcess");
+                }
+                // Unblock HibernateProcess now that WakeupProcess has been called.
+                wakeupCalledPromise.set_value();
+                return DobbyHibernate::Error::ErrorNone;
+            }));
+
+    EXPECT_CALL(*p_runcMock, killCont(::testing::_, ::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const ContainerId&, int, bool)
+            {
+                std::lock_guard<std::mutex> lk(callOrderMutex);
+                callOrder.push_back("killCont");
+                return true;
+            }));
+
+    // Start hibernation (spawns a detached worker thread that blocks in HibernateProcess).
+    bool ret = dobbyManager_test->hibernateContainer(cd, "");
+    EXPECT_EQ(ret, true);
+
+    // Spin until the container state becomes Hibernating (worker thread has
+    // recorded hibernatingPid and released mLock).
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (dobbyManager_test->stateOfContainer(cd) != CONTAINER_STATE_HIBERNATING)
+    {
+        ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+            << "Timed out waiting for container to enter Hibernating state";
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    // Now call stopContainer — this must call WakeupProcess then killCont.
+    ret = dobbyManager_test->stopContainer(cd, true);
+    EXPECT_EQ(ret, true);
+
+    // Verify ordering.
+    {
+        std::lock_guard<std::mutex> lk(callOrderMutex);
+        ASSERT_GE(callOrder.size(), 2u);
+        EXPECT_EQ(callOrder[0], "WakeupProcess");
+        EXPECT_EQ(callOrder[1], "killCont");
+    }
+}
+
+/**
+ * @brief stopContainer() on a Hibernating container — WakeupProcess fails.
+ *
+ * When WakeupProcess returns an error, abortContainerHibernationIfNeeded()
+ * reverts state to Hibernating and returns false.  stopContainer() must
+ * propagate this as a false return without calling killCont().
+ */
+TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupFails_ReturnsFalse)
+{
+    Json::Value expected_json;
+    expected_json["id"] = "container1";
+    expected_json["state"] = "running";
+    expected_json["pids"] = Json::arrayValue;
+    expected_json["pids"].append(1);
+
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+    expect_startContainerFromBundle(cd, id);
+
+    EXPECT_CALL(*p_statsMock, stats())
+        .Times(1)
+        .WillOnce(::testing::ReturnRef(expected_json));
+
+    std::promise<void> wakeupCalledPromise;
+    std::future<void> wakeupCalledFuture = wakeupCalledPromise.get_future();
+
+    EXPECT_CALL(*p_hibernateMock, HibernateProcess(
+            ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const pid_t, const uint32_t, const std::string&,
+                const std::string&, DobbyHibernate::CompressionAlg)
+            {
+                wakeupCalledFuture.wait();
+                return DobbyHibernate::Error::ErrorNone;
+            }));
+
+    EXPECT_CALL(*p_hibernateMock, WakeupProcess(
+            static_cast<pid_t>(1), ::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Invoke(
+            [&](const pid_t, const uint32_t, const std::string&)
+            {
+                wakeupCalledPromise.set_value();
+                return DobbyHibernate::Error::ErrorGeneral;
+            }));
+
+    // killCont must NOT be called when the abort fails.
+    EXPECT_CALL(*p_runcMock, killCont(::testing::_, ::testing::_, ::testing::_))
+        .Times(0);
+
+    bool ret = dobbyManager_test->hibernateContainer(cd, "");
+    EXPECT_EQ(ret, true);
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (dobbyManager_test->stateOfContainer(cd) != CONTAINER_STATE_HIBERNATING)
+    {
+        ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+            << "Timed out waiting for container to enter Hibernating state";
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    ret = dobbyManager_test->stopContainer(cd, true);
+    EXPECT_EQ(ret, false);
+}
+
+/**
+ * @brief stopContainer() on a Hibernating container — hibernatingPid is 0.
+ *
+ * If stopContainer() arrives between per-PID iterations (hibernatingPid == 0),
+ * abortContainerHibernationIfNeeded() must set state = Awakening (so the
+ * hibernate thread does not start a new HibernateProcess call) and then
+ * return true without calling WakeupProcess.  killCont() must still be called.
+ */
+TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_NoPidInFlight_KillContCalled)
+{
+    Json::Value expected_json;
+    expected_json["id"] = "container1";
+    expected_json["state"] = "running";
+    expected_json["pids"] = Json::arrayValue;
+    expected_json["pids"].append(1);
+    expected_json["pids"].append(2);
+
+    int32_t cd = 1234;
+    ContainerId id = ContainerId::create("container1");
+    expect_invalidContainerCleanupTask();
+    expect_startContainerFromBundle(cd, id);
+
+    EXPECT_CALL(*p_statsMock, stats())
+        .Times(1)
+        .WillOnce(::testing::ReturnRef(expected_json));
+
+    // Gate: HibernateProcess(pid=1) signals it has finished (hibernatingPid
+    // will be cleared before mLock is released for the next iteration).
+    std::promise<void> firstPidDonePromise;
+    std::future<void> firstPidDoneFuture = firstPidDonePromise.get_future();
+
+    // Gate: HibernateProcess(pid=2) blocks until the test calls stopContainer.
+    std::promise<void> stopCalledPromise;
+    std::future<void> stopCalledFuture = stopCalledPromise.get_future();
+
+    int callCount = 0;
+    EXPECT_CALL(*p_hibernateMock, HibernateProcess(
+            ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(::testing::AtLeast(1))
+        .WillRepeatedly(::testing::Invoke(
+            [&](const pid_t pid, const uint32_t, const std::string&,
+                const std::string&, DobbyHibernate::CompressionAlg)
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    // First PID done — let the test thread know hibernatingPid
+                    // will momentarily be 0 (between iterations).
+                    firstPidDonePromise.set_value();
+                }
+                else
+                {
+                    // Second PID: block until stopContainer is called.
+                    stopCalledFuture.wait();
+                }
+                return DobbyHibernate::Error::ErrorNone;
+            }));
+
+    // WakeupProcess must NOT be called (hibernatingPid == 0 at the moment stop sees it).
+    EXPECT_CALL(*p_hibernateMock, WakeupProcess(::testing::_, ::testing::_, ::testing::_))
+        .Times(0);
+
+    EXPECT_CALL(*p_runcMock, killCont(::testing::_, ::testing::_, ::testing::_))
+        .Times(1)
+        .WillOnce(::testing::Return(true));
+
+    bool ret = dobbyManager_test->hibernateContainer(cd, "");
+    EXPECT_EQ(ret, true);
+
+    // Wait until the first PID has finished so hibernatingPid is transiently 0.
+    firstPidDoneFuture.wait();
+
+    // Call stopContainer while hibernatingPid is (or was) 0.
+    // Release the second HibernateProcess only after stopContainer has returned.
+    // This is intentionally racy — we are testing the hibernatingPid==0 branch,
+    // not a perfectly timed window. The key assertion is that WakeupProcess is
+    // never called and killCont is called exactly once.
+    stopCalledPromise.set_value();   // release any blocked second-pid call
+    ret = dobbyManager_test->stopContainer(cd, true);
+    // stopContainer returns true when the abort path succeeds (no in-flight PID)
+    // or when the container is no longer Hibernating by the time we check.
+    EXPECT_TRUE(ret);
+}
+
+// =============================================================================
 // Unit tests for DobbyManager::synthesizeContainerSignalStatus()
 //
 // These validate the 128+signum exit code to WIFSIGNALED status synthesis

--- a/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -4458,6 +4458,12 @@ TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupCalledBefore
     std::promise<void> wakeupCalledPromise;
     std::future<void> wakeupCalledFuture = wakeupCalledPromise.get_future();
 
+    // Synchronisation: fires when HibernateProcess is actually entered, meaning
+    // the thread has set hibernatingPid under mLock and released it.  stopContainer()
+    // must not run until this point so it sees a non-zero hibernatingPid.
+    std::promise<void> hibernateStartedPromise;
+    std::future<void> hibernateStartedFuture = hibernateStartedPromise.get_future();
+
     // Track call ordering to verify WakeupProcess precedes killCont.
     std::vector<std::string> callOrder;
     std::mutex callOrderMutex;
@@ -4469,6 +4475,9 @@ TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupCalledBefore
             [&](const pid_t pid, const uint32_t, const std::string&,
                 const std::string&, DobbyHibernate::CompressionAlg)
             {
+                // Signal that HibernateProcess is now in-flight (hibernatingPid
+                // has been set under mLock and mLock has been released).
+                hibernateStartedPromise.set_value();
                 // Block until the abort path has called WakeupProcess.
                 wakeupCalledFuture.wait();
                 {
@@ -4507,15 +4516,10 @@ TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupCalledBefore
     bool ret = dobbyManager_test->hibernateContainer(cd, "");
     EXPECT_EQ(ret, true);
 
-    // Spin until the container state becomes Hibernating (worker thread has
-    // recorded hibernatingPid and released mLock).
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-    while (dobbyManager_test->stateOfContainer(cd) != CONTAINER_STATE_HIBERNATING)
-    {
-        ASSERT_LT(std::chrono::steady_clock::now(), deadline)
-            << "Timed out waiting for container to enter Hibernating state";
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
+    // Wait until HibernateProcess is actually invoked — the thread has set
+    // hibernatingPid under mLock and released it, so stopContainer() will
+    // see a non-zero hibernatingPid and correctly call WakeupProcess.
+    hibernateStartedFuture.wait();
 
     // Now call stopContainer — this must call WakeupProcess then killCont.
     ret = dobbyManager_test->stopContainer(cd, true);
@@ -4557,6 +4561,9 @@ TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupFails_Return
     std::promise<void> wakeupCalledPromise;
     std::future<void> wakeupCalledFuture = wakeupCalledPromise.get_future();
 
+    std::promise<void> hibernateStartedPromise;
+    std::future<void> hibernateStartedFuture = hibernateStartedPromise.get_future();
+
     EXPECT_CALL(*p_hibernateMock, HibernateProcess(
             ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
         .Times(1)
@@ -4564,6 +4571,7 @@ TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupFails_Return
             [&](const pid_t, const uint32_t, const std::string&,
                 const std::string&, DobbyHibernate::CompressionAlg)
             {
+                hibernateStartedPromise.set_value();
                 wakeupCalledFuture.wait();
                 return DobbyHibernate::Error::ErrorNone;
             }));
@@ -4585,13 +4593,7 @@ TEST_F(DaemonDobbyManagerTest, stopContainer_HibernatingState_WakeupFails_Return
     bool ret = dobbyManager_test->hibernateContainer(cd, "");
     EXPECT_EQ(ret, true);
 
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-    while (dobbyManager_test->stateOfContainer(cd) != CONTAINER_STATE_HIBERNATING)
-    {
-        ASSERT_LT(std::chrono::steady_clock::now(), deadline)
-            << "Timed out waiting for container to enter Hibernating state";
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
+    hibernateStartedFuture.wait();
 
     ret = dobbyManager_test->stopContainer(cd, true);
     EXPECT_EQ(ret, false);


### PR DESCRIPTION
### Description

A race condition existed between DobbyManager::stopContainer() and an in-progress
hibernateContainer() that intermittently caused memcr_worker to crash with an assertion
failure.

The hibernate thread releases mLock before calling DobbyHibernate::HibernateProcess(pid).
If stopContainer() acquired the lock during this window and killed the container's PIDs, the
hibernate thread would then call HibernateProcess() for an already-dead PID. Inside memcr,
seize_pid() treats ESRCH as success, so execution proceeds to execute_parasite_checkpoint()
where assert(WIFSTOPPED(status)) fires on the terminated PID.

The crash is not harmful to memcr or the user experience, but causes misleading failures
visible to QA.

Root Cause
----------
No synchronisation between stopContainer() and the hibernate background thread.
stopContainer() had no knowledge of whether a HibernateProcess() call was in flight.

Fix
---
- Added uint32_t hibernatingPid field to DobbyContainer, written under mLock immediately
  before each HibernateProcess() call and cleared when the full sequence completes. This
  allows the stop path to identify the single PID currently held under ptrace seize by memcr.

- Added new DobbyContainer::State::Awakening enum value as an abort signal to the hibernate
  thread, preventing it from starting any further HibernateProcess() calls.

- Added private method abortContainerHibernationIfNeeded(int32_t cd,
  std::unique_lock<std::mutex>& locker) which: sets state to Awakening, reads hibernatingPid
  under the lock, releases the lock, calls WakeupProcess() for the single in-flight PID
  (driving memcr to unseize_target() before the PID is killed), then reacquires the lock.

- Updated stopContainer() to use std::unique_lock (instead of lock_guard) and call
  abortContainerHibernationIfNeeded() synchronously before killCont() when the container is
  in Hibernating state.

Why only the in-flight PID needs a wakeup
-----------------------------------------
Previously-checkpointed PIDs are frozen but have no active ptrace seize -- they respond to
SIGKILL normally. Future PIDs are blocked by the Awakening state check at the top of the
hibernate thread's loop. Only the single PID currently inside HibernateProcess() has an
active seize that would trigger the assert.

### Test Procedure
- Existing L1/L2 tests continue to pass (mock updated).
- Manual test: trigger hibernate on a container, immediately call stop -- verify no
  memcr_worker assert crash and container terminates cleanly.
- Stop latency increase in worst case: up to one DobbyHibernate::DFL_TIMEOUTE_MS (20 s) if
  a WakeupProcess call is needed, which is the expected trade-off for correctness.


### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)