### PR TITLE
RDKEMW-19889: Kill orphaned grandchildren when main child exits

### DIFF
--- a/daemon/init/source/InitMain.cpp
+++ b/daemon/init/source/InitMain.cpp
@@ -352,6 +352,16 @@ static int doForkExec(int argc, char * argv[])
                     kill(-1, SIGKILL);
                 }
             }
+            else if (WIFSIGNALED(status) && pid == exePid)
+            {
+                ret = EXIT_FAILURE;
+
+                // The main child was killed by a signal. Any grandchildren
+                // it spawned are now reparented to us (PID 1). Kill them
+                // unconditionally so we don't block in wait() forever and
+                // the container can be stopped cleanly.
+                kill(-1, SIGKILL);
+            }
 
             // if the process died because of a signal, or it didn't exit with
             // success then log as an error, otherwise it's just info

--- a/daemon/init/source/InitMain.cpp
+++ b/daemon/init/source/InitMain.cpp
@@ -351,7 +351,6 @@ static int doForkExec(int argc, char * argv[])
                     // and the container can be stopped cleanly.
                     kill(-1, SIGKILL);
                 }
-
             }
 
             // if the process died because of a signal, or it didn't exit with

--- a/daemon/init/source/InitMain.cpp
+++ b/daemon/init/source/InitMain.cpp
@@ -344,13 +344,14 @@ static int doForkExec(int argc, char * argv[])
                 if (pid == exePid)
                 {
                     ret = WEXITSTATUS(status);
+
+                    // The main child has exited (normally or with an error).
+                    // Any grandchildren it spawned are now reparented to us
+                    // (PID 1). Kill them so we don't block in wait() forever
+                    // and the container can be stopped cleanly.
+                    kill(-1, SIGKILL);
                 }
 
-                // The main child has exited (normally or with an error).
-                // Any grandchildren it spawned are now reparented to us
-                // (PID 1). Kill them so we don't block in wait() forever
-                // and the container can be stopped cleanly.
-                kill(-1, SIGKILL);
             }
 
             // if the process died because of a signal, or it didn't exit with

--- a/daemon/init/source/InitMain.cpp
+++ b/daemon/init/source/InitMain.cpp
@@ -345,6 +345,12 @@ static int doForkExec(int argc, char * argv[])
                 {
                     ret = WEXITSTATUS(status);
                 }
+
+                // The main child has exited (normally or with an error).
+                // Any grandchildren it spawned are now reparented to us
+                // (PID 1). Kill them so we don't block in wait() forever
+                // and the container can be stopped cleanly.
+                kill(-1, SIGKILL);
             }
 
             // if the process died because of a signal, or it didn't exit with


### PR DESCRIPTION
### Description
When the main child calls exit(), any grandchildren it spawned but did not reap are reparented to DobbyInit (PID 1). Without this fix, DobbyInit blocks in wait() forever waiting for those orphaned processes, preventing runc from quitting and leaving the container stuck.

Add kill(-1, SIGKILL) in the WIFEXITED branch after the main child exits so all reparented orphans are killed unconditionally, allowing wait() to unblock and the container to stop cleanly.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)