### PR TITLE
RDKEMW-17166: Make container memory limits zram-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The table below lists the supported top-level fields. Fields marked **mandatory*
 | `version` | string | Yes | Spec version. Currently `"1.0"` or `"1.1"`. |
 | `args` | array | Yes | Command and arguments to run inside the container. |
 | `user` | object | Yes | `uid` and `gid` the container process runs as. |
-| `memLimit` | integer | Yes | Requested memory limit in bytes. When `swapLimit` is present, this value is scaled down according to the host's RAM and swap capacity before being applied to `memory.limit_in_bytes`. Values below 256 KiB are accepted but will only generate a warning and may not be effective. |
+| `memLimit` | integer | Yes | Requested memory limit in bytes. When `swapLimit` is present, this value is scaled down according to the host's RAM and active zram swap capacity before being applied to `memory.limit_in_bytes`. Other swap types, such as swapfiles and partitions, are ignored. Values below 256 KiB are accepted but will only generate a warning and may not be effective. |
 | `swapLimit` | integer | No | Swap+memory limit in bytes (`memory.memsw.limit_in_bytes`). Must be ≥ the effective scaled memory limit. Defaults to unlimited (-1) when absent. |
 | `env` | array | No | Environment variables in `"KEY=VALUE"` format. |
 | `cwd` | string | No | Working directory inside the container. |
@@ -168,7 +168,7 @@ The table below lists the supported top-level fields. Fields marked **mandatory*
 }
 ```
 
-When `swapLimit` is present, `memLimit` is scaled down based on the host's swap-to-RAM ratio before it is applied to `memory.limit_in_bytes`. `swapLimit` sets the combined memory+swap ceiling enforced by the kernel cgroup (`memory.memsw.limit_in_bytes`). When omitted, `memLimit` is applied directly and memory+swap is unlimited (-1), allowing the container to use as much swap as the system provides.
+When `swapLimit` is present, `memLimit` is scaled down based on the host's active zram-swap-to-RAM ratio before it is applied to `memory.limit_in_bytes`. Swapfiles and swap partitions are not included in this ratio. `swapLimit` sets the combined memory+swap ceiling enforced by the kernel cgroup (`memory.memsw.limit_in_bytes`). When omitted, `memLimit` is applied directly and memory+swap is unlimited (-1), allowing the container to use as much swap as the system provides.
 
 ## DobbyTool
 This is a simple command line tool that is used for debugging purporses. It connects to the Dobby daemon over dbus and allows for debugging and testing containers.

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ The table below lists the supported top-level fields. Fields marked **mandatory*
 | `version` | string | Yes | Spec version. Currently `"1.0"` or `"1.1"`. |
 | `args` | array | Yes | Command and arguments to run inside the container. |
 | `user` | object | Yes | `uid` and `gid` the container process runs as. |
-| `memLimit` | integer | Yes | Memory limit in bytes (`memory.limit_in_bytes`). Values below 256 KiB are accepted but will only generate a warning and may not be effective. |
-| `swapLimit` | integer | No | Swap+memory limit in bytes (`memory.memsw.limit_in_bytes`). Must be ≥ `memLimit`. Defaults to unlimited (-1) when absent. |
+| `memLimit` | integer | Yes | Requested memory limit in bytes. When `swapLimit` is present, this value is scaled down according to the host's RAM and swap capacity before being applied to `memory.limit_in_bytes`. Values below 256 KiB are accepted but will only generate a warning and may not be effective. |
+| `swapLimit` | integer | No | Swap+memory limit in bytes (`memory.memsw.limit_in_bytes`). Must be ≥ the effective scaled memory limit. Defaults to unlimited (-1) when absent. |
 | `env` | array | No | Environment variables in `"KEY=VALUE"` format. |
 | `cwd` | string | No | Working directory inside the container. |
 | `console` | object | No | Console log settings: `path` and `limit` (bytes). |
@@ -168,7 +168,7 @@ The table below lists the supported top-level fields. Fields marked **mandatory*
 }
 ```
 
-`swapLimit` sets the combined memory+swap ceiling enforced by the kernel cgroup (`memory.memsw.limit_in_bytes`). When omitted, memory+swap is unlimited (-1), allowing the container to use as much swap as the system provides.
+When `swapLimit` is present, `memLimit` is scaled down based on the host's swap-to-RAM ratio before it is applied to `memory.limit_in_bytes`. `swapLimit` sets the combined memory+swap ceiling enforced by the kernel cgroup (`memory.memsw.limit_in_bytes`). When omitted, `memLimit` is applied directly and memory+swap is unlimited (-1), allowing the container to use as much swap as the system provides.
 
 ## DobbyTool
 This is a simple command line tool that is used for debugging purporses. It connects to the Dobby daemon over dbus and allows for debugging and testing containers.

--- a/bundle/lib/include/DobbySpecConfig.h
+++ b/bundle/lib/include/DobbySpecConfig.h
@@ -191,6 +191,7 @@ private:
 private:
     bool mValid;
     ctemplate::TemplateDictionary* mDictionary;
+    double mZramSwapToRamRatio;
 
 private:
     Json::Value mSpec;

--- a/bundle/lib/include/DobbySpecConfig.h
+++ b/bundle/lib/include/DobbySpecConfig.h
@@ -28,6 +28,7 @@
 
 #include <set>
 #include <bitset>
+#include <cstdint>
 #include <memory>
 
 namespace ctemplate {
@@ -173,6 +174,9 @@ private:
 private:
     static void addGpuDevNodes(const std::shared_ptr<const IDobbySettings::HardwareAccessSettings> &settings,
                                ctemplate::TemplateDictionary *dict);
+
+    static int64_t calculatePhysicalMemoryLimit(int64_t memLimit,
+                                                double swapToRamRatio);
 
     static  void addVpuDevNodes(const std::shared_ptr<const IDobbySettings::HardwareAccessSettings> &settings,
                                 ctemplate::TemplateDictionary *dict);

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -1359,7 +1359,7 @@ bool DobbySpecConfig::processMemLimit(const Json::Value& value,
     // Only apply the zram-aware adjustment when swapLimit is explicitly
     // set; otherwise keep memLimit as-is to match the memory.limit_in_bytes.
     unsigned physLimit = memLimit;
-    if (mSpec["swapLimit"].isIntegral())
+    if (mSpec.isMember("swapLimit") && mSpec["swapLimit"].isIntegral())
     {
         const double alpha = getZramPercentage();
         physLimit = static_cast<unsigned>((1.0 - alpha) * static_cast<double>(memLimit));

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -37,6 +37,7 @@
 #include <sys/capability.h>
 #include <sys/stat.h>
 #include <fstream>
+#include <sstream>
 
 // Compile time generated strings that (in theory) speeds up the processing
 // of ctemplate expanding
@@ -195,6 +196,55 @@ static const ctemplate::StaticTemplateString SECCOMP_SYSCALLS =
 #define JSON_FLAG_SWAPLIMIT          (0x1U << 23)
 
 int DobbySpecConfig::mNumCores = -1;
+
+static double getZramPercentage()
+{
+    std::ifstream meminfo("/proc/meminfo");
+    if (!meminfo.is_open())
+    {
+        return 0.0;
+    }
+
+    unsigned long long memTotalKb = 0;
+    unsigned long long swapTotalKb = 0;
+    std::string line;
+
+    while (std::getline(meminfo, line))
+    {
+        std::istringstream iss(line);
+        std::string key;
+        iss >> key;
+
+        if (key == "MemTotal:")
+        {
+            unsigned long long value = 0;
+            std::string units;
+            if (!(iss >> value >> units))
+            {
+                return 0.0;
+            }
+            memTotalKb = value;
+        }
+        else if (key == "SwapTotal:")
+        {
+            unsigned long long value = 0;
+            std::string units;
+            if (!(iss >> value >> units))
+            {
+                return 0.0;
+            }
+            swapTotalKb = value;
+        }
+    }
+
+    if (memTotalKb == 0 || swapTotalKb == 0)
+    {
+        return 0.0;
+    }
+
+    const double alpha = static_cast<double>(swapTotalKb) / static_cast<double>(memTotalKb);
+    return std::max(0.0, std::min(alpha, 1.0));
+}
 
 // TODO: should we only allowed these if a network namespace is enabled ?
 const std::map<std::string, int> DobbySpecConfig::mAllowedCaps =
@@ -636,8 +686,15 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
 
     if (!(flags & JSON_FLAG_SWAPLIMIT))
     {
-        // swapLimit not supplied: leave memory+swap unlimited (-1)
-        dictionary->SetIntValue(MEM_SWAP, -1);
+        const Json::Value& memLimitVal = mSpec["memLimit"];
+        if (memLimitVal.isIntegral())
+        {
+            dictionary->SetIntValue(MEM_SWAP, static_cast<unsigned>(memLimitVal.asUInt()));
+        }
+        else
+        {
+            dictionary->SetIntValue(MEM_SWAP, -1);
+        }
     }
 
     // swappiness is not supported on cgroups v2, only show if on v1
@@ -1306,7 +1363,9 @@ bool DobbySpecConfig::processMemLimit(const Json::Value& value,
         AI_LOG_WARN("memory limit looks dangerously low");
     }
 
-    dictionary->SetIntValue(MEM_LIMIT, memLimit);
+    const double alpha = getZramPercentage();
+    const unsigned physLimit = static_cast<unsigned>((1.0 - alpha) * static_cast<double>(memLimit));
+    dictionary->SetIntValue(MEM_LIMIT, physLimit);
 
     return true;
 }
@@ -1363,10 +1422,13 @@ bool DobbySpecConfig::processSwapLimit(const Json::Value& value,
             AI_LOG_ERROR("memLimit is negative; cannot validate swapLimit");
             return false;
         }
-        if (memSwapSigned < memLimitSigned)
+
+        const double alpha = getZramPercentage();
+        const int64_t physLimit = static_cast<int64_t>((1.0 - alpha) * static_cast<double>(memLimitSigned));
+        if (memSwapSigned < physLimit)
         {
-            AI_LOG_ERROR("swapLimit (%" PRId64 ") must be >= memLimit (%" PRId64 ")",
-                         memSwapSigned, memLimitSigned);
+            AI_LOG_ERROR("swapLimit (%" PRId64 ") must be >= memory.limit_in_bytes (%" PRId64 ")",
+                         memSwapSigned, physLimit);
             return false;
         }
     }

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -686,15 +686,8 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
 
     if (!(flags & JSON_FLAG_SWAPLIMIT))
     {
-        const Json::Value& memLimitVal = mSpec["memLimit"];
-        if (memLimitVal.isIntegral())
-        {
-            dictionary->SetIntValue(MEM_SWAP, static_cast<unsigned>(memLimitVal.asUInt()));
-        }
-        else
-        {
-            dictionary->SetIntValue(MEM_SWAP, -1);
-        }
+        // swapLimit not supplied: leave memory+swap unlimited (-1)
+        dictionary->SetIntValue(MEM_SWAP, -1);
     }
 
     // swappiness is not supported on cgroups v2, only show if on v1
@@ -1363,8 +1356,14 @@ bool DobbySpecConfig::processMemLimit(const Json::Value& value,
         AI_LOG_WARN("memory limit looks dangerously low");
     }
 
-    const double alpha = getZramPercentage();
-    const unsigned physLimit = static_cast<unsigned>((1.0 - alpha) * static_cast<double>(memLimit));
+    // Only apply the zram-aware adjustment when swapLimit is explicitly
+    // set; otherwise keep memLimit as-is to match the memory.limit_in_bytes.
+    unsigned physLimit = memLimit;
+    if (mSpec["swapLimit"].isIntegral())
+    {
+        const double alpha = getZramPercentage();
+        physLimit = static_cast<unsigned>((1.0 - alpha) * static_cast<double>(memLimit));
+    }
     dictionary->SetIntValue(MEM_LIMIT, physLimit);
 
     return true;

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -197,6 +197,12 @@ static const ctemplate::StaticTemplateString SECCOMP_SYSCALLS =
 
 int DobbySpecConfig::mNumCores = -1;
 
+int64_t DobbySpecConfig::calculatePhysicalMemoryLimit(int64_t memLimit,
+                                                      double swapToRamRatio)
+{
+    return static_cast<int64_t>((1.0 / (1.0 + swapToRamRatio)) * static_cast<double>(memLimit));
+}
+
 static double getZramPercentage()
 {
     std::ifstream meminfo("/proc/meminfo");
@@ -206,7 +212,6 @@ static double getZramPercentage()
     }
 
     unsigned long long memTotalKb = 0;
-    unsigned long long swapTotalKb = 0;
     std::string line;
 
     while (std::getline(meminfo, line))
@@ -225,25 +230,40 @@ static double getZramPercentage()
             }
             memTotalKb = value;
         }
-        else if (key == "SwapTotal:")
-        {
-            unsigned long long value = 0;
-            std::string units;
-            if (!(iss >> value >> units))
-            {
-                return 0.0;
-            }
-            swapTotalKb = value;
-        }
     }
 
-    if (memTotalKb == 0 || swapTotalKb == 0)
+    if (memTotalKb == 0)
     {
         return 0.0;
     }
 
-    const double alpha = static_cast<double>(swapTotalKb) / static_cast<double>(memTotalKb);
-    return std::max(0.0, std::min(alpha, 1.0));
+    std::ifstream swaps("/proc/swaps");
+    if (!swaps.is_open())
+    {
+        return 0.0;
+    }
+
+    unsigned long long zramTotalKb = 0;
+    std::string filename;
+    std::string type;
+    unsigned long long sizeKb = 0;
+    unsigned long long usedKb = 0;
+    int priority = 0;
+    std::getline(swaps, line);
+    while (swaps >> filename >> type >> sizeKb >> usedKb >> priority)
+    {
+        if (filename.rfind("/dev/zram", 0) == 0)
+        {
+            zramTotalKb += sizeKb;
+        }
+    }
+
+    if (zramTotalKb == 0)
+    {
+        return 0.0;
+    }
+
+    return static_cast<double>(zramTotalKb) / static_cast<double>(memTotalKb);
 }
 
 // TODO: should we only allowed these if a network namespace is enabled ?
@@ -1362,7 +1382,7 @@ bool DobbySpecConfig::processMemLimit(const Json::Value& value,
     if (mSpec.isMember("swapLimit") && mSpec["swapLimit"].isIntegral())
     {
         const double alpha = getZramPercentage();
-        physLimit = static_cast<unsigned>((1.0 - alpha) * static_cast<double>(memLimit));
+        physLimit = static_cast<unsigned>(calculatePhysicalMemoryLimit(memLimit, alpha));
     }
     dictionary->SetIntValue(MEM_LIMIT, physLimit);
 
@@ -1377,8 +1397,9 @@ bool DobbySpecConfig::processMemLimit(const Json::Value& value,
  *  allowing swap to be configured independently of the memory limit.  When
  *  absent the swap limit is set to -1 (unlimited).
  *
- *  The kernel requires swap >= memLimit, so an error is returned if the
- *  supplied value is smaller than the memLimit already set.
+ *  The kernel requires swap >= the effective physical memory limit, so an
+ *  error is returned if the supplied value is smaller than the adjusted
+ *  memory.limit_in_bytes value.
  *
  *  Example json:
  *
@@ -1422,8 +1443,9 @@ bool DobbySpecConfig::processSwapLimit(const Json::Value& value,
             return false;
         }
 
+        // swapLimit must be at least the effective zram-adjusted physical limit.
         const double alpha = getZramPercentage();
-        const int64_t physLimit = static_cast<int64_t>((1.0 - alpha) * static_cast<double>(memLimitSigned));
+        const int64_t physLimit = calculatePhysicalMemoryLimit(memLimitSigned, alpha);
         if (memSwapSigned < physLimit)
         {
             AI_LOG_ERROR("swapLimit (%" PRId64 ") must be >= memory.limit_in_bytes (%" PRId64 ")",

--- a/bundle/lib/source/DobbySpecConfig.cpp
+++ b/bundle/lib/source/DobbySpecConfig.cpp
@@ -203,7 +203,7 @@ int64_t DobbySpecConfig::calculatePhysicalMemoryLimit(int64_t memLimit,
     return static_cast<int64_t>((1.0 / (1.0 + swapToRamRatio)) * static_cast<double>(memLimit));
 }
 
-static double getZramPercentage()
+static double getZramSwapToRamRatio()
 {
     std::ifstream meminfo("/proc/meminfo");
     if (!meminfo.is_open())
@@ -295,6 +295,7 @@ DobbySpecConfig::DobbySpecConfig(const std::shared_ptr<IDobbyUtils> &utils,
     , mDefaultPlugins(settings->defaultPlugins())
     , mRdkPluginsData(settings->rdkPluginsData())
     , mDictionary(nullptr)
+    , mZramSwapToRamRatio(0.0)
     , mConf(nullptr)
     , mSpecVersion(SpecVersion::Unknown)
     , mUserId(-1)
@@ -378,6 +379,7 @@ DobbySpecConfig::DobbySpecConfig(const std::shared_ptr<IDobbyUtils> &utils,
     , mGpuSettings(settings->gpuAccessSettings())
     , mVpuSettings(settings->vpuAccessSettings())
     , mDictionary(nullptr)
+    , mZramSwapToRamRatio(0.0)
     , mConf(nullptr)
     , mSpecVersion(SpecVersion::Unknown)
     , mUserId(-1)
@@ -600,6 +602,11 @@ bool DobbySpecConfig::parseSpec(ctemplate::TemplateDictionary* dictionary,
                               reader.getFormattedErrorMessages().c_str());
             return false;
         }
+    }
+
+    if (mSpec.isMember("swapLimit") && mSpec["swapLimit"].isIntegral())
+    {
+        mZramSwapToRamRatio = getZramSwapToRamRatio();
     }
 
     // step 2 - get the version number of the spec first, it may determine how
@@ -1381,8 +1388,7 @@ bool DobbySpecConfig::processMemLimit(const Json::Value& value,
     unsigned physLimit = memLimit;
     if (mSpec.isMember("swapLimit") && mSpec["swapLimit"].isIntegral())
     {
-        const double alpha = getZramPercentage();
-        physLimit = static_cast<unsigned>(calculatePhysicalMemoryLimit(memLimit, alpha));
+        physLimit = static_cast<unsigned>(calculatePhysicalMemoryLimit(memLimit, mZramSwapToRamRatio));
     }
     dictionary->SetIntValue(MEM_LIMIT, physLimit);
 
@@ -1444,8 +1450,7 @@ bool DobbySpecConfig::processSwapLimit(const Json::Value& value,
         }
 
         // swapLimit must be at least the effective zram-adjusted physical limit.
-        const double alpha = getZramPercentage();
-        const int64_t physLimit = calculatePhysicalMemoryLimit(memLimitSigned, alpha);
+        const int64_t physLimit = calculatePhysicalMemoryLimit(memLimitSigned, mZramSwapToRamRatio);
         if (memSwapSigned < physLimit)
         {
             AI_LOG_ERROR("swapLimit (%" PRId64 ") must be >= memory.limit_in_bytes (%" PRId64 ")",

--- a/tests/L1_testing/tests/DobbySpecConfigTest/DobbySpecConfigTest.cpp
+++ b/tests/L1_testing/tests/DobbySpecConfigTest/DobbySpecConfigTest.cpp
@@ -23,10 +23,13 @@
 #include <gmock/gmock.h>
 #include <ctemplate/template.h>
 #include <json/json.h>
+#include <algorithm>
 #include <climits>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
+#include <sstream>
 #include <string>
 #include <memory>
 #include <unistd.h>
@@ -97,6 +100,42 @@ static const char* kMemTemplateStr  = "LIMIT={{MEM_LIMIT}} SWAP={{MEM_SWAP}}";
 // ── Inline ctemplate for reading NO_NEW_PRIVS back from the dict ─────────────
 static const char* kPrivsTemplateName = "test_no_new_privs";
 static const char* kPrivsTemplateStr  = "NO_NEW_PRIVS={{NO_NEW_PRIVS}}";
+
+static unsigned expectedPhysicalLimit(unsigned memLimit)
+{
+    std::ifstream meminfo("/proc/meminfo");
+    unsigned long long memTotalKb = 0;
+    unsigned long long swapTotalKb = 0;
+    std::string line;
+
+    while (std::getline(meminfo, line))
+    {
+        std::istringstream iss(line);
+        std::string key;
+        iss >> key;
+
+        if (key == "MemTotal:")
+        {
+            unsigned long long value = 0;
+            std::string units;
+            iss >> value >> units;
+            memTotalKb = value;
+        }
+        else if (key == "SwapTotal:")
+        {
+            unsigned long long value = 0;
+            std::string units;
+            iss >> value >> units;
+            swapTotalKb = value;
+        }
+    }
+
+    const double alpha = (memTotalKb > 0 && swapTotalKb > 0)
+        ? std::min(1.0, static_cast<double>(swapTotalKb) / static_cast<double>(memTotalKb))
+        : 0.0;
+
+    return static_cast<unsigned>((1.0 - alpha) * static_cast<double>(memLimit));
+}
 
 // ── Fixture ───────────────────────────────────────────────────────────────────
 
@@ -208,13 +247,16 @@ protected:
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 /**
- * When 'swapLimit' is absent, MEM_SWAP must default to -1 (unlimited).
+ * When 'swapLimit' is absent, MEM_SWAP must default to the original maxAppRam
+ * while MEM_LIMIT reflects the zram-adjusted physical RAM budget.
  */
-TEST_F(DobbySpecConfigTest, SwapLimit_DefaultsToUnlimited)
+TEST_F(DobbySpecConfigTest, SwapLimit_DefaultsToMemLimit)
 {
     auto cfg = makeConfig(kSpecMemOnly);
     EXPECT_TRUE(cfg->isValid());
-    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=2998272 SWAP=-1");
+
+    const unsigned expectedLimit = expectedPhysicalLimit(2998272);
+    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=" + std::to_string(expectedLimit) + " SWAP=2998272");
 }
 
 /**
@@ -225,7 +267,9 @@ TEST_F(DobbySpecConfigTest, SwapLimit_SetIndependently)
 {
     auto cfg = makeConfig(kSpecWithSwap);
     EXPECT_TRUE(cfg->isValid());
-    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=2998272 SWAP=5996544");
+
+    const unsigned expectedLimit = expectedPhysicalLimit(2998272);
+    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=" + std::to_string(expectedLimit) + " SWAP=5996544");
 }
 
 /**
@@ -236,7 +280,9 @@ TEST_F(DobbySpecConfigTest, SwapLimit_EqualToMemLimit_Succeeds)
 {
     auto cfg = makeConfig(kSpecSwapEqualsLimit);
     EXPECT_TRUE(cfg->isValid());
-    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=2998272 SWAP=2998272");
+
+    const unsigned expectedLimit = expectedPhysicalLimit(2998272);
+    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=" + std::to_string(expectedLimit) + " SWAP=2998272");
 }
 
 /**

--- a/tests/L1_testing/tests/DobbySpecConfigTest/DobbySpecConfigTest.cpp
+++ b/tests/L1_testing/tests/DobbySpecConfigTest/DobbySpecConfigTest.cpp
@@ -247,16 +247,15 @@ protected:
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 /**
- * When 'swapLimit' is absent, MEM_SWAP must default to the original maxAppRam
- * while MEM_LIMIT reflects the zram-adjusted physical RAM budget.
+ * When 'swapLimit' is absent, MEM_SWAP must default to -1 (unlimited) and
+ * MEM_LIMIT must be left as the raw memLimit (no zram adjustment applied).
  */
-TEST_F(DobbySpecConfigTest, SwapLimit_DefaultsToMemLimit)
+TEST_F(DobbySpecConfigTest, SwapLimit_DefaultsToUnlimited)
 {
     auto cfg = makeConfig(kSpecMemOnly);
     EXPECT_TRUE(cfg->isValid());
 
-    const unsigned expectedLimit = expectedPhysicalLimit(2998272);
-    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=" + std::to_string(expectedLimit) + " SWAP=2998272");
+    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=2998272 SWAP=-1");
 }
 
 /**

--- a/tests/L1_testing/tests/DobbySpecConfigTest/DobbySpecConfigTest.cpp
+++ b/tests/L1_testing/tests/DobbySpecConfigTest/DobbySpecConfigTest.cpp
@@ -23,13 +23,10 @@
 #include <gmock/gmock.h>
 #include <ctemplate/template.h>
 #include <json/json.h>
-#include <algorithm>
 #include <climits>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <fstream>
-#include <sstream>
 #include <string>
 #include <memory>
 #include <unistd.h>
@@ -80,7 +77,7 @@ static const char* kSpecSwapBelowLimit = R"({
     "args": ["/bin/true"],
     "user": { "uid": 1000, "gid": 1000 },
     "memLimit": 5996544,
-    "swapLimit": 2998272
+    "swapLimit": 0
 })";
 
 // ── Spec with capabilities ────────────────────────────────────────────────────
@@ -100,42 +97,6 @@ static const char* kMemTemplateStr  = "LIMIT={{MEM_LIMIT}} SWAP={{MEM_SWAP}}";
 // ── Inline ctemplate for reading NO_NEW_PRIVS back from the dict ─────────────
 static const char* kPrivsTemplateName = "test_no_new_privs";
 static const char* kPrivsTemplateStr  = "NO_NEW_PRIVS={{NO_NEW_PRIVS}}";
-
-static unsigned expectedPhysicalLimit(unsigned memLimit)
-{
-    std::ifstream meminfo("/proc/meminfo");
-    unsigned long long memTotalKb = 0;
-    unsigned long long swapTotalKb = 0;
-    std::string line;
-
-    while (std::getline(meminfo, line))
-    {
-        std::istringstream iss(line);
-        std::string key;
-        iss >> key;
-
-        if (key == "MemTotal:")
-        {
-            unsigned long long value = 0;
-            std::string units;
-            iss >> value >> units;
-            memTotalKb = value;
-        }
-        else if (key == "SwapTotal:")
-        {
-            unsigned long long value = 0;
-            std::string units;
-            iss >> value >> units;
-            swapTotalKb = value;
-        }
-    }
-
-    const double alpha = (memTotalKb > 0 && swapTotalKb > 0)
-        ? std::min(1.0, static_cast<double>(swapTotalKb) / static_cast<double>(memTotalKb))
-        : 0.0;
-
-    return static_cast<unsigned>((1.0 - alpha) * static_cast<double>(memLimit));
-}
 
 // ── Fixture ───────────────────────────────────────────────────────────────────
 
@@ -258,6 +219,13 @@ TEST_F(DobbySpecConfigTest, SwapLimit_DefaultsToUnlimited)
     EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=2998272 SWAP=-1");
 }
 
+TEST_F(DobbySpecConfigTest, PhysicalMemoryLimit_UsesRamShareOfTotalCapacity)
+{
+    EXPECT_EQ(DobbySpecConfig::calculatePhysicalMemoryLimit(1000, 0.0), 1000);
+    EXPECT_EQ(DobbySpecConfig::calculatePhysicalMemoryLimit(1000, 1.0), 500);
+    EXPECT_EQ(DobbySpecConfig::calculatePhysicalMemoryLimit(1000, 3.0), 250);
+}
+
 /**
  * When 'swapLimit' is greater than 'memLimit', MEM_SWAP must be set to the
  * supplied swap limit independently of MEM_LIMIT.
@@ -267,8 +235,7 @@ TEST_F(DobbySpecConfigTest, SwapLimit_SetIndependently)
     auto cfg = makeConfig(kSpecWithSwap);
     EXPECT_TRUE(cfg->isValid());
 
-    const unsigned expectedLimit = expectedPhysicalLimit(2998272);
-    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=" + std::to_string(expectedLimit) + " SWAP=5996544");
+    EXPECT_NE(expandMemTemplate(*cfg).find("SWAP=5996544"), std::string::npos);
 }
 
 /**
@@ -280,13 +247,12 @@ TEST_F(DobbySpecConfigTest, SwapLimit_EqualToMemLimit_Succeeds)
     auto cfg = makeConfig(kSpecSwapEqualsLimit);
     EXPECT_TRUE(cfg->isValid());
 
-    const unsigned expectedLimit = expectedPhysicalLimit(2998272);
-    EXPECT_EQ(expandMemTemplate(*cfg), "LIMIT=" + std::to_string(expectedLimit) + " SWAP=2998272");
+    EXPECT_NE(expandMemTemplate(*cfg).find("SWAP=2998272"), std::string::npos);
 }
 
 /**
- * When 'swapLimit' < 'memLimit', processSwapLimit must reject the value
- * and parsing must fail (kernel requires memsw >= mem).
+ * When 'swapLimit' is below the effective physical memory limit,
+ * processSwapLimit must reject the value and parsing must fail.
  */
 TEST_F(DobbySpecConfigTest, SwapLimit_LessThanMemLimit_Fails)
 {

--- a/tests/L2_testing/test_runner/bundle_generation.py
+++ b/tests/L2_testing/test_runner/bundle_generation.py
@@ -73,11 +73,14 @@ def _normalise_config(config):
             if not cpu:
                 resources.pop("cpu", None)
 
-        # swap limit is injected by the OCI config template (set equal to
-        # memory limit to disable swap).  Original test bundles pre-date
-        # this addition, so strip it to keep the comparison stable.
+        # memory limit/swap are now scaled by the host's zram ratio, so they
+        # vary between the CI runner and whatever host generated the
+        # original fixture bundle. Strip both to keep the comparison stable.
         if isinstance(resources, dict) and isinstance(resources.get("memory"), dict):
             resources["memory"].pop("swap", None)
+            resources["memory"].pop("limit", None)
+            if not resources["memory"]:
+                resources.pop("memory", None)
 
     # Runtime may append tmpfs size options at generation time
     for mount in cfg.get("mounts", []):

--- a/tests/L2_testing/test_runner/bundle_generation.py
+++ b/tests/L2_testing/test_runner/bundle_generation.py
@@ -73,13 +73,17 @@ def _normalise_config(config):
             if not cpu:
                 resources.pop("cpu", None)
 
-        # memory limit/swap are now scaled by the host's zram ratio, so they
-        # vary between the CI runner and whatever host generated the
-        # original fixture bundle. Strip both to keep the comparison stable.
+        # Swap is generated as -1 when no swapLimit is configured. Preserve the
+        # stable physical memory limit in that case; only omit it when an
+        # explicit swap limit caused host-dependent zram scaling.
         if isinstance(resources, dict) and isinstance(resources.get("memory"), dict):
-            resources["memory"].pop("swap", None)
-            resources["memory"].pop("limit", None)
-            if not resources["memory"]:
+            memory = resources["memory"]
+            swap = memory.get("swap")
+            limit = memory.get("limit")
+            memory.pop("swap", None)
+            if swap is not None and swap != -1 and swap != limit:
+                memory.pop("limit", None)
+            if not memory:
                 resources.pop("memory", None)
 
     # Runtime may append tmpfs size options at generation time


### PR DESCRIPTION
### Description
If swap limit is explicitly set, this change makes Dobby zram-aware by reading the system's zram configuration at container start time and splitting the container's memory budget proportionally between physical RAM and swap

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)