### PR TITLE
RDKEMW-18141:Update isApparmorProfileLoaded() to avoid audit logs in kernel version

### DIFF
--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -791,31 +791,41 @@ bool DobbyConfig::updateBundleConfig(const ContainerId& id, std::shared_ptr<rt_d
 
 bool DobbyConfig::isApparmorProfileLoaded(const char *profile) const
  {
+     DIR *d = NULL;
      bool status = false;
-     int fd = open("/proc/self/attr/current", O_WRONLY);
+     struct dirent *cur_dir = NULL;
+     size_t profile_len = strlen(profile);
 
-     if (fd < 0)
-     {
-         AI_LOG_ERROR("/proc/self/attr/current open failed");
-         return status;
-     }
-     char profile_name[256];
-     snprintf(profile_name, sizeof(profile_name), "permprofile %s", profile);
-
-     if (write(fd, profile_name, strlen(profile_name)) < 0)
-     {
-         if (errno == ENOENT)
-             AI_LOG_INFO("Apparmor profile [%s] doesn't exist", profile);
-         else
-             AI_LOG_ERROR("/proc/self/attr/current write failed");
-     }
-     else
-     {
-         status = true;
-         AI_LOG_INFO("Apparmor profile [%s] is loaded", profile);
+     d = opendir("/sys/kernel/security/apparmor/policy/profiles/");
+     if(!d) {
+          AI_LOG_SYS_ERROR(errno, "opendir() failed on apparmorfs policy directory.");
+          return false;
      }
 
-     close(fd);
+     errno = 0;
+     while((cur_dir = readdir(d)) != NULL) {
+          if(strlen(cur_dir->d_name) >= (profile_len + 2)) {
+               if(!strncmp(cur_dir->d_name, profile, profile_len) &&
+                    cur_dir->d_name[profile_len] == '.' &&
+                    isdigit(cur_dir->d_name[profile_len + 1])) {
+                    
+                    status = true;
+                    AI_LOG_INFO("AppArmor profile [%s] is loaded.", profile);
+                    break;
+               }
+          }
+     }
+
+     if(!status) {
+          AI_LOG_INFO("AppArmor profile [%s] not found.", profile);
+     }
+
+     if(!cur_dir && errno) {
+          AI_LOG_SYS_ERROR(errno, "readdir() failed on apparmorfs policy directory");
+     }
+
+     closedir(d);
+
      return status;
  }
 


### PR DESCRIPTION

### Description
The container configuration allows AppArmor profiles to be specified, which will be applied to processes running in the container. The logic checks if the profile is loaded into the kernel, then assigns the profile if it is found.

The current mechanism for testing if an AppArmor profile is loaded depends on the kernel module permprofile logic. Unfortunately, after kernel [version 4.13](https://github.com/torvalds/linux/commit/e00b02bb6ac2a1893227ce8014b649028d6425d2), this logic is changed in such a way that results in logs being created whenever a profile is passed in via permprofile, which results in a number of logs created unnecessarily.

These logs are marked with info="profile not found" with DobbyDaemon as the process and profile name:
2025-10-23T10:24:24.077Z audit[3773]: AVC apparmor="DENIED" operation="change_profile" info="label not found" error=-2 profile="DobbyDaemon" name="dobby_default" pid=3773 comm="DobbyDaemon"

This change removes the use of permprofile in favor of walking sysfs directories to determine if a profile is loaded. The logic prior to permprofile was to walk the apparmorfs profiles file and string search for the entry, however this operation slowed down container startup when the profiles list was large. The change here should occur in ~6-7ms compared to 40-50ms (per testing on-device by @goruklu) with the string search when 100 profiles are loaded.

Note that due to the nature of apparmorfs pseudofiles, these files can't be mmap()'d or used in other optimized loads, so those options were not viable.

The change assumes the following directory structure in apparmorfs, which was confirmed to exist in kernels 4.9 - 6.14 (and current):

root@Docsis-Gateway:~# ls /sys/kernel/security/apparmor/policy/profiles/ PolicyA.sp.1                PolicyB.141                                      PolicyC.45                        PolicyD.138                          PolicyE.101

It is important that the profile name be examined to ensure that it is followed with both a . and numeric value, to avoid conflicts with other profile naming schemes (mainly ending in .sp), hence the added conditions there.

This resolves part of https://ccp.sys.comcast.net/browse/DELIA-68521

Test Procedure
Verify DobbyDaemon is confined (cat /proc/<DobbyDaemon pid>/attr/current), profile name should be DobbyDaemon
Verify dobby_default profile is NOT loaded (cat /sys/kernel/security/apparmor/profiles | grep dobby_default)
Attempt to start a container and measure startup time
Alternatively, the code can be put into a standalone stub and measure execution time using the same instructions above with >100 profiles loaded. The script below can be used to automatically create placeholder profiles:
`DIR="/tmp/test_profiles"
mkdir "$DIR"

for i in $(seq 1 100); do
    file="$DIR/test_profile_$i"
    printf 'profile test_profile%s flags=(complain) {\n\n}\n' "$i" > "$file"
done `

Removing dobby_default from the kernel ensures full iteration of the list occurs instead of stopping when a result is found, which should provide a more accurate measure of performance.



### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)