### PR TITLE
RDKEMW-18340:  Improve Minidump naming and crash-time fireboltState selection

### DIFF
--- a/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
@@ -21,6 +21,7 @@
 
 #include <Logging.h>
 #include <string.h>
+#include <chrono>
 #include <fstream>
 #include <unistd.h>
 #include <fcntl.h>
@@ -764,7 +765,30 @@ bool DobbyRdkPluginUtils::addAnnotation(const std::string &key, const std::strin
 
     std::lock_guard<std::mutex> locker(mLock);
 
+    // Before overwriting, preserve the previous value and its timestamp
+    // so that plugins can recover the state that was valid at an earlier point
+    // in time (e.g. the state at crash time vs the state set after the crash).
+    auto existing = mAnnotations.find(key);
+    if (existing != mAnnotations.end())
+    {
+        mAnnotations[key + "_prev"] = existing->second;
+        auto existingTs = mAnnotations.find(key + "_ts");
+        if (existingTs != mAnnotations.end())
+        {
+            mAnnotations[key + "_prev_ts"] = existingTs->second;
+        }
+    }
+
     mAnnotations[key] = value;
+
+    // Store the time the annotation was set (in milliseconds since epoch)
+    // so plugins can determine if the annotation arrived before or after an
+    // event (e.g. a crash).  Millisecond resolution is needed because
+    // AppService can update the annotation within a few ms of the crash.
+    auto now = std::chrono::system_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  now.time_since_epoch()).count();
+    mAnnotations[key + "_ts"] = std::to_string(ms);
 
     AI_LOG_FN_EXIT();
 
@@ -798,3 +822,4 @@ bool DobbyRdkPluginUtils::removeAnnotation(const std::string &key)
 
     return success;
 }
+

--- a/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginUtils.cpp
@@ -813,6 +813,11 @@ bool DobbyRdkPluginUtils::removeAnnotation(const std::string &key)
     const auto it = mAnnotations.find(key);
     if (it != mAnnotations.end()){
         mAnnotations.erase(it);
+        // remove metadata entries derived in addAnnotation()
+        mAnnotations.erase(key + "_ts");
+        mAnnotations.erase(key + "_prev");
+        mAnnotations.erase(key + "_prev_ts");
+      
         success = true;
     } else {
         AI_LOG_ERROR("Key %s not found in annotations", key.c_str());

--- a/rdkPlugins/Minidump/source/Minidump.cpp
+++ b/rdkPlugins/Minidump/source/Minidump.cpp
@@ -20,9 +20,11 @@
 #include "Minidump.h"
 #include "AnonymousFile.h"
 
+#include <chrono>
 #include <sstream>
 #include <unistd.h>
 #include <iomanip>
+#include <sys/stat.h>
 
 /**
  * Need to do this at the start of every plugin to make sure the correct
@@ -116,7 +118,7 @@ bool Minidump::postHalt()
     }
 
     int hostFd = fileFds.front();
-    std::string destFile = getDestinationFile();
+    std::string destFile = getDestinationFile(hostFd);
 
     // copies content of volatile file from RAM to a disk
     bool success = AnonymousFile(hostFd).copyContentTo(destFile);
@@ -135,16 +137,51 @@ bool Minidump::postHalt()
  *
  * @return Destination minidump file path string
  */
-#define FIREBOLT_STATE  "fireboltState"
+#define FIREBOLT_STATE          "fireboltState"
+#define FIREBOLT_STATE_TS       "fireboltState_ts"
+#define FIREBOLT_STATE_PREV     "fireboltState_prev"
+#define FIREBOLT_STATE_PREV_TS  "fireboltState_prev_ts"
 #define MINIDUMP_FILENAME_LENGTH 44
 #define MINIDUMP_FN_SEPERATOR "<#=#>"
 
-std::string Minidump::getDestinationFile()
+// Helper to safely parse a millisecond timestamp string, returns 0 on failure
+static long long parseTimestampMs(const std::string &str)
 {
-    // If an app crashes multiple times, a previous dump might still exist in the destination
-    // path. Append the current date/time to the filename to prevent conflicts
-    auto now = std::chrono::system_clock::now();
-    std::time_t currentTime = std::chrono::system_clock::to_time_t(now);
+    try
+    {
+        return std::stoll(str);
+    }
+    catch (const std::exception &e)
+    {
+        AI_LOG_WARN("failed to parse timestamp '%s': %s", str.c_str(), e.what());
+        return 0;
+    }
+}
+
+std::string Minidump::getDestinationFile(int fd)
+{
+    // Use the modification time of the anonymous file (set when breakpad writes the
+    // minidump at crash time) rather than the current time which is some variable
+    // delay later when the postHalt hook runs.
+    // We need millisecond resolution because AppService can update the
+    // fireboltState annotation within a few ms of the crash.
+    long long crashTimeMs = 0;
+    std::time_t currentTime;
+    struct stat st;
+    if (fd >= 0 && fstat(fd, &st) == 0 && st.st_mtime != 0)
+    {
+        currentTime = st.st_mtime;
+        crashTimeMs = static_cast<long long>(st.st_mtim.tv_sec) * 1000
+                    + st.st_mtim.tv_nsec / 1000000;
+    }
+    else
+    {
+        AI_LOG_WARN("failed to get mtime from minidump fd, falling back to current time");
+        auto now = std::chrono::system_clock::now();
+        currentTime = std::chrono::system_clock::to_time_t(now);
+        crashTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          now.time_since_epoch()).count();
+    }
     std::stringstream timeString;
     timeString << std::put_time(std::localtime(&currentTime), "%FT%T");
     std::string destFile;
@@ -154,16 +191,67 @@ std::string Minidump::getDestinationFile()
 
     std::map<std::string, std::string> annotations = mUtils->getAnnotations();
 
+    // Only use the fireboltState annotation if it was set BEFORE the crash.
+    // AppService often transitions the app to "background" after the crash but
+    // before postHalt runs, which would record the wrong state.  If the current
+    // annotation is stale, fall back to the previous value (which was the state
+    // at the time of the crash, e.g. "foreground").
     auto it = annotations.find(FIREBOLT_STATE);
+    if (it != annotations.end())
+    {
+        auto tsIt = annotations.find(FIREBOLT_STATE_TS);
+        if (tsIt != annotations.end())
+        {
+            long long annotationMs = parseTimestampMs(tsIt->second);
+            if (annotationMs > 0 && annotationMs > crashTimeMs)
+            {
+                AI_LOG_INFO("Current fireboltState '%s' was set after crash "
+                            "(annotation_ms=%lld, crash_ms=%lld) - checking previous value",
+                            it->second.c_str(),
+                            annotationMs,
+                            crashTimeMs);
+
+                // Try the previous annotation value that was valid at crash time
+                auto prevIt = annotations.find(FIREBOLT_STATE_PREV);
+                auto prevTsIt = annotations.find(FIREBOLT_STATE_PREV_TS);
+                if (prevIt != annotations.end() && prevTsIt != annotations.end())
+                {
+                    long long prevMs = parseTimestampMs(prevTsIt->second);
+                    if (prevMs > 0 && prevMs <= crashTimeMs)
+                    {
+                        AI_LOG_INFO("Using previous fireboltState '%s' (set_ms=%lld, crash_ms=%lld)",
+                                    prevIt->second.c_str(),
+                                    prevMs,
+                                    crashTimeMs);
+                        it = prevIt;
+                    }
+                    else
+                    {
+                        it = annotations.end(); // both are after crash or parse failed
+                    }
+                }
+                else
+                {
+                    it = annotations.end(); // no previous value available
+                }
+            }
+        }
+    }
+
+    std::string containerId = mUtils->getContainerId();
+    if (containerId.find("apps_") != std::string::npos) {
+        //remove prefix before "apps_" from containerId
+        containerId = containerId.substr(containerId.find("apps_"));
+    }
     if (it != annotations.end()) {
-        fileName = mUtils->getContainerId() + MINIDUMP_FN_SEPERATOR + it->second.c_str() + MINIDUMP_FN_SEPERATOR + timeString.str();
+        fileName = containerId + MINIDUMP_FN_SEPERATOR + it->second.c_str() + MINIDUMP_FN_SEPERATOR + timeString.str();
         if (fileName.length() > MINIDUMP_FILENAME_LENGTH)
             fileName.resize(MINIDUMP_FILENAME_LENGTH);
         destFile = dir + "/" + fileName + ".dmp";
         AI_LOG_INFO("Firebolt state: %s, minidump filename: %s", it->second.c_str(), destFile.c_str());
-    }else{
-        AI_LOG_INFO("Firebolt state not found");
-        fileName = mUtils->getContainerId() + MINIDUMP_FN_SEPERATOR + timeString.str();
+    } else {
+        AI_LOG_INFO("Firebolt state not found or not valid at crash time");
+        fileName = containerId + MINIDUMP_FN_SEPERATOR + timeString.str();
         if (fileName.length() > MINIDUMP_FILENAME_LENGTH)
             fileName.resize(MINIDUMP_FILENAME_LENGTH);
         destFile = dir + "/" + fileName + ".dmp";
@@ -192,3 +280,4 @@ std::vector<std::string> Minidump::getDependencies() const
 
     return dependencies;
 }
+

--- a/rdkPlugins/Minidump/source/Minidump.cpp
+++ b/rdkPlugins/Minidump/source/Minidump.cpp
@@ -240,9 +240,9 @@ std::string Minidump::getDestinationFile(int fd)
 
     std::string containerId = mUtils->getContainerId();
     if (containerId.find("apps_") != std::string::npos) {
-        //remove prefix before "apps_" from containerId
-        containerId = containerId.substr(containerId.find("apps_"));
-    }
+         //remove prefix before and including "apps_" from containerId
+        containerId = containerId.substr(containerId.find("apps_") + 5);
+      }
     if (it != annotations.end()) {
         fileName = containerId + MINIDUMP_FN_SEPERATOR + it->second.c_str() + MINIDUMP_FN_SEPERATOR + timeString.str();
         if (fileName.length() > MINIDUMP_FILENAME_LENGTH)

--- a/rdkPlugins/Minidump/source/Minidump.h
+++ b/rdkPlugins/Minidump/source/Minidump.h
@@ -59,7 +59,7 @@ public:
     std::vector<std::string> getDependencies() const override;
 
 private:
-    std::string getDestinationFile();
+    std::string getDestinationFile(int fd);
 
     const std::string mName;
     std::shared_ptr<rt_dobby_schema> mContainerConfig;
@@ -68,3 +68,4 @@ private:
 };
 
 #endif // !defined(MINIDUMP_H)
+


### PR DESCRIPTION
Description:
Integrates minidump fixes directly in Dobby by improving crash-time fireboltState selection and trimming container names using apps_ so dump filenames use a cleaner app identifier

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [x] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)