### PR TITLE
RDKEMW-19889: Kill orphaned grandchildren when main child exits

### DIFF
--- a/daemon/init/source/InitMain.cpp
+++ b/daemon/init/source/InitMain.cpp
@@ -405,6 +405,13 @@ static int doForkExec(int argc, char * argv[])
                     // signal death.
                     if (ret == EXIT_SUCCESS)
                         gReceivedSignal = 0;
+
+                    // The main child called exit() leaving any grandchildren
+                    // it spawned but did not reap reparented to us (PID 1).
+                    // Kill them so DobbyInit doesn't block in wait() forever,
+                    // which would prevent runc from quitting and leave the
+                    // container stuck.
+                    kill(-1, SIGKILL);
                 }
             }
             else if (WIFSIGNALED(status) && pid == exePid)
@@ -420,9 +427,12 @@ static int doForkExec(int argc, char * argv[])
                 ret = EXIT_FAILURE;
 
                 // The main child's orphaned descendants have been
-                // reparented to us (PID 1).  Send them the same signal
-                // so they terminate and we don't block in wait() forever.
-                kill(-1, sig);
+                // reparented to us (PID 1).  The signal was already
+                // forwarded by signalHandler(); use SIGKILL here so
+                // any grandchild that caught/ignored the original signal
+                // is still guaranteed to terminate and we don't block
+                // in wait() forever.
+                kill(-1, SIGKILL);
             }
 
             // if the process died because of a signal, or it didn't exit with

--- a/daemon/init/source/InitMain.cpp
+++ b/daemon/init/source/InitMain.cpp
@@ -27,10 +27,13 @@
  *  https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/
  *
  *  It boils down to ensuring we have an 'init' process that does at least the
- *  following two things:
+ *  following things:
  *
  *      1. Reaps adopted child processes.
  *      2. Forwards on signals to child processes.
+ *      3. Kills orphaned grandchildren when the main child exits, so
+ *         DobbyInit doesn't block in wait() forever and the container
+ *         can be stopped cleanly.
  *
  *  In addition to the above it provides some basic logging to indicate why a
  *  child process died.
@@ -411,7 +414,9 @@ static int doForkExec(int argc, char * argv[])
                     // Kill them so DobbyInit doesn't block in wait() forever,
                     // which would prevent runc from quitting and leave the
                     // container stuck.
-                    kill(-1, SIGKILL);
+                    if (kill(-1, SIGKILL) != 0 && errno != ESRCH)
+                        LOG_ERR("failed to SIGKILL orphaned processes (%d - %s)",
+                                errno, strerror(errno));
                 }
             }
             else if (WIFSIGNALED(status) && pid == exePid)
@@ -432,7 +437,9 @@ static int doForkExec(int argc, char * argv[])
                 // any grandchild that caught/ignored the original signal
                 // is still guaranteed to terminate and we don't block
                 // in wait() forever.
-                kill(-1, SIGKILL);
+                if (kill(-1, SIGKILL) != 0 && errno != ESRCH)
+                    LOG_ERR("failed to SIGKILL orphaned processes (%d - %s)",
+                            errno, strerror(errno));
             }
 
             // if the process died because of a signal, or it didn't exit with


### PR DESCRIPTION
### Description
When the main child calls exit(), any grandchildren it spawned but did not reap are reparented to DobbyInit (PID 1). Without this fix, DobbyInit blocks in wait() forever waiting for those orphaned processes, preventing runc from quitting and leaving the container stuck.

Fix: after the main child terminates — whether via exit() (WIFEXITED) or killed by a signal (WIFSIGNALED) — issue kill(-1, SIGKILL) to guarantee all reparented grandchildren are reaped and the wait() loop exits cleanly.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)